### PR TITLE
Test/withdraw function tests

### DIFF
--- a/stellar-lend/contracts/lending/src/borrow.rs
+++ b/stellar-lend/contracts/lending/src/borrow.rs
@@ -41,8 +41,8 @@ pub enum BorrowError {
 pub enum BorrowDataKey {
     /// Per-user debt position
     UserDebt(Address),
-    /// Per-user collateral position
-    UserCollateral(Address),
+    /// Per-user collateral position (borrow module)
+    BorrowerCollateral(Address),
     /// Aggregate protocol debt
     TotalDebt,
     /// Maximum total debt allowed
@@ -241,7 +241,7 @@ fn save_debt_position(env: &Env, user: &Address, position: &DebtPosition) {
 fn get_collateral_position(env: &Env, user: &Address) -> CollateralPosition {
     env.storage()
         .persistent()
-        .get(&BorrowDataKey::UserCollateral(user.clone()))
+        .get(&BorrowDataKey::BorrowerCollateral(user.clone()))
         .unwrap_or(CollateralPosition {
             amount: 0,
             asset: user.clone(), // Placeholder, will be replaced on first borrow
@@ -251,7 +251,7 @@ fn get_collateral_position(env: &Env, user: &Address) -> CollateralPosition {
 fn save_collateral_position(env: &Env, user: &Address, position: &CollateralPosition) {
     env.storage()
         .persistent()
-        .set(&BorrowDataKey::UserCollateral(user.clone()), position);
+        .set(&BorrowDataKey::BorrowerCollateral(user.clone()), position);
 }
 
 fn get_total_debt(env: &Env) -> i128 {

--- a/stellar-lend/contracts/lending/src/withdraw.rs
+++ b/stellar-lend/contracts/lending/src/withdraw.rs
@@ -1,0 +1,216 @@
+use soroban_sdk::{contracterror, contracttype, Address, Env, Symbol};
+
+use crate::deposit::{CollateralPosition, DepositDataKey};
+
+/// Errors that can occur during withdraw operations
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum WithdrawError {
+    InvalidAmount = 1,
+    WithdrawPaused = 2,
+    Overflow = 3,
+    InsufficientCollateral = 4,
+    InsufficientCollateralRatio = 5,
+}
+
+/// Storage keys for withdraw-related data
+#[contracttype]
+#[derive(Clone)]
+pub enum WithdrawDataKey {
+    Paused,
+    MinWithdrawAmount,
+}
+
+/// Withdraw event data
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct WithdrawEvent {
+    pub user: Address,
+    pub asset: Address,
+    pub amount: i128,
+    pub remaining_balance: i128,
+    pub timestamp: u64,
+}
+
+/// Minimum collateral ratio in basis points (150%)
+const MIN_COLLATERAL_RATIO_BPS: i128 = 15000;
+
+/// Withdraw collateral from the protocol
+///
+/// # Arguments
+/// * `env` - The contract environment
+/// * `user` - The withdrawer's address
+/// * `asset` - The collateral asset address
+/// * `amount` - The amount to withdraw
+///
+/// # Returns
+/// Returns the remaining collateral balance on success
+pub fn withdraw(
+    env: &Env,
+    user: Address,
+    asset: Address,
+    amount: i128,
+) -> Result<i128, WithdrawError> {
+    user.require_auth();
+
+    if is_paused(env) {
+        return Err(WithdrawError::WithdrawPaused);
+    }
+
+    if amount <= 0 {
+        return Err(WithdrawError::InvalidAmount);
+    }
+
+    let min_withdraw = get_min_withdraw_amount(env);
+    if amount < min_withdraw {
+        return Err(WithdrawError::InvalidAmount);
+    }
+
+    let position = get_collateral_position(env, &user, &asset);
+
+    if position.amount < amount {
+        return Err(WithdrawError::InsufficientCollateral);
+    }
+
+    let new_amount = position
+        .amount
+        .checked_sub(amount)
+        .ok_or(WithdrawError::Overflow)?;
+
+    validate_collateral_ratio_after_withdraw(env, &user, new_amount)?;
+
+    let updated_position = CollateralPosition {
+        amount: new_amount,
+        asset: asset.clone(),
+        last_deposit_time: position.last_deposit_time,
+    };
+
+    save_collateral_position(env, &user, &updated_position);
+
+    let total_deposits = get_total_deposits(env);
+    let new_total = total_deposits.checked_sub(amount).unwrap_or(0);
+    set_total_deposits(env, new_total);
+
+    emit_withdraw_event(env, user, asset, amount, new_amount);
+
+    Ok(new_amount)
+}
+
+/// Validate collateral ratio remains above minimum after withdrawal
+fn validate_collateral_ratio_after_withdraw(
+    env: &Env,
+    user: &Address,
+    remaining_collateral: i128,
+) -> Result<(), WithdrawError> {
+    use crate::borrow::{BorrowDataKey, DebtPosition};
+
+    let debt_position: Option<DebtPosition> = env
+        .storage()
+        .persistent()
+        .get(&BorrowDataKey::UserDebt(user.clone()));
+
+    if let Some(debt) = debt_position {
+        let total_debt = debt
+            .borrowed_amount
+            .checked_add(debt.interest_accrued)
+            .ok_or(WithdrawError::Overflow)?;
+
+        if total_debt > 0 {
+            let min_collateral = total_debt
+                .checked_mul(MIN_COLLATERAL_RATIO_BPS)
+                .ok_or(WithdrawError::Overflow)?
+                .checked_div(10000)
+                .ok_or(WithdrawError::Overflow)?;
+
+            if remaining_collateral < min_collateral {
+                return Err(WithdrawError::InsufficientCollateralRatio);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Initialize withdraw settings
+pub fn initialize_withdraw_settings(
+    env: &Env,
+    min_withdraw_amount: i128,
+) -> Result<(), WithdrawError> {
+    env.storage()
+        .persistent()
+        .set(&WithdrawDataKey::MinWithdrawAmount, &min_withdraw_amount);
+    env.storage()
+        .persistent()
+        .set(&WithdrawDataKey::Paused, &false);
+    Ok(())
+}
+
+/// Set withdraw pause state
+pub fn set_withdraw_paused(env: &Env, paused: bool) -> Result<(), WithdrawError> {
+    env.storage()
+        .persistent()
+        .set(&WithdrawDataKey::Paused, &paused);
+    Ok(())
+}
+
+fn get_collateral_position(env: &Env, user: &Address, asset: &Address) -> CollateralPosition {
+    env.storage()
+        .persistent()
+        .get(&DepositDataKey::UserCollateral(user.clone()))
+        .unwrap_or(CollateralPosition {
+            amount: 0,
+            asset: asset.clone(),
+            last_deposit_time: env.ledger().timestamp(),
+        })
+}
+
+fn save_collateral_position(env: &Env, user: &Address, position: &CollateralPosition) {
+    env.storage()
+        .persistent()
+        .set(&DepositDataKey::UserCollateral(user.clone()), position);
+}
+
+fn get_total_deposits(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DepositDataKey::TotalDeposits)
+        .unwrap_or(0)
+}
+
+fn set_total_deposits(env: &Env, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DepositDataKey::TotalDeposits, &amount);
+}
+
+fn get_min_withdraw_amount(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&WithdrawDataKey::MinWithdrawAmount)
+        .unwrap_or(0)
+}
+
+fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get(&WithdrawDataKey::Paused)
+        .unwrap_or(false)
+}
+
+fn emit_withdraw_event(
+    env: &Env,
+    user: Address,
+    asset: Address,
+    amount: i128,
+    remaining_balance: i128,
+) {
+    let event = WithdrawEvent {
+        user,
+        asset,
+        amount,
+        remaining_balance,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish((Symbol::new(env, "withdraw"),), event);
+}

--- a/stellar-lend/contracts/lending/src/withdraw_test.rs
+++ b/stellar-lend/contracts/lending/src/withdraw_test.rs
@@ -1,0 +1,454 @@
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    Address, Env, IntoVal, Symbol,
+};
+
+/// Helper: register contract and return client
+fn setup_env() -> (Env, LendingContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+/// Helper: initialize deposit + withdraw settings and deposit collateral
+fn setup_with_deposit(
+    _env: &Env,
+    client: &LendingContractClient,
+    user: &Address,
+    asset: &Address,
+    deposit_amount: i128,
+) {
+    client.initialize_deposit_settings(&1_000_000_000, &100);
+    client.initialize_withdraw_settings(&100);
+    client.deposit(user, asset, &deposit_amount);
+}
+
+// --- Successful withdrawal ---
+
+#[test]
+fn test_withdraw_success() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    let remaining = client.withdraw(&user, &asset, &20_000);
+    assert_eq!(remaining, 30_000);
+
+    let position = client.get_user_collateral_deposit(&user, &asset);
+    assert_eq!(position.amount, 30_000);
+}
+
+#[test]
+fn test_withdraw_full_balance() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    let remaining = client.withdraw(&user, &asset, &50_000);
+    assert_eq!(remaining, 0);
+
+    let position = client.get_user_collateral_deposit(&user, &asset);
+    assert_eq!(position.amount, 0);
+}
+
+#[test]
+fn test_withdraw_multiple_times() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 100_000);
+
+    let r1 = client.withdraw(&user, &asset, &30_000);
+    assert_eq!(r1, 70_000);
+
+    let r2 = client.withdraw(&user, &asset, &20_000);
+    assert_eq!(r2, 50_000);
+
+    let r3 = client.withdraw(&user, &asset, &50_000);
+    assert_eq!(r3, 0);
+}
+
+// --- Invalid amount ---
+
+#[test]
+fn test_withdraw_invalid_amount_zero() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    let result = client.try_withdraw(&user, &asset, &0);
+    assert_eq!(result, Err(Ok(WithdrawError::InvalidAmount)));
+}
+
+#[test]
+fn test_withdraw_invalid_amount_negative() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    let result = client.try_withdraw(&user, &asset, &-500);
+    assert_eq!(result, Err(Ok(WithdrawError::InvalidAmount)));
+}
+
+#[test]
+fn test_withdraw_below_minimum() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    client.initialize_deposit_settings(&1_000_000_000, &100);
+    client.initialize_withdraw_settings(&5000);
+    client.deposit(&user, &asset, &50_000);
+
+    let result = client.try_withdraw(&user, &asset, &1000);
+    assert_eq!(result, Err(Ok(WithdrawError::InvalidAmount)));
+}
+
+// --- Insufficient collateral ---
+
+#[test]
+fn test_withdraw_insufficient_collateral() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 10_000);
+
+    let result = client.try_withdraw(&user, &asset, &50_000);
+    assert_eq!(result, Err(Ok(WithdrawError::InsufficientCollateral)));
+}
+
+#[test]
+fn test_withdraw_no_deposit() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    client.initialize_deposit_settings(&1_000_000_000, &100);
+    client.initialize_withdraw_settings(&100);
+
+    let result = client.try_withdraw(&user, &asset, &1000);
+    assert_eq!(result, Err(Ok(WithdrawError::InsufficientCollateral)));
+}
+
+// --- Pause functionality ---
+
+#[test]
+fn test_withdraw_paused() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+    client.set_withdraw_paused(&true);
+
+    let result = client.try_withdraw(&user, &asset, &10_000);
+    assert_eq!(result, Err(Ok(WithdrawError::WithdrawPaused)));
+}
+
+#[test]
+fn test_withdraw_pause_unpause() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    client.set_withdraw_paused(&true);
+    let result = client.try_withdraw(&user, &asset, &10_000);
+    assert_eq!(result, Err(Ok(WithdrawError::WithdrawPaused)));
+
+    client.set_withdraw_paused(&false);
+    let remaining = client.withdraw(&user, &asset, &10_000);
+    assert_eq!(remaining, 40_000);
+}
+
+// --- Collateral ratio validation ---
+
+#[test]
+fn test_withdraw_ratio_violation_with_debt() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let borrow_asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+
+    // Deposit 100,000 collateral
+    setup_with_deposit(&env, &client, &user, &asset, 100_000);
+
+    // Borrow 10,000 against 15,000 collateral (borrow module tracks separately)
+    client.initialize_borrow_settings(&1_000_000_000, &1000);
+    client.borrow(&user, &borrow_asset, &10_000, &collateral_asset, &15_000);
+
+    // Try to withdraw 90,000 -> remaining 10,000 vs debt 10,000 * 1.5 = 15,000 -> fail
+    let result = client.try_withdraw(&user, &asset, &90_000);
+    assert_eq!(result, Err(Ok(WithdrawError::InsufficientCollateralRatio)));
+}
+
+#[test]
+fn test_withdraw_ratio_valid_with_debt() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let borrow_asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+
+    // Deposit 100,000 collateral
+    setup_with_deposit(&env, &client, &user, &asset, 100_000);
+
+    // Borrow 10,000 against 15,000 collateral
+    client.initialize_borrow_settings(&1_000_000_000, &1000);
+    client.borrow(&user, &borrow_asset, &10_000, &collateral_asset, &15_000);
+
+    // Withdraw 80,000 -> remaining 20,000 vs debt 10,000 * 1.5 = 15,000 -> pass
+    let remaining = client.withdraw(&user, &asset, &80_000);
+    assert_eq!(remaining, 20_000);
+}
+
+#[test]
+fn test_withdraw_ratio_boundary_exact_150_percent() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let borrow_asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+
+    // Deposit 100,000
+    setup_with_deposit(&env, &client, &user, &asset, 100_000);
+
+    // Borrow 10,000 (min collateral = 10,000 * 1.5 = 15,000)
+    client.initialize_borrow_settings(&1_000_000_000, &1000);
+    client.borrow(&user, &borrow_asset, &10_000, &collateral_asset, &15_000);
+
+    // Withdraw exactly to 15,000 remaining -> should succeed (exactly 150%)
+    let remaining = client.withdraw(&user, &asset, &85_000);
+    assert_eq!(remaining, 15_000);
+
+    // Further withdrawal would violate ratio (tested in ratio_boundary_just_below)
+}
+
+#[test]
+fn test_withdraw_ratio_boundary_just_below() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let borrow_asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+
+    // Deposit 30,000
+    setup_with_deposit(&env, &client, &user, &asset, 30_000);
+
+    // Borrow 10,000 (min collateral = 15,000)
+    client.initialize_borrow_settings(&1_000_000_000, &1000);
+    client.borrow(&user, &borrow_asset, &10_000, &collateral_asset, &15_000);
+
+    // Withdraw 15,100 -> remaining 14,900 < 15,000 -> fail
+    let result = client.try_withdraw(&user, &asset, &15_100);
+    assert_eq!(result, Err(Ok(WithdrawError::InsufficientCollateralRatio)));
+}
+
+#[test]
+fn test_withdraw_no_debt_allows_full_withdrawal() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    // No borrow debt — full withdrawal allowed
+    let remaining = client.withdraw(&user, &asset, &50_000);
+    assert_eq!(remaining, 0);
+}
+
+// --- Max withdrawal ---
+
+#[test]
+fn test_withdraw_max_with_debt() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let borrow_asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+
+    // Deposit 100,000
+    setup_with_deposit(&env, &client, &user, &asset, 100_000);
+
+    // Borrow 10,000 (min collateral = 15,000)
+    client.initialize_borrow_settings(&1_000_000_000, &1000);
+    client.borrow(&user, &borrow_asset, &10_000, &collateral_asset, &15_000);
+
+    // Max safe withdrawal = 100,000 - 15,000 = 85,000
+    let remaining = client.withdraw(&user, &asset, &85_000);
+    assert_eq!(remaining, 15_000);
+
+    // Any further withdrawal beyond min_withdraw should fail on ratio
+    let result = client.try_withdraw(&user, &asset, &100);
+    assert_eq!(result, Err(Ok(WithdrawError::InsufficientCollateralRatio)));
+}
+
+// --- Total deposits tracking ---
+
+#[test]
+fn test_withdraw_updates_total_deposits() {
+    let (env, client) = setup_env();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user1, &asset, 60_000);
+    client.deposit(&user2, &asset, &40_000);
+
+    // Total deposits = 100,000
+    client.withdraw(&user1, &asset, &20_000);
+
+    // Verify user1 position
+    let pos1 = client.get_user_collateral_deposit(&user1, &asset);
+    assert_eq!(pos1.amount, 40_000);
+
+    // Verify user2 unaffected
+    let pos2 = client.get_user_collateral_deposit(&user2, &asset);
+    assert_eq!(pos2.amount, 40_000);
+}
+
+// --- Separate users ---
+
+#[test]
+fn test_withdraw_separate_users() {
+    let (env, client) = setup_env();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user1, &asset, 50_000);
+    client.deposit(&user2, &asset, &30_000);
+
+    client.withdraw(&user1, &asset, &10_000);
+
+    let pos1 = client.get_user_collateral_deposit(&user1, &asset);
+    let pos2 = client.get_user_collateral_deposit(&user2, &asset);
+    assert_eq!(pos1.amount, 40_000);
+    assert_eq!(pos2.amount, 30_000);
+}
+
+// --- Timestamp preservation ---
+
+#[test]
+fn test_withdraw_preserves_deposit_timestamp() {
+    let (env, client) = setup_env();
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    let pos_before = client.get_user_collateral_deposit(&user, &asset);
+    assert_eq!(pos_before.last_deposit_time, 1000);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 2000;
+    });
+
+    client.withdraw(&user, &asset, &10_000);
+
+    // Withdraw should preserve the last deposit time, not update it
+    let pos_after = client.get_user_collateral_deposit(&user, &asset);
+    assert_eq!(pos_after.last_deposit_time, 1000);
+    assert_eq!(pos_after.amount, 40_000);
+}
+
+// --- Event emission ---
+
+#[test]
+fn test_withdraw_emits_event() {
+    let (env, client) = setup_env();
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 5000;
+    });
+
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    client.withdraw(&user, &asset, &20_000);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+
+    let expected_topics = (Symbol::new(&env, "withdraw"),).into_val(&env);
+    assert_eq!(last_event.0, client.address);
+    assert_eq!(last_event.1, expected_topics);
+}
+
+// --- Edge cases ---
+
+#[test]
+fn test_withdraw_minimum_amount_boundary() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    client.initialize_deposit_settings(&1_000_000_000, &100);
+    client.initialize_withdraw_settings(&500);
+    client.deposit(&user, &asset, &50_000);
+
+    // Below minimum — should fail
+    let result = client.try_withdraw(&user, &asset, &499);
+    assert_eq!(result, Err(Ok(WithdrawError::InvalidAmount)));
+
+    // Exactly minimum — should succeed
+    let remaining = client.withdraw(&user, &asset, &500);
+    assert_eq!(remaining, 49_500);
+}
+
+#[test]
+fn test_withdraw_after_multiple_deposits() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 20_000);
+    client.deposit(&user, &asset, &30_000);
+
+    // Total deposited = 50,000
+    let remaining = client.withdraw(&user, &asset, &40_000);
+    assert_eq!(remaining, 10_000);
+}
+
+#[test]
+fn test_withdraw_deposit_withdraw_cycle() {
+    let (env, client) = setup_env();
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    setup_with_deposit(&env, &client, &user, &asset, 50_000);
+
+    client.withdraw(&user, &asset, &20_000);
+    let pos = client.get_user_collateral_deposit(&user, &asset);
+    assert_eq!(pos.amount, 30_000);
+
+    client.deposit(&user, &asset, &10_000);
+    let pos = client.get_user_collateral_deposit(&user, &asset);
+    assert_eq!(pos.amount, 40_000);
+
+    client.withdraw(&user, &asset, &40_000);
+    let pos = client.get_user_collateral_deposit(&user, &asset);
+    assert_eq!(pos.amount, 0);
+}

