### PR TITLE
feat: Add repay, withdraw, liquidate stubs, events, and Position struct to contract

### DIFF
--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -4,7 +4,7 @@
 //! Core features will be implemented incrementally in separate modules.
 
 #![no_std]
-use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec, Symbol};
 
 // Module placeholders for future expansion
 // mod deposit;
@@ -16,6 +16,49 @@ use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 /// The main contract struct for StellarLend
 #[contract]
 pub struct Contract;
+
+/// Represents a user's position in the protocol (placeholder)
+#[derive(Clone, Debug)]
+pub struct Position {
+    /// The address of the user (placeholder type)
+    pub user: String,
+    /// The amount of collateral deposited
+    pub collateral: i128,
+    /// The amount borrowed
+    pub debt: i128,
+}
+
+/// Event types for protocol actions
+pub enum ProtocolEvent {
+    Deposit { user: String, amount: i128 },
+    Borrow { user: String, amount: i128 },
+    Repay { user: String, amount: i128 },
+    Withdraw { user: String, amount: i128 },
+    Liquidate { user: String, amount: i128 },
+}
+
+impl ProtocolEvent {
+    /// Emit the event using Soroban's event system
+    pub fn emit(&self, env: &Env) {
+        match self {
+            ProtocolEvent::Deposit { user, amount } => {
+                env.events().publish((Symbol::short("deposit"), Symbol::short("user")), (Symbol::short("user"), *amount));
+            }
+            ProtocolEvent::Borrow { user, amount } => {
+                env.events().publish((Symbol::short("borrow"), Symbol::short("user")), (Symbol::short("user"), *amount));
+            }
+            ProtocolEvent::Repay { user, amount } => {
+                env.events().publish((Symbol::short("repay"), Symbol::short("user")), (Symbol::short("user"), *amount));
+            }
+            ProtocolEvent::Withdraw { user, amount } => {
+                env.events().publish((Symbol::short("withdraw"), Symbol::short("user")), (Symbol::short("user"), *amount));
+            }
+            ProtocolEvent::Liquidate { user, amount } => {
+                env.events().publish((Symbol::short("liquidate"), Symbol::short("user")), (Symbol::short("user"), *amount));
+            }
+        }
+    }
+}
 
 // This is a sample contract. Replace this placeholder with your own contract logic.
 // A corresponding test example is available in `test.rs`.
@@ -55,20 +98,35 @@ impl Contract {
         // TODO: Implement borrow logic
     }
 
-    // /// Repay borrowed assets
-    // pub fn repay(...) {
-    //     // Implementation will go here
-    // }
+    /// Repay borrowed assets (stub)
+    ///
+    /// # Parameters
+    /// - `env`: The contract environment
+    /// - `repayer`: The address of the user repaying (placeholder type)
+    /// - `amount`: The amount to repay (placeholder type)
+    pub fn repay(_env: Env, _repayer: String, _amount: i128) {
+        // TODO: Implement repay logic
+    }
 
-    // /// Withdraw collateral
-    // pub fn withdraw(...) {
-    //     // Implementation will go here
-    // }
+    /// Withdraw collateral (stub)
+    ///
+    /// # Parameters
+    /// - `env`: The contract environment
+    /// - `withdrawer`: The address of the user withdrawing (placeholder type)
+    /// - `amount`: The amount to withdraw (placeholder type)
+    pub fn withdraw(_env: Env, _withdrawer: String, _amount: i128) {
+        // TODO: Implement withdraw logic
+    }
 
-    // /// Liquidate undercollateralized positions
-    // pub fn liquidate(...) {
-    //     // Implementation will go here
-    // }
+    /// Liquidate undercollateralized positions (stub)
+    ///
+    /// # Parameters
+    /// - `env`: The contract environment
+    /// - `liquidator`: The address of the user performing liquidation (placeholder type)
+    /// - `amount`: The amount to liquidate (placeholder type)
+    pub fn liquidate(_env: Env, _liquidator: String, _amount: i128) {
+        // TODO: Implement liquidation logic
+    }
 
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]


### PR DESCRIPTION
## Overview

This PR expands the StellarLend Soroban contract by adding stubs for the `repay`, `withdraw`, and `liquidate` functions. It also introduces event types for all major actions and a placeholder `Position` struct for user positions. Documentation and comments have been expanded throughout.

## Changes

- Added public `repay`, `withdraw`, and `liquidate` function stubs.
- Defined event types for deposit, borrow, repay, withdraw, and liquidate actions.
- Added a `Position` struct as a placeholder for user positions.
- Expanded documentation and comments for all new code.

## Related Issue

Closes #9  - Add repay, withdraw, and liquidate stubs with event and struct definitions

---

**Note:**  
This PR is focused on scaffolding and does not implement business logic.