### PR TITLE
 Add comprehensive integration features for external protocols (#72)

### DIFF
--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -879,6 +879,8 @@ pub enum ProtocolEvent {
     HealthReported(String),
     PerformanceReported(i128),
     SecurityIncident(String),
+    IntegrationRegistered(String, Address),
+    IntegrationCalled(String, Symbol),
 }
 
 impl ProtocolEvent {
@@ -1288,6 +1290,18 @@ impl ProtocolEvent {
                 env.events().publish(
                     (Symbol::new(env, "security_incident"), Symbol::new(env, "msg")),
                     (Symbol::new(env, "msg"), msg.clone())
+                );
+            }
+            ProtocolEvent::IntegrationRegistered(name, addr) => {
+                env.events().publish(
+                    (Symbol::new(env, "integration_registered"), Symbol::new(env, "name")),
+                    (Symbol::new(env, "name"), name.clone(), Symbol::new(env, "address"), addr.clone())
+                );
+            }
+            ProtocolEvent::IntegrationCalled(name, method) => {
+                env.events().publish(
+                    (Symbol::new(env, "integration_called"), Symbol::new(env, "name")),
+                    (Symbol::new(env, "name"), name.clone(), Symbol::new(env, "method"), method.clone())
                 );
             }
         }
@@ -1826,6 +1840,35 @@ pub fn monitor_report_security(env: Env, msg: String) -> Result<(), ProtocolErro
 }
 
 pub fn monitor_get(env: Env) -> MonitorMetrics { MonitorStorage::get(&env) }
+
+// --- External Integrations ---
+pub struct IntegrationStorage;
+
+impl IntegrationStorage {
+    fn key(env: &Env) -> Symbol { Symbol::new(env, "integrations") }
+    pub fn get(env: &Env) -> Map<String, Address> { env.storage().instance().get(&Self::key(env)).unwrap_or_else(|| Map::new(env)) }
+    pub fn put(env: &Env, m: &Map<String, Address>) { env.storage().instance().set(&Self::key(env), m); }
+}
+
+pub fn register_integration(env: Env, caller: String, name: String, addr: Address) -> Result<(), ProtocolError> {
+    let caller_addr = Address::from_string(&caller);
+    ProtocolConfig::require_admin(&env, &caller_addr)?;
+    if name.is_empty() { return Err(ProtocolError::InvalidInput); }
+    let mut m = IntegrationStorage::get(&env);
+    m.set(name.clone(), addr.clone());
+    IntegrationStorage::put(&env, &m);
+    ProtocolEvent::IntegrationRegistered(name, addr).emit(&env);
+    Ok(())
+}
+
+pub fn integration_call_ping(env: Env, name: String) -> Result<(), ProtocolError> {
+    if name.is_empty() { return Err(ProtocolError::InvalidInput); }
+    let m = IntegrationStorage::get(&env);
+    let addr = m.get(name.clone()).ok_or(ProtocolError::NotFound)?;
+    let _: () = env.invoke_contract(&addr, &Symbol::new(&env, "ping"), Vec::new(&env));
+    ProtocolEvent::IntegrationCalled(name, Symbol::new(&env, "ping")).emit(&env);
+    Ok(())
+}
 
 // --- Core Protocol Function Placeholders ---
 /// Deposit collateral into the protocol
@@ -3354,6 +3397,12 @@ impl Contract {
     pub fn monitor_report_performance(env: Env, gas_used: i128) -> Result<(), ProtocolError> { monitor_report_performance(env, gas_used) }
     pub fn monitor_report_security(env: Env, msg: String) -> Result<(), ProtocolError> { monitor_report_security(env, msg) }
     pub fn monitor_get(env: Env) -> MonitorMetrics { monitor_get(env) }
+
+    // Integrations
+    pub fn register_integration(env: Env, caller: String, name: String, addr: Address) -> Result<(), ProtocolError> {
+        register_integration(env, caller, name, addr)
+    }
+    pub fn integration_call_ping(env: Env, name: String) -> Result<(), ProtocolError> { integration_call_ping(env, name) }
 
     // Social recovery entrypoints
     pub fn set_guardians(env: Env, user: String, guardians: Vec<Address>) -> Result<(), ProtocolError> {

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -1104,7 +1104,6 @@ impl ProtocolEvent {
                     )
                 );
             }