--- a/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_borrow_interest_accrual.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_borrow_interest_accrual.1.json
@@ -57,6 +57,68 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "BorrowerCollateral"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BorrowerCollateral"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "200000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "asset"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "DebtCeiling"
                 }
               ]
@@ -198,68 +260,6 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "100000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "UserCollateral"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "UserCollateral"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "amount"
-                      },
-                      "val": {
-                        "i128": "200000"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                      }
-                    }
-                  ]
                 }
               }
             },

--- a/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_borrow_multiple_times.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_borrow_multiple_times.1.json
@@ -89,6 +89,68 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "BorrowerCollateral"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BorrowerCollateral"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "30000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "asset"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "DebtCeiling"
                 }
               ]
@@ -230,68 +292,6 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "15000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "UserCollateral"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "UserCollateral"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "amount"
-                      },
-                      "val": {
-                        "i128": "30000"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                      }
-                    }
-                  ]
                 }
               }
             },

--- a/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_borrow_success.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_borrow_success.1.json
@@ -58,6 +58,68 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "BorrowerCollateral"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BorrowerCollateral"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "20000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "asset"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "DebtCeiling"
                 }
               ]
@@ -199,68 +261,6 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "10000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "UserCollateral"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "UserCollateral"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "amount"
-                      },
-                      "val": {
-                        "i128": "20000"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                      }
-                    }
-                  ]
                 }
               }
             },

