### PR TITLE
feat: add per-asset min borrow thresholds #660

### DIFF
--- a/docs/reserve.md
+++ b/docs/reserve.md
@@ -756,3 +756,8 @@ For questions or issues:
 
 MIT License - See LICENSE file for details
 
+
+
+## Error Mapping: Minimum Borrow Requirements
+When a borrow request fails with `BelowMinimumBorrow` (Error Code 8), the frontend should fetch the `min_borrow_amount` for that specific asset from contract storage.
+Guidance: Display a message like 'The minimum borrow amount for this asset is {min_borrow_amount}. Please increase your loan size.'

--- a/stellar-lend/contracts/lending/src/borrow.rs
+++ b/stellar-lend/contracts/lending/src/borrow.rs
@@ -36,7 +36,7 @@ pub enum BorrowDataKey {
     BorrowUserCollateral(Address),
     BorrowTotalDebt,
     BorrowDebtCeiling,
-    BorrowMinAmount,
+    BorrowMinAmountPerAsset(Address),
     OracleAddress,
     LiquidationThresholdBps,
     CloseFactor,
@@ -124,7 +124,7 @@ pub fn borrow(
     }
 
     // Instance storage read (Cheap)
-    let min_borrow = get_min_borrow_amount(env);
+    let min_borrow = get_min_borrow_amount(env, &asset);
     if amount < min_borrow {
         return Err(BorrowError::BelowMinimumBorrow);
     }
@@ -395,7 +395,7 @@ pub fn initialize_borrow_settings(
         .set(&BorrowDataKey::BorrowDebtCeiling, &debt_ceiling);
     env.storage()
         .instance()
-        .set(&BorrowDataKey::BorrowMinAmount, &min_borrow_amount);
+        .set(&BorrowDataKey::BorrowMinAmountPerAsset(asset), &min_borrow_amount);
     Ok(())
 }
 


### PR DESCRIPTION
Implement per-asset minimum borrow amounts to optimize protocol health and prevent dust positions.

Changes
Storage: Updated BorrowDataKey to support BorrowMinAmountPerAsset(Address) mapping.

Logic: Modified the borrow function in borrow.rs to enforce asset-specific minimums instead of a global threshold.

Docs: Updated docs/reserve.md with error mapping guidance (Error 8: BelowMinimumBorrow) for frontend integration.

Security Note
This change significantly reduces the attack surface for "dust exploitation" where malicious actors create thousands of tiny, unliquidatable positions to bloat contract storage.

Closes #660