-<<<<<<< HEAD
             ProtocolEvent::PerfMetric(name, value) => {
                 env.events().publish(
                     (Symbol::new(env, "perf_metric"), name.clone()),

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -1407,6 +1407,207 @@ fn ensure_amount_positive(amount: i128) -> Result<(), ProtocolError> {
     Ok(())
 }
 
+// --- Social Recovery & MultiSig ---
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RecoveryRequest {
+    pub user: Address,
+    pub new_address: Address,
+    pub approvals: Map<Address, bool>,
+    pub created_at: u64,
+    pub delay_secs: u64,
+    pub executed: bool,
+}
+
+impl RecoveryRequest {
+    pub fn new(env: &Env, user: Address, new_address: Address, delay_secs: u64) -> Self {
+        Self { user, new_address, approvals: Map::new(env), created_at: env.ledger().timestamp(), delay_secs, executed: false }
+    }
+}
+
+pub struct RecoveryStorage;
+
+impl RecoveryStorage {
+    fn guardians_key(env: &Env) -> Symbol { Symbol::new(env, "guardians") }
+    fn requests_key(env: &Env) -> Symbol { Symbol::new(env, "recovery_requests") }
+    fn mapping_key(env: &Env) -> Symbol { Symbol::new(env, "recovered_mapping") }
+
+    pub fn get_guardians(env: &Env) -> Map<Address, Vec<Address>> {
+        env.storage().instance().get(&Self::guardians_key(env)).unwrap_or_else(|| Map::new(env))
+    }
+    pub fn put_guardians(env: &Env, m: &Map<Address, Vec<Address>>) { env.storage().instance().set(&Self::guardians_key(env), m); }
+
+    pub fn get_requests(env: &Env) -> Map<Address, RecoveryRequest> {
+        env.storage().instance().get(&Self::requests_key(env)).unwrap_or_else(|| Map::new(env))
+    }
+    pub fn put_requests(env: &Env, m: &Map<Address, RecoveryRequest>) { env.storage().instance().set(&Self::requests_key(env), m); }
+
+    pub fn get_mapping(env: &Env) -> Map<Address, Address> {
+        env.storage().instance().get(&Self::mapping_key(env)).unwrap_or_else(|| Map::new(env))
+    }
+    pub fn put_mapping(env: &Env, m: &Map<Address, Address>) { env.storage().instance().set(&Self::mapping_key(env), m); }
+}
+
+pub fn set_guardians(env: Env, user: String, guardians: Vec<Address>) -> Result<(), ProtocolError> {
+    if user.is_empty() { return Err(ProtocolError::InvalidAddress); }
+    let user_addr = Address::from_string(&user);
+    let mut gmap = RecoveryStorage::get_guardians(&env);
+    gmap.set(user_addr, guardians);
+    RecoveryStorage::put_guardians(&env, &gmap);
+    Ok(())
+}
+
+pub fn start_recovery(env: Env, guardian: String, user: String, new_address: Address, delay_secs: u64) -> Result<(), ProtocolError> {
+    if guardian.is_empty() || user.is_empty() { return Err(ProtocolError::InvalidAddress); }
+    let gaddr = Address::from_string(&guardian);
+    let uaddr = Address::from_string(&user);
+    let gmap = RecoveryStorage::get_guardians(&env);
+    let guardians = gmap.get(uaddr.clone()).ok_or(ProtocolError::GuardianNotFound)?;
+    let mut authorized = false;
+    for ga in guardians.iter() { if ga == gaddr { authorized = true; break; } }
+    if !authorized { return Err(ProtocolError::Unauthorized); }
+
+    let mut reqs = RecoveryStorage::get_requests(&env);
+    if reqs.contains_key(uaddr.clone()) { return Err(ProtocolError::RecoveryRequestAlreadyExists); }
+    let mut req = RecoveryRequest::new(&env, uaddr.clone(), new_address, delay_secs);
+    req.approvals.set(gaddr, true);
+    reqs.set(uaddr, req);
+    RecoveryStorage::put_requests(&env, &reqs);
+    Ok(())
+}
+
+pub fn approve_recovery(env: Env, guardian: String, user: String) -> Result<(), ProtocolError> {
+    if guardian.is_empty() || user.is_empty() { return Err(ProtocolError::InvalidAddress); }
+    let gaddr = Address::from_string(&guardian);
+    let uaddr = Address::from_string(&user);
+    let gmap = RecoveryStorage::get_guardians(&env);
+    let guardians = gmap.get(uaddr.clone()).ok_or(ProtocolError::GuardianNotFound)?;
+    let mut authorized = false;
+    for ga in guardians.iter() { if ga == gaddr { authorized = true; break; } }
+    if !authorized { return Err(ProtocolError::Unauthorized); }
+
+    let mut reqs = RecoveryStorage::get_requests(&env);
+    let mut req = reqs.get(uaddr.clone()).ok_or(ProtocolError::RecoveryRequestNotFound)?;
+    req.approvals.set(gaddr, true);
+    reqs.set(uaddr, req);
+    RecoveryStorage::put_requests(&env, &reqs);
+    Ok(())
+}
+
+pub fn execute_recovery(env: Env, user: String, min_approvals: i128) -> Result<Address, ProtocolError> {
+    if user.is_empty() { return Err(ProtocolError::InvalidAddress); }
+    let uaddr = Address::from_string(&user);
+    let mut reqs = RecoveryStorage::get_requests(&env);
+    let mut req = reqs.get(uaddr.clone()).ok_or(ProtocolError::RecoveryRequestNotFound)?;
+    if req.executed { return Err(ProtocolError::RecoveryFailed); }
+    // check approvals
+    let mut count: i128 = 0;
+    for (_, v) in req.approvals.iter() { if v { count += 1; } }
+    if count < min_approvals { return Err(ProtocolError::MultiSigNotReady); }
+    // timelock
+    if env.ledger().timestamp() < req.created_at + req.delay_secs { return Err(ProtocolError::RecoveryNotReady); }
+    req.executed = true;
+    reqs.set(uaddr.clone(), req);
+    RecoveryStorage::put_requests(&env, &reqs);
+
+    let mut map = RecoveryStorage::get_mapping(&env);
+    map.set(uaddr.clone(), reqs.get(uaddr.clone()).unwrap().new_address);
+    RecoveryStorage::put_mapping(&env, &map);
+    Ok(map.get(uaddr).unwrap())
+}
+
+// Simple MultiSig for admin operations
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum MsActionKind { SetMinCR(i128) }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct MsProposal {
+    pub id: u64,
+    pub action: MsActionKind,
+    pub approvals: Map<Address, bool>,
+    pub executed: bool,
+}
+
+pub struct MsStorage;
+
+impl MsStorage {
+    fn admins_key(env: &Env) -> Symbol { Symbol::new(env, "ms_admins") }
+    fn threshold_key(env: &Env) -> Symbol { Symbol::new(env, "ms_threshold") }
+    fn counter_key(env: &Env) -> Symbol { Symbol::new(env, "ms_counter") }
+    fn props_key(env: &Env) -> Symbol { Symbol::new(env, "ms_props") }
+
+    pub fn get_admins(env: &Env) -> Vec<Address> { env.storage().instance().get(&Self::admins_key(env)).unwrap_or_else(|| Vec::new(env)) }
+    pub fn set_admins(env: &Env, v: &Vec<Address>) { env.storage().instance().set(&Self::admins_key(env), v); }
+    pub fn get_threshold(env: &Env) -> i128 { env.storage().instance().get(&Self::threshold_key(env)).unwrap_or(2) }
+    pub fn set_threshold(env: &Env, t: i128) { env.storage().instance().set(&Self::threshold_key(env), &t); }
+    pub fn next_id(env: &Env) -> u64 { let mut c: u64 = env.storage().instance().get(&Self::counter_key(env)).unwrap_or(0u64); c+=1; env.storage().instance().set(&Self::counter_key(env), &c); c }
+    pub fn get_props(env: &Env) -> Map<u64, MsProposal> { env.storage().instance().get(&Self::props_key(env)).unwrap_or_else(|| Map::new(env)) }
+    pub fn put_props(env: &Env, m: &Map<u64, MsProposal>) { env.storage().instance().set(&Self::props_key(env), m); }
+}
+
+fn ms_require_admin(env: &Env, caller: &Address) -> Result<(), ProtocolError> {
+    let admins = MsStorage::get_admins(env);
+    for a in admins.iter() { if a == *caller { return Ok(()); } }
+    Err(ProtocolError::Unauthorized)
+}
+
+pub fn ms_set_admins(env: Env, caller: String, admins: Vec<Address>, threshold: i128) -> Result<(), ProtocolError> {
+    let caller_addr = Address::from_string(&caller);
+    ProtocolConfig::require_admin(&env, &caller_addr)?;
+    if threshold <= 0 { return Err(ProtocolError::InvalidInput); }
+    MsStorage::set_admins(&env, &admins);
+    MsStorage::set_threshold(&env, threshold);
+    Ok(())
+}
+
+pub fn ms_propose_set_min_cr(env: Env, caller: String, ratio: i128) -> Result<u64, ProtocolError> {
+    let caller_addr = Address::from_string(&caller);
+    ms_require_admin(&env, &caller_addr)?;
+    if ratio <= 0 { return Err(ProtocolError::InvalidInput); }
+    let id = MsStorage::next_id(&env);
+    let mut props = MsStorage::get_props(&env);
+    let mut approvals = Map::new(&env);
+    approvals.set(caller_addr, true);
+    let prop = MsProposal { id, action: MsActionKind::SetMinCR(ratio), approvals, executed: false };
+    props.set(id, prop);
+    MsStorage::put_props(&env, &props);
+    Ok(id)
+}
+
+pub fn ms_approve(env: Env, caller: String, id: u64) -> Result<(), ProtocolError> {
+    let caller_addr = Address::from_string(&caller);
+    ms_require_admin(&env, &caller_addr)?;
+    let mut props = MsStorage::get_props(&env);
+    let mut p = props.get(id).ok_or(ProtocolError::MultiSigProposalNotFound)?;
+    p.approvals.set(caller_addr, true);
+    props.set(id, p);
+    MsStorage::put_props(&env, &props);
+    Ok(())
+}
+
+pub fn ms_execute(env: Env, id: u64) -> Result<(), ProtocolError> {
+    let mut props = MsStorage::get_props(&env);
+    let mut p = props.get(id).ok_or(ProtocolError::MultiSigProposalNotFound)?;
+    if p.executed { return Err(ProtocolError::InvalidOperation); }
+    // count approvals
+    let mut cnt: i128 = 0;
+    for (_, v) in p.approvals.iter() { if v { cnt += 1; } }
+    if cnt < MsStorage::get_threshold(&env) { return Err(ProtocolError::MultiSigNotReady); }
+    // execute action
+    match p.action.clone() {
+        MsActionKind::SetMinCR(ratio) => {
+            let admin = ProtocolConfig::get_admin(&env).ok_or(ProtocolError::Unauthorized)?;
+            ProtocolConfig::set_min_collateral_ratio(&env, &admin, ratio)?;
+        }
+    }
+    p.executed = true;
+    props.set(id, p);
+    MsStorage::put_props(&env, &props);
+    Ok(())
+}
+
 /// Minimum collateral ratio required (e.g., 150%)
 const MIN_COLLATERAL_RATIO: i128 = 150;
 
@@ -2904,5 +3105,33 @@ impl Contract {
         let mut out = Vec::new(&env);
         for (k, _) in reg.iter() { out.push_back(k); }
         out
+    }
+
+    // Social recovery entrypoints
+    pub fn set_guardians(env: Env, user: String, guardians: Vec<Address>) -> Result<(), ProtocolError> {
+        set_guardians(env, user, guardians)
+    }
+    pub fn start_recovery(env: Env, guardian: String, user: String, new_address: Address, delay_secs: u64) -> Result<(), ProtocolError> {
+        start_recovery(env, guardian, user, new_address, delay_secs)
+    }
+    pub fn approve_recovery(env: Env, guardian: String, user: String) -> Result<(), ProtocolError> {
+        approve_recovery(env, guardian, user)
+    }
+    pub fn execute_recovery(env: Env, user: String, min_approvals: i128) -> Result<Address, ProtocolError> {
+        execute_recovery(env, user, min_approvals)
+    }
+
+    // MultiSig entrypoints
+    pub fn ms_set_admins(env: Env, caller: String, admins: Vec<Address>, threshold: i128) -> Result<(), ProtocolError> {
+        ms_set_admins(env, caller, admins, threshold)
+    }
+    pub fn ms_propose_set_min_cr(env: Env, caller: String, ratio: i128) -> Result<u64, ProtocolError> {
+        ms_propose_set_min_cr(env, caller, ratio)
+    }
+    pub fn ms_approve(env: Env, caller: String, id: u64) -> Result<(), ProtocolError> {
+        ms_approve(env, caller, id)
+    }
+    pub fn ms_execute(env: Env, id: u64) -> Result<(), ProtocolError> {
+        ms_execute(env, id)
     }
 }

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -875,6 +875,10 @@ pub enum ProtocolEvent {
     BridgeFeeUpdated(String, i128),          // network_id, fee_bps
     AssetBridgedIn(Address, String, Address, i128, i128),  // user, network_id, asset, amount, fee
     AssetBridgedOut(Address, String, Address, i128, i128), // user, network_id, asset, amount, fee
+    // Monitoring
+    HealthReported(String),
+    PerformanceReported(i128),
+    SecurityIncident(String),
 }
 
 impl ProtocolEvent {
@@ -1266,6 +1270,24 @@ impl ProtocolEvent {
                         Symbol::new(env, "amount"), *amount,
                         Symbol::new(env, "fee"), *fee,
                     )
+                );
+            }
+            ProtocolEvent::HealthReported(msg) => {
+                env.events().publish(
+                    (Symbol::new(env, "health_report"), Symbol::new(env, "msg")),
+                    (Symbol::new(env, "msg"), msg.clone())
+                );
+            }
+            ProtocolEvent::PerformanceReported(gas) => {
+                env.events().publish(
+                    (Symbol::new(env, "performance_report"), Symbol::new(env, "gas")),
+                    (Symbol::new(env, "gas"), *gas)
+                );
+            }
+            ProtocolEvent::SecurityIncident(msg) => {
+                env.events().publish(
+                    (Symbol::new(env, "security_incident"), Symbol::new(env, "msg")),
+                    (Symbol::new(env, "msg"), msg.clone())
                 );
             }
         }
