### PR TITLE
Implement strict parameter range validation

### DIFF
--- a/stellar-lend/contracts/lending/src/borrow.rs
+++ b/stellar-lend/contracts/lending/src/borrow.rs
@@ -11,6 +11,7 @@ use crate::constants::{
     DEFAULT_LIQUIDATION_THRESHOLD_BPS,
 };
 use crate::pause::{self, blocks_high_risk_ops, PauseType};
+use crate::validation;
 use soroban_sdk::{contracterror, contractevent, contracttype, Address, Env, I256};
 
 pub use crate::errors::BorrowError;
@@ -286,9 +287,7 @@ pub fn set_liquidation_threshold_bps(
         return Err(BorrowError::Unauthorized);
     }
     admin.require_auth();
-    if bps <= 0 || bps > BPS_SCALE {
-        return Err(BorrowError::InvalidAmount);
-    }
+    validation::assert_bps_range(bps)?;
     env.storage()
         .instance()
         .set(&BorrowDataKey::LiquidationThresholdBps, &bps);
@@ -311,8 +310,9 @@ pub fn set_close_factor_bps(env: &Env, admin: &Address, bps: i128) -> Result<(),
         return Err(BorrowError::Unauthorized);
     }
     admin.require_auth();
-    if !(1..=BPS_SCALE).contains(&bps) {
-        return Err(BorrowError::InvalidAmount);
+    validation::assert_bps_range(bps)?;
+    if bps == 0 {
+        return Err(BorrowError::InvalidParameterRange);
     }
     env.storage()
         .instance()
@@ -340,9 +340,7 @@ pub fn set_liquidation_incentive_bps(
         return Err(BorrowError::Unauthorized);
     }
     admin.require_auth();
-    if !(0..=BPS_SCALE).contains(&bps) {
-        return Err(BorrowError::InvalidAmount);
-    }
+    validation::assert_bps_range(bps)?;
     env.storage()
         .instance()
         .set(&BorrowDataKey::LiquidationIncentiveBps, &bps);
@@ -419,6 +417,8 @@ pub fn initialize_borrow_settings(
     debt_ceiling: i128,
     min_borrow_amount: i128,
 ) -> Result<(), BorrowError> {
+    validation::assert_positive(debt_ceiling)?;
+    validation::assert_positive(min_borrow_amount)?;
     env.storage()
         .instance()
         .set(&BorrowDataKey::BorrowDebtCeiling, &debt_ceiling);

--- a/stellar-lend/contracts/lending/src/cross_asset.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset.rs
@@ -88,6 +88,7 @@ use soroban_sdk::{contracterror, contractevent, contracttype, token, Address, En
 
 use crate::constants::{BPS_SCALE, HEALTH_FACTOR_SCALE};
 use crate::pause::{self, PauseType};
+use crate::validation;
 
 pub use crate::errors::CrossAssetError;
 
@@ -192,6 +193,12 @@ pub fn set_asset_params(
     params: AssetParams,
 ) -> Result<(), CrossAssetError> {
     check_admin(env)?;
+    
+    validation::assert_bps_range(params.ltv)?;
+    validation::assert_bps_range(params.liquidation_threshold)?;
+    validation::assert_ltv_threshold(params.ltv, params.liquidation_threshold)?;
+    validation::assert_positive(params.debt_ceiling)?;
+
     env.storage()
         .persistent()
         .set(&CrossAssetDataKey::AssetParams(asset), &params);

--- a/stellar-lend/contracts/lending/src/errors.rs
+++ b/stellar-lend/contracts/lending/src/errors.rs
@@ -30,6 +30,7 @@ pub enum BorrowError {
     BelowMinimumBorrow = 1008,
     RepayAmountTooHigh = 1009,
     Reentrancy = 1010,
+    InvalidParameterRange = 1011,
 }
 
 // ── Deposits (2000–2999) ──────────────────────────────────────────────

--- a/stellar-lend/contracts/lending/src/interest_rate.rs
+++ b/stellar-lend/contracts/lending/src/interest_rate.rs
@@ -140,6 +140,20 @@ pub fn calculate_supply_rate(env: &Env) -> Result<i128, InterestRateError> {
     Ok((borrow_rate - config.spread_bps).max(config.rate_floor_bps))
 }
 
-pub fn update_config(env: &Env, config: InterestRateConfig) {
-    env.storage().persistent().set(&InterestRateDataKey::Config, &config);
+pub fn update_config(env: &Env, config: InterestRateConfig) -> Result<(), InterestRateError> {
+    if !(0..=BPS_SCALE).contains(&config.base_rate_bps)
+        || !(0..=BPS_SCALE).contains(&config.kink_utilization_bps)
+        || !(0..=BPS_SCALE).contains(&config.multiplier_bps)
+        || !(0..=BPS_SCALE).contains(&config.jump_multiplier_bps)
+        || !(0..=BPS_SCALE).contains(&config.rate_floor_bps)
+        || !(0..=BPS_SCALE).contains(&config.rate_ceiling_bps)
+        || !(0..=BPS_SCALE).contains(&config.spread_bps)
+        || config.rate_floor_bps > config.rate_ceiling_bps
+    {
+        return Err(InterestRateError::InvalidParameter);
+    }
+    env.storage()
+        .persistent()
+        .set(&InterestRateDataKey::Config, &config);
+    Ok(())
 }

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -18,6 +18,7 @@ mod reentrancy;
 mod token_receiver;
 mod withdraw;
 mod errors;
+mod validation;
 #[cfg(test)]
 mod errors_test;
 

--- a/stellar-lend/contracts/lending/src/rate_model_test.rs
+++ b/stellar-lend/contracts/lending/src/rate_model_test.rs
@@ -33,7 +33,7 @@ impl MockRateContract {
         interest_rate::get_config(&env)
     }
     pub fn update_config(env: Env, config: InterestRateConfig) {
-        interest_rate::update_config(&env, config);
+        interest_rate::update_config(&env, config).unwrap();
     }
     pub fn set_market(env: Env, deposits: i128, borrows: i128) {
         env.storage().persistent().set(&DepositDataKey::TotalAmount, &deposits);
@@ -177,4 +177,17 @@ fn test_supply_rate() {
     // 0% Utilization -> Borrow 1%, Supply = 1% - 2% = -1% -> capped at floor (0.5%)
     client.set_market(&1000, &0);
     assert_eq!(client.get_supply_rate(), 50);
+}
+
+#[test]
+#[should_panic(expected = "Status(ContractError(2))")]
+fn test_invalid_rate_config() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, MockRateContract);
+    let client = MockRateContractClient::new(&env, &contract_id);
+    client.init();
+    
+    let mut config = client.get_config();
+    config.base_rate_bps = 10001; // Invalid
+    client.update_config(&config);
 }

--- a/stellar-lend/contracts/lending/src/validation.rs
+++ b/stellar-lend/contracts/lending/src/validation.rs
@@ -1,0 +1,53 @@
+//! # Parameter Validation Helpers
+//!
+//! Provides centralized logic for enforcing strict bounds on admin-set parameters.
+//! Prevents unsafe configurations that could lead to protocol instability.
+
+use soroban_sdk::Env;
+use crate::constants::BPS_SCALE;
+use crate::errors::BorrowError;
+
+/// Enforces that a value expressed in basis points is within [0, 10000].
+pub fn assert_bps_range(bps: i128) -> Result<(), BorrowError> {
+    if !(0..=BPS_SCALE).contains(&bps) {
+        return Err(BorrowError::InvalidParameterRange);
+    }
+    Ok(())
+}
+
+/// Enforces that a value is non-negative.
+pub fn assert_positive(value: i128) -> Result<(), BorrowError> {
+    if value < 0 {
+        return Err(BorrowError::InvalidParameterRange);
+    }
+    Ok(())
+}
+
+/// Enforces that LTV is less than or equal to the liquidation threshold.
+/// This prevents positions from being immediately liquidatable.
+pub fn assert_ltv_threshold(ltv: i128, threshold: i128) -> Result<(), BorrowError> {
+    assert_bps_range(ltv)?;
+    assert_bps_range(threshold)?;
+    if ltv > threshold {
+        return Err(BorrowError::InvalidParameterRange);
+    }
+    Ok(())
+}
+
+/// Enforces that a rate floor is less than or equal to a rate ceiling.
+pub fn assert_rate_bounds(floor: i128, ceiling: i128) -> Result<(), BorrowError> {
+    assert_bps_range(floor)?;
+    assert_bps_range(ceiling)?;
+    if floor > ceiling {
+        return Err(BorrowError::InvalidParameterRange);
+    }
+    Ok(())
+}
+
+/// Enforces that a time interval is positive and within a reasonable max (e.g. 30 days).
+pub fn assert_time_interval(seconds: u64, min: u64, max: u64) -> Result<(), BorrowError> {
+    if seconds < min || seconds > max {
+        return Err(BorrowError::InvalidParameterRange);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #695. This PR adds strict validation for admin-set parameters across the lending protocol.

Key changes:
- Created `validation.rs` with centralized assertion helpers.
- Updated `borrow.rs`, `cross_asset.rs`, and `interest_rate.rs` to enforce BPS ranges and logical constraints (e.g. LTV <= Liquidation Threshold).
- Added `InvalidParameterRange` error code to `BorrowError`.
- Updated interest rate model tests to verify validation logic.