### PR TITLE
docs(hello-world): reentrancy guarantees link

### DIFF
--- a/stellar-lend/contracts/hello-world/README.md
+++ b/stellar-lend/contracts/hello-world/README.md
@@ -24,7 +24,7 @@ Refer to `src/lib.rs` for detailed types and events.
 
 ## Security Notes
 
-- Reentrancy guarantees and Soroban execution-model assumptions are documented in [`REENTRANCY.md`](./REENTRANCY.md).
+- Reentrancy guarantees and Soroban execution-model assumptions are documented in [`REENTRANCY.md`](./REENTRANCY.md) and [`REENTRANCY_GUARANTEES.md`](../../docs/REENTRANCY_GUARANTEES.md).
 - Formal verification preparation notes for borrow/repay/liquidate are documented in [`docs/formal_verification_prep.md`](./docs/formal_verification_prep.md).
 
 ### Oracle Trust Boundaries


### PR DESCRIPTION
## Summary

- Add cross-link to [`REENTRANCY_GUARANTEES.md`](../../docs/REENTRANCY_GUARANTEES.md) from the hello-world README security notes section.
- The file already exists at `stellar-lend/docs/REENTRANCY_GUARANTEES.md` and covers the `ReentrancyGuard` mechanism, protected operations, and Soroban execution-model security assumptions for auditors.
- Existing link to `REENTRANCY.md` (contract-local audit notes) is preserved; the new link provides the companion canonical guarantees document.

## Change

One line in `stellar-lend/contracts/hello-world/README.md` — no logic or code change.

## Why the previous PR had 0 files changed

The prior PR targeting this issue was opened against a stale branch and contained no commits. This PR replaces it with the actual change.

closes #527