--- a/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_collateral_ratio_validation.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_collateral_ratio_validation.1.json
@@ -57,6 +57,68 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "BorrowerCollateral"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BorrowerCollateral"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "15000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "asset"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "DebtCeiling"
                 }
               ]
@@ -198,68 +260,6 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "10000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "UserCollateral"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "UserCollateral"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "amount"
-                      },
-                      "val": {
-                        "i128": "15000"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                      }
-                    }
-                  ]
                 }
               }
             },

--- a/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_overflow_protection.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_overflow_protection.1.json
@@ -57,6 +57,68 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "BorrowerCollateral"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BorrowerCollateral"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "2000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "asset"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "DebtCeiling"
                 }
               ]
@@ -198,68 +260,6 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "1000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "UserCollateral"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "UserCollateral"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "amount"
-                      },
-                      "val": {
-                        "i128": "2000000"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                      }
-                    }
-                  ]
                 }
               }
             },

--- a/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_pause_unpause.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/borrow_test/test_pause_unpause.1.json
@@ -59,6 +59,68 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "BorrowerCollateral"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BorrowerCollateral"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "20000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "asset"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "DebtCeiling"
                 }
               ]
@@ -200,68 +262,6 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "10000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "UserCollateral"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "UserCollateral"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "amount"
-                      },
-                      "val": {
-                        "i128": "20000"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                      }
-                    }
-                  ]
                 }
               }
             },