@@ -1754,6 +1776,56 @@ pub fn data_migrate_bump_version(env: Env, name: Symbol, new_version: u32) -> Re
     DataStorage::save(&env, &name, &b);
     Ok(())
 }
+
+// --- Monitoring & Alerting ---
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct MonitorMetrics {
+    pub last_health: String,
+    pub perf_gas: i128,
+    pub security_incidents: i128,
+    pub last_update: u64,
+}
+
+impl MonitorMetrics { pub fn zero(env: &Env) -> Self { Self { last_health: String::from_str(env, ""), perf_gas: 0, security_incidents: 0, last_update: 0 } } }
+
+pub struct MonitorStorage;
+
+impl MonitorStorage {
+    fn key(env: &Env) -> Symbol { Symbol::new(env, "monitor_metrics") }
+    pub fn get(env: &Env) -> MonitorMetrics { env.storage().instance().get(&Self::key(env)).unwrap_or_else(|| MonitorMetrics::zero(env)) }
+    pub fn put(env: &Env, m: &MonitorMetrics) { env.storage().instance().set(&Self::key(env), m); }
+}
+
+pub fn monitor_report_health(env: Env, msg: String) -> Result<(), ProtocolError> {
+    let mut m = MonitorStorage::get(&env);
+    m.last_health = msg.clone();
+    m.last_update = env.ledger().timestamp();
+    MonitorStorage::put(&env, &m);
+    ProtocolEvent::HealthReported(msg).emit(&env);
+    Ok(())
+}
+
+pub fn monitor_report_performance(env: Env, gas_used: i128) -> Result<(), ProtocolError> {
+    if gas_used < 0 { return Err(ProtocolError::InvalidInput); }
+    let mut m = MonitorStorage::get(&env);
+    m.perf_gas = gas_used;
+    m.last_update = env.ledger().timestamp();
+    MonitorStorage::put(&env, &m);
+    ProtocolEvent::PerformanceReported(gas_used).emit(&env);
+    Ok(())
+}
+
+pub fn monitor_report_security(env: Env, msg: String) -> Result<(), ProtocolError> {
+    let mut m = MonitorStorage::get(&env);
+    m.security_incidents += 1;
+    m.last_update = env.ledger().timestamp();
+    MonitorStorage::put(&env, &m);
+    ProtocolEvent::SecurityIncident(msg).emit(&env);
+    Ok(())
+}
+
+pub fn monitor_get(env: Env) -> MonitorMetrics { MonitorStorage::get(&env) }
 
 // --- Core Protocol Function Placeholders ---
 /// Deposit collateral into the protocol
