### PR TITLE
docs: define and implement persistent storage TTL policy

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -10,6 +10,27 @@ All keys are defined using `contracttype` enums.
 > [!IMPORTANT]
 > **Namespace Isolation**: To prevent collisions between modules, all storage key enum variants MUST be unique across the entire contract. Even different enum types will collide if their variants share the same name (as they serialize to the same `Symbol`).
 
+## Persistent TTL Policy
+
+To keep user positions readable, the lending contract now extends the TTL for the two position-specific persistent entries:
+
+- `("col", user)` — collateral balance
+- `("debt", user)` — debt position record
+
+The policy is:
+
+- `deposit`, `withdraw`, `borrow`, and `repay` extend TTL on the corresponding `col` or `debt` entry when the position changes.
+- `get_position` extends TTL for an existing collateral entry and existing debt entry during a position read.
+- `get_debt_position` extends TTL for an existing debt entry during a debt-only read.
+
+This design keeps actively used positions live while limiting extra gas cost to the small set of position read/write entrypoints.
+
+### Gas trade-offs
+
+- Write-side TTL bumps are the primary mechanism and add a small storage extension cost to each position-changing call.
+- Read-side TTL bumps are only applied on explicit position queries, which preserves liveness for read-heavy users without imposing additional fees on unrelated contract calls.
+- The TTL is long-lived (up to 1,000,000 ledgers or the network maximum), so routine use keeps positions live and infrequent inactive positions are not constantly bumped.
+
 ## Storage Map
 
 ### 1. Cross-Asset Core (`cross_asset.rs`)

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -1,11 +1,18 @@
 #![no_std]
 
 pub mod rounding_strategy;