### PR DESCRIPTION
## Summary

Closes #273. Adds the `withdraw` function and a comprehensive test suite for the lending contract's withdraw functionality.

## Root Cause

The lending contract had no withdraw module. Additionally, a storage key collision between `BorrowDataKey::UserCollateral` and `DepositDataKey::UserCollateral` (identical Soroban serialization) prevented cross-module interactions needed for collateral ratio tests.

## Changes

- **`withdraw.rs`** — Withdraw function with amount validation, pause checks, balance verification, collateral ratio enforcement (150% minimum against borrow debt), total deposit tracking, and event emission
- **`withdraw_test.rs`** — 23 test cases covering all required scenarios (success, ratio violations, max withdrawal, pause, invalid inputs, events, edge cases)
- **`lib.rs`** — Register withdraw module and expose contract methods
- **`borrow.rs`** — Rename `UserCollateral` to `BorrowerCollateral` in `BorrowDataKey` to resolve storage key collision

## Testing

- ✅ 46/46 tests pass (11 borrow + 12 deposit + 23 withdraw)
- ✅ `cargo clippy -- -D warnings`: clean
- ✅ `cargo fmt -- --check`: clean
- ✅ All existing borrow and deposit tests continue to pass


## Files Changed

| File | Description |
|------|-------------|
| `withdraw.rs` | New withdraw module |
| `withdraw_test.rs` | 23 test cases |
| `lib.rs` | Module registration + contract methods |
| `borrow.rs` | Storage key rename (3 lines) |