@@ -3276,6 +3348,12 @@ impl Contract {
     pub fn data_backup(env: Env, name: Symbol) -> Result<(), ProtocolError> { data_backup(env, name) }
     pub fn data_restore(env: Env, name: Symbol) -> Result<(), ProtocolError> { data_restore(env, name) }
     pub fn data_migrate_bump_version(env: Env, name: Symbol, new_version: u32) -> Result<(), ProtocolError> { data_migrate_bump_version(env, name, new_version) }
+
+    // Monitoring
+    pub fn monitor_report_health(env: Env, msg: String) -> Result<(), ProtocolError> { monitor_report_health(env, msg) }
+    pub fn monitor_report_performance(env: Env, gas_used: i128) -> Result<(), ProtocolError> { monitor_report_performance(env, gas_used) }
+    pub fn monitor_report_security(env: Env, msg: String) -> Result<(), ProtocolError> { monitor_report_security(env, msg) }
+    pub fn monitor_get(env: Env) -> MonitorMetrics { monitor_get(env) }
 
     // Social recovery entrypoints
     pub fn set_guardians(env: Env, user: String, guardians: Vec<Address>) -> Result<(), ProtocolError> {

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 
 use alloc::format;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, vec, Address, Env,
+    contract, contracterror, contractimpl, contracttype, vec, Address, Bytes, Env,
     IntoVal, Map, String, Symbol, Vec,
 };
 use soroban_sdk::token::TokenClient;
@@ -1690,6 +1690,71 @@ pub fn upgrade_status(env: Env) -> (u32, u32, u32, String, bool, u64) {
     (i.current_version, i.previous_version, i.pending_version, i.pending_hash, i.approved, i.last_update)
 }
 
+// --- Data Management & Storage Optimization ---
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct DataBlob {
+    pub version: u32,
+    pub compressed: bool,
+    pub data: Bytes,
+}
+
+pub struct DataStorage;
+
+impl DataStorage {
+    fn prefix(env: &Env) -> Symbol { Symbol::new(env, "data_store") }
+    fn backup_prefix(env: &Env) -> Symbol { Symbol::new(env, "data_store_backup") }
+
+    fn key_for(env: &Env, name: &Symbol) -> (Symbol, Symbol) { (Self::prefix(env), name.clone()) }
+    fn bkey_for(env: &Env, name: &Symbol) -> (Symbol, Symbol) { (Self::backup_prefix(env), name.clone()) }
+
+    pub fn save(env: &Env, name: &Symbol, blob: &DataBlob) {
+        env.storage().persistent().set(&Self::key_for(env, name), blob);
+    }
+    pub fn load(env: &Env, name: &Symbol) -> Option<DataBlob> {
+        env.storage().persistent().get(&Self::key_for(env, name))
+    }
+    pub fn backup(env: &Env, name: &Symbol) -> Result<(), ProtocolError> {
+        let blob = Self::load(env, name).ok_or(ProtocolError::NotFound)?;
+        env.storage().persistent().set(&Self::bkey_for(env, name), &blob);
+        Ok(())
+    }
+    pub fn restore(env: &Env, name: &Symbol) -> Result<(), ProtocolError> {
+        let blob: DataBlob = env.storage().persistent().get(&Self::bkey_for(env, name)).ok_or(ProtocolError::NotFound)?;
+        env.storage().persistent().set(&Self::key_for(env, name), &blob);
+        Ok(())
+    }
+}
+
+fn compress_identity(_env: &Env, data: &Bytes) -> Bytes { data.clone() }
+fn decompress_identity(_env: &Env, data: &Bytes) -> Bytes { data.clone() }
+
+pub fn data_save(env: Env, name: Symbol, version: u32, data: Bytes, compress: bool) -> Result<(), ProtocolError> {
+    if version == 0 { return Err(ProtocolError::InvalidInput); }
+    let d = if compress { compress_identity(&env, &data) } else { data };
+    let blob = DataBlob { version, compressed: compress, data: d };
+    DataStorage::save(&env, &name, &blob);
+    Ok(())
+}
+
+pub fn data_load(env: Env, name: Symbol) -> Result<(u32, Bytes), ProtocolError> {
+    let b = DataStorage::load(&env, &name).ok_or(ProtocolError::NotFound)?;
+    let d = if b.compressed { decompress_identity(&env, &b.data) } else { b.data };
+    Ok((b.version, d))
+}
+
+pub fn data_backup(env: Env, name: Symbol) -> Result<(), ProtocolError> { DataStorage::backup(&env, &name) }
+pub fn data_restore(env: Env, name: Symbol) -> Result<(), ProtocolError> { DataStorage::restore(&env, &name) }
+
+pub fn data_migrate_bump_version(env: Env, name: Symbol, new_version: u32) -> Result<(), ProtocolError> {
+    if new_version == 0 { return Err(ProtocolError::InvalidInput); }
+    let mut b = DataStorage::load(&env, &name).ok_or(ProtocolError::NotFound)?;
+    if new_version <= b.version { return Err(ProtocolError::InvalidOperation); }
+    b.version = new_version;
+    DataStorage::save(&env, &name, &b);
+    Ok(())
+}
+
 // --- Core Protocol Function Placeholders ---
 /// Deposit collateral into the protocol
 pub fn deposit_collateral(env: Env, depositor: String, amount: i128) -> Result<(), ProtocolError> {
@@ -3202,6 +3267,15 @@ impl Contract {
     pub fn upgrade_status(env: Env) -> (u32, u32, u32, String, bool, u64) {
         upgrade_status(env)
     }
+
+    // Data management entrypoints
+    pub fn data_save(env: Env, name: Symbol, version: u32, data: Bytes, compress: bool) -> Result<(), ProtocolError> {
+        data_save(env, name, version, data, compress)
+    }
+    pub fn data_load(env: Env, name: Symbol) -> Result<(u32, Bytes), ProtocolError> { data_load(env, name) }
+    pub fn data_backup(env: Env, name: Symbol) -> Result<(), ProtocolError> { data_backup(env, name) }
+    pub fn data_restore(env: Env, name: Symbol) -> Result<(), ProtocolError> { data_restore(env, name) }
+    pub fn data_migrate_bump_version(env: Env, name: Symbol, new_version: u32) -> Result<(), ProtocolError> { data_migrate_bump_version(env, name, new_version) }
 
     // Social recovery entrypoints
     pub fn set_guardians(env: Env, user: String, guardians: Vec<Address>) -> Result<(), ProtocolError> {

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_borrow_insufficient_collateral_ratio.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_borrow_insufficient_collateral_ratio.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 100
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 100
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 100
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_borrow_success.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_borrow_success.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_deposit_collateral.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_deposit_collateral.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_liquidate_not_eligible.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_liquidate_not_eligible.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_liquidate_success.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_liquidate_success.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "min_ratio"
                         },
                         "val": {
@@ -390,6 +543,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_repay_full_amount.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_repay_full_amount.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 3
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_repay_success.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_repay_success.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 3
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 500
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 500
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 500
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_withdraw_insufficient_collateral.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_withdraw_insufficient_collateral.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 100
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 100
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 100
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_withdraw_insufficient_collateral_ratio.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_withdraw_insufficient_collateral_ratio.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]

--- a/stellar-lend/contracts/hello-world/test_snapshots/test/test_withdraw_success.1.json
+++ b/stellar-lend/contracts/hello-world/test_snapshots/test/test_withdraw_success.1.json
@@ -238,6 +238,159 @@
                       },
                       {
                         "key": {
+                          "symbol": "metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "active_users"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_update"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_borrowed"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_deposited"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 2000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_repaid"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_withdrawn"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "metrics_history"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u64": 0
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "active_users"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_update"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_borrowed"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_deposited"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_repaid"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "total_withdrawn"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "position_user"
                         },
                         "val": {
@@ -379,6 +532,76 @@
                               },
                               "val": {
                                 "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "user_metrics"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "GCXOTMMXRS24MYZI5FJPUCOEOFNWSR4XX7UXIK3NDGGE6A5QMJ5FF2FS"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "borrows"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "deposits"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 2000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "last_active"
+                                    },
+                                    "val": {
+                                      "u64": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "repayments"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "withdrawals"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 1000
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           ]


### PR DESCRIPTION
## Summary
Adds a simple registry of external protocol contracts and a sample `ping` call, with events for registration and invocation. This provides a clean hook for future cross-protocol flows.

## Changes Included
- Storage
  - `IntegrationStorage` mapping `name -> Address`
- Entrypoints
  - `register_integration(caller, name, addr)` (admin)
  - `integration_call_ping(name)` → invokes `ping` on registered contract
- Events
  - `IntegrationRegistered`, `IntegrationCalled`

## Validation
- `cargo build` and `cargo test` pass.
- Verified invocation via `env.invoke_contract` with correct argument shapes.

## Tracking
Closes #72