+mod debt;
 
 #[cfg(test)]
 mod interest_drift_regression_test;
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Symbol};
+use debt::{borrow_amount, load_debt, save_debt, DebtPosition, DEFAULT_APR_BPS, repay_amount, effective_debt};
+
+/// Maximum desired persistent TTL for position entries, in ledgers.
+/// We bound the extension by the network's `max_ttl` to remain compatible
+/// with runtime limits while keeping active positions alive for a long window.
+const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -23,6 +30,22 @@ pub enum LendingError {
 
 #[contract]
 pub struct LendingContract;
+
+/// Helper function to extend TTL for collateral entries
+/// Prevents collateral data from being archived during the TTL period
+fn extend_collateral_ttl(env: &Env, user: &Address) {
+    let key = ("col", user.clone());
+    let ttl = env.storage().max_ttl().min(PERSISTENT_TTL_LEDGERS);
+    env.storage().persistent().extend_ttl(&key, ttl, ttl);
+}
+
+/// Helper function to extend TTL for debt entries
+/// Prevents debt data from being archived during the TTL period
+fn extend_debt_ttl(env: &Env, user: &Address) {
+    let key = ("debt", user.clone());
+    let ttl = env.storage().max_ttl().min(PERSISTENT_TTL_LEDGERS);
+    env.storage().persistent().extend_ttl(&key, ttl, ttl);
+}
 
 #[contractimpl]
 impl LendingContract {
@@ -61,6 +84,8 @@ impl LendingContract {
         let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
         let new_balance = current + amount;
         env.storage().persistent().set(&key, &new_balance);
+        // Extend TTL to prevent archival of collateral entry
+        extend_collateral_ttl(&env, &user);
         new_balance
     }
 
@@ -75,6 +100,8 @@ impl LendingContract {
         let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
         let new_balance = current - amount;
         env.storage().persistent().set(&key, &new_balance);
+        // Extend TTL to prevent archival of collateral entry
+        extend_collateral_ttl(&env, &user);
         new_balance
     }
 
@@ -85,11 +112,14 @@ impl LendingContract {
         if amount < min_borrow {
             return Err(LendingError::BelowMinimumBorrow);
         }
-        let key = ("debt", user.clone());
-        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-        let new_debt = current + amount;
-        env.storage().persistent().set(&key, &new_debt);
-        Ok(new_debt)
+        let now = env.ledger().timestamp();
+        let position = load_debt(&env, &user);
+        let updated = borrow_amount(position, now, amount, DEFAULT_APR_BPS)
+            .unwrap_or_else(|_| panic_with_debt_error());
+        save_debt(&env, &user, &updated);
+        // Extend TTL to prevent archival of debt entry
+        extend_debt_ttl(&env, &user);
+        Ok(updated.principal)
     }
 
     pub fn repay(env: Env, user: Address, amount: i128) -> i128 {
@@ -104,11 +134,16 @@ impl LendingContract {
         let updated = repay_amount(position, now, amount, DEFAULT_APR_BPS)
             .unwrap_or_else(|_| panic_with_debt_error());
         save_debt(&env, &user, &updated);
+        extend_debt_ttl(&env, &user);
         updated.principal
     }
 
     pub fn get_debt_position(env: Env, user: Address) -> DebtPosition {
-        load_debt(&env, &user)
+        let position = load_debt(&env, &user);
+        if position.principal != 0 {
+            extend_debt_ttl(&env, &user);
+        }
+        position
     }
 
     // Flash loan fee setter (bps). Only admin may call.
@@ -198,12 +233,15 @@ impl LendingContract {
 
     /// Get the user's current position summary.
     pub fn get_position(env: Env, user: Address) -> PositionSummary {
-        let col: i128 = env
-            .storage()
-            .persistent()
-            .get(&("col", user.clone()))
-            .unwrap_or(0);
+        let col_key = ("col", user.clone());
+        let col: i128 = env.storage().persistent().get(&col_key).unwrap_or(0);
+        if col != 0 {
+            extend_collateral_ttl(&env, &user);
+        }
         let position = load_debt(&env, &user);
+        if position.principal != 0 {
+            extend_debt_ttl(&env, &user);
+        }
         let debt = effective_debt(&position, env.ledger().timestamp(), DEFAULT_APR_BPS)
             .unwrap_or(position.principal);
         PositionSummary {
@@ -236,7 +274,7 @@ mod test {
     fn advance_time(env: &Env, seconds: u64) {
         let mut li = env.ledger().get();
         li.timestamp = li.timestamp.saturating_add(seconds);
-        li.sequence_number = li.sequence_number.saturating_add(1);
+        li.sequence_number = li.sequence_number.saturating_add(seconds);
         env.ledger().set(li);
     }
 
@@ -286,6 +324,39 @@ mod test {
         let pos = client.get_position(&user);
         assert_eq!(pos.collateral, 200);
         assert_eq!(pos.debt, 75);
+    }
+
+    #[test]
+    fn test_ttl_keeps_position_live_across_reads() {
+        let (env, client, _admin, user) = setup();
+        client.deposit(&user, &200);
+        client.borrow(&user, &75);
+
+        // Move time to the middle of the TTL window and read the position.
+        advance_time(&env, (PERSISTENT_TTL_LEDGERS / 2) as u64);
+        let pos_mid = client.get_position(&user);
+        assert_eq!(pos_mid.collateral, 200);
+        assert_eq!(pos_mid.debt, 75);
+
+        // Advance past the original TTL boundary. The previous read should have extended TTL.
+        advance_time(&env, (PERSISTENT_TTL_LEDGERS / 2 + 1) as u64);
+        let pos_after = client.get_position(&user);
+        assert_eq!(pos_after.collateral, 200);
+        assert_eq!(pos_after.debt, 75);
+    }
+
+    #[test]
+    fn test_get_debt_position_extends_debt_ttl() {
+        let (env, client, _admin, user) = setup();
+        client.borrow(&user, &100);
+
+        advance_time(&env, (PERSISTENT_TTL_LEDGERS / 2) as u64);
+        let debt_mid = client.get_debt_position(&user);
+        assert_eq!(debt_mid.principal, 100);
+
+        advance_time(&env, (PERSISTENT_TTL_LEDGERS / 2 + 1) as u64);
+        let debt_after = client.get_debt_position(&user);
+        assert_eq!(debt_after.principal, 100);
     }
 
     #[test]


### PR DESCRIPTION
Closes #830 
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed

Summary

This PR defines and implements a persistent storage TTL policy for the StellarLend lending contract.
It updates `stellar-lend/contracts/lending/src/lib.rs` to extend TTL for user collateral and debt entries, and documents the policy in `docs/storage.md`.

## What changed

- Added TTL extension helpers for persistent position storage:
  - `("col", user)` collateral entries
  - `("debt", user)` debt entries
- Extended TTL on write operations:
  - `deposit`
  - `withdraw`
  - `borrow`
  - `repay`
- Extended TTL on read operations for active positions:
  - `get_position`
  - `get_debt_position`
- Bound extensions to the network maximum TTL using `env.storage().max_ttl().min(...)`.
- Added tests simulating ledger advancement to verify entries remain live across TTL boundaries.
- Documented the TTL policy and gas trade-offs in `docs/storage.md`.

## Rationale

A user's collateral and debt records are stored as Soroban persistent entries, which can be archived if their TTL lapses.
Without explicit TTL bumps, active positions can become temporarily unreadable.

This PR uses a policy of bumping TTL on both position mutations and explicit position reads, keeping active positions live while minimizing gas overhead.

## Testing

- `cargo test`
- `cargo test test_ttl_keeps_position_live_across_reads test_get_debt_position_extends_debt_ttl`

## Notes

- The TTL policy is intentionally scoped to position-specific storage keys only.
- Reads only extend TTL for existing entries, so zero positions do not create unnecessary storage extensions.
- The chosen TTL window is long-lived and bounded by network limits.

## Suggested commit message

`docs: define and implement persistent storage TTL policy`
