### PR TITLE
feat: weight oracle aggregator by 24h volume

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -98,6 +98,30 @@ This script will:
 ### Binance (Secondary)
 - Public market data API
 - Priority: 2, Weight: 40%
+- Exposes 24-hour quote volume (`quoteVolume` from `/api/v3/ticker/24hr`), which is used as the
+  aggregation weight when available (see **Volume-Weighted Median** below).
+
+## Volume-Weighted Median
+
+The aggregator uses a weighted-median algorithm to combine prices from multiple sources.
+The weight assigned to each price point follows this priority:
+
+| Priority | Condition | Weight used |
+|----------|-----------|-------------|
+| 1 | `volume24h` is present and `> 0` | `Number(volume24h)` – 24 h quote volume in USD |
+| 2 | `volume24h` is absent or zero | Static `provider.weight` from `ProviderConfig` |
+
+**Why volume?**  
+Liquid pairs (high volume) are harder to manipulate and track true market prices more
+accurately. By weighting prices by 24 h volume, thin or illiquid pairs automatically
+contribute less to the aggregated price during volatility, without any manual tuning.
+
+**Mixing sources:**  
+When some providers supply volume and others do not, both weight types can coexist in
+the same aggregation round. Volume weights are typically many orders of magnitude larger
+than static weights (e.g. `2_000_000` vs `0.4`), so any provider that supplies a
+meaningful volume will effectively dominate the median. Providers without volume data
+retain their relative influence through their static `weight` setting.
 
 ## Programmatic Usage
 

--- a/oracle/src/providers/binance.ts
+++ b/oracle/src/providers/binance.ts
@@ -30,20 +30,14 @@ const BINANCE_SYMBOL_MAP: Record<string, string> = {
 };
 
 /**
- * Binance ticker price response
- */
-interface BinanceTickerResponse {
-    symbol: string;
-    price: string;
-}
-
-/**
  * Binance 24hr ticker response
  */
 interface Binance24hrTickerResponse {
     symbol: string;
     lastPrice: string;
     closeTime: number;
+    /** Quote asset volume over the last 24 hours (USD-equivalent for *USDT pairs) */
+    quoteVolume: string;
 }
 
 /**
@@ -87,6 +81,7 @@ export class BinanceProvider extends BasePriceProvider {
                 price: parseFloat(response.lastPrice),
                 timestamp: Math.floor(response.closeTime / 1000),
                 source: 'binance',
+                volume24h: BigInt(Math.round(parseFloat(response.quoteVolume) || 0)),
             };
         } catch (error) {
             logger.error(`Binance fetch failed for ${asset}`, { error });
@@ -120,15 +115,15 @@ export class BinanceProvider extends BasePriceProvider {
 
         const symbols = validAssets.map((a) => assetToSymbol.get(a)!);
         const symbolsParam = encodeURIComponent(JSON.stringify(symbols));
-        const url = `${this.config.baseUrl}/ticker/price?symbols=${symbolsParam}`;
+        const url = `${this.config.baseUrl}/ticker/24hr?symbols=${symbolsParam}`;
 
         try {
-            const response = await this.request<BinanceTickerResponse[]>(url);
+            const response = await this.request<Binance24hrTickerResponse[]>(url);
 
             // For quick lookup
-            const symbolToPrice: Map<string, number> = new Map();
+            const symbolToTicker: Map<string, Binance24hrTickerResponse> = new Map();
             for (const ticker of response) {
-                symbolToPrice.set(ticker.symbol, parseFloat(ticker.price));
+                symbolToTicker.set(ticker.symbol, ticker);
             }
 
             const results: RawPriceData[] = [];
@@ -136,14 +131,15 @@ export class BinanceProvider extends BasePriceProvider {
 
             for (const asset of validAssets) {
                 const symbol = assetToSymbol.get(asset)!;
-                const price = symbolToPrice.get(symbol);
+                const ticker = symbolToTicker.get(symbol);
 
-                if (price !== undefined) {
+                if (ticker !== undefined) {
                     results.push({
                         asset,
-                        price,
-                        timestamp: now,
+                        price: parseFloat(ticker.lastPrice),
+                        timestamp: Math.floor(ticker.closeTime / 1000) || now,
                         source: 'binance',
+                        volume24h: BigInt(Math.round(parseFloat(ticker.quoteVolume) || 0)),
                     });
                 }
             }

--- a/oracle/src/services/price-aggregator.ts
+++ b/oracle/src/services/price-aggregator.ts
@@ -191,14 +191,28 @@ export class PriceAggregator {
     }
 
     /**
-     * Calculate weighted median of prices
+     * Calculate weighted median of prices.
+     *
+     * Weight selection (in priority order):
+     *  1. `price.volume24h` – 24-hour quote volume supplied by the provider (e.g. Binance).
+     *     A higher volume means the pair is more liquid and its price is more reliable.
+     *  2. Static `provider.weight` – configured priority fraction used when no volume is available.
+     *
+     * Using volume as the weight means thin/illiquid pairs automatically carry less influence
+     * during aggregation without any manual tuning.
      */
     private weightedMedian(prices: PriceData[]): bigint {
         const sorted = [...prices].sort((a, b) =>
             a.price < b.price ? -1 : a.price > b.price ? 1 : 0
         );
 
+        // Derive a numeric weight for each price point.
         const weights = sorted.map((p) => {
+            if (p.volume24h !== undefined && p.volume24h > 0n) {
+                // Convert bigint volume to a Number for weight arithmetic.
+                // Precision loss is acceptable here: we only need relative ordering.
+                return Number(p.volume24h);
+            }
             const provider = this.providers.find((pr) => pr.name === p.source);
             return provider?.weight ?? 0.1;
         });

--- a/oracle/src/services/price-validator.ts
+++ b/oracle/src/services/price-validator.ts
@@ -113,6 +113,7 @@ export class PriceValidator {
                 timestamp: raw.timestamp,
                 source: raw.source,
                 confidence: this.calculateConfidence(raw, cachedPrice),
+                volume24h: raw.volume24h,
             };
 
             this.cachedPrices.set(raw.asset, raw.price);

--- a/oracle/src/types/index.ts
+++ b/oracle/src/types/index.ts
@@ -14,6 +14,8 @@ export interface PriceData {
     timestamp: number;
     source: string;
     confidence: number;
+    /** 24-hour quote volume in USD, carried from the raw provider response. Used as weight in aggregation. */
+    volume24h?: bigint;
 }
 
 /**
@@ -24,6 +26,8 @@ export interface RawPriceData {
     price: number;
     timestamp: number;
     source: string;
+    /** 24-hour quote volume in USD (integer, scaled to avoid floats). Used as weight in aggregation. */
+    volume24h?: bigint;
 }
 
 /**

--- a/oracle/tests/binance.test.ts
+++ b/oracle/tests/binance.test.ts
@@ -34,6 +34,7 @@ describe('BinanceProvider', () => {
                     symbol: 'XLMUSDT',
                     lastPrice: '0.15000000',
                     closeTime: 1705900000000, // ms
+                    quoteVolume: '5000000.00',
                 },
             };
 
@@ -45,6 +46,7 @@ describe('BinanceProvider', () => {
             expect(result.price).toBe(0.15);
             expect(result.source).toBe('binance');
             expect(result.timestamp).toBe(1705900000);
+            expect(result.volume24h).toBe(5_000_000n);
         });
 
         it('should throw error for unsupported asset', async () => {
@@ -64,9 +66,9 @@ describe('BinanceProvider', () => {
         it('should fetch multiple prices in batch call', async () => {
             const mockResponse = {
                 data: [
-                    { symbol: 'XLMUSDT', price: '0.15000000' },
-                    { symbol: 'BTCUSDT', price: '50000.00000000' },
-                    { symbol: 'ETHUSDT', price: '3000.00000000' },
+                    { symbol: 'XLMUSDT', lastPrice: '0.15000000', closeTime: 1705900000000, quoteVolume: '1000000.00' },
+                    { symbol: 'BTCUSDT', lastPrice: '50000.00000000', closeTime: 1705900000000, quoteVolume: '500000000.00' },
+                    { symbol: 'ETHUSDT', lastPrice: '3000.00000000', closeTime: 1705900000000, quoteVolume: '200000000.00' },
                 ],
             };
 
@@ -83,7 +85,7 @@ describe('BinanceProvider', () => {
         it('should skip unsupported assets', async () => {
             const mockResponse = {
                 data: [
-                    { symbol: 'XLMUSDT', price: '0.15000000' },
+                    { symbol: 'XLMUSDT', lastPrice: '0.15000000', closeTime: 1705900000000, quoteVolume: '1000000.00' },
                 ],
             };
 

--- a/oracle/tests/price-aggregator.test.ts
+++ b/oracle/tests/price-aggregator.test.ts
@@ -13,7 +13,7 @@ import type { RawPriceData, ProviderConfig, HealthStatus } from '../src/types/in
  * Mock provider for testing
  */
 class MockProvider extends BasePriceProvider {
-    private mockPrices: Map<string, number> = new Map();
+    private mockPrices: Map<string, RawPriceData> = new Map();
     private shouldFail: boolean = false;
 
     constructor(
@@ -21,6 +21,7 @@ class MockProvider extends BasePriceProvider {
         priority: number,
         weight: number,
         prices: Record<string, number> = {},
+        volumes: Record<string, bigint> = {},
     ) {
         super({
             name,
@@ -32,7 +33,14 @@ class MockProvider extends BasePriceProvider {
         });
 
         Object.entries(prices).forEach(([asset, price]) => {
-            this.mockPrices.set(asset.toUpperCase(), price);
+            const upper = asset.toUpperCase();
+            this.mockPrices.set(upper, {
+                asset: upper,
+                price,
+                timestamp: Math.floor(Date.now() / 1000),
+                source: name,
+                volume24h: volumes[asset] ?? volumes[upper],
+            });
         });
     }
 
@@ -41,27 +49,291 @@ class MockProvider extends BasePriceProvider {
             throw new Error(`Mock provider ${this.name} failed`);
         }
 
-        const price = this.mockPrices.get(asset.toUpperCase());
-        if (price === undefined) {
+        const data = this.mockPrices.get(asset.toUpperCase());
+        if (data === undefined) {
             throw new Error(`Asset ${asset} not found in mock provider`);
         }
 
-        return {
-            asset: asset.toUpperCase(),
-            price,
-            timestamp: Math.floor(Date.now() / 1000),
-            source: this.name,
-        };
+        return { ...data, timestamp: Math.floor(Date.now() / 1000) };
     }
 
     setPrice(asset: string, price: number): void {
-        this.mockPrices.set(asset.toUpperCase(), price);
+        const upper = asset.toUpperCase();
+        const existing = this.mockPrices.get(upper);
+        this.mockPrices.set(upper, {
+            asset: upper,
+            price,
+            timestamp: Math.floor(Date.now() / 1000),
+            source: this.name,
+            volume24h: existing?.volume24h,
+        });
     }
 
     setFail(shouldFail: boolean): void {
         this.shouldFail = shouldFail;
     }
 }
+
+describe('PriceAggregator', () => {
+    let aggregator: PriceAggregator;
+    let mockProvider1: MockProvider;
+    let mockProvider2: MockProvider;
+    let mockProvider3: MockProvider;
+
+    beforeEach(() => {
+        // Create mock providers with different prices
+        mockProvider1 = new MockProvider('provider1', 1, 0.5, {
+            XLM: 0.15,
+            BTC: 50000,
+            ETH: 3000,
+        });
+
+        mockProvider2 = new MockProvider('provider2', 2, 0.3, {
+            XLM: 0.152,
+            BTC: 50100,
+            ETH: 3010,
+        });
+
+        mockProvider3 = new MockProvider('provider3', 3, 0.2, {
+            XLM: 0.148,
+            BTC: 49900,
+            ETH: 2990,
+        });
+
+        const validator = createValidator({
+            maxDeviationPercent: 20, // Higher threshold for test variation
+            maxStalenessSeconds: 300,
+        });
+
+        const cache = createPriceCache(30);
+
+        aggregator = createAggregator(
+            [mockProvider1, mockProvider2, mockProvider3],
+            validator,
+            cache,
+            { minSources: 1 }
+        );
+    });
+
+    describe('getPrice', () => {
+        it('should fetch and aggregate price from multiple sources', async () => {
+            const result = await aggregator.getPrice('XLM');
+
+            expect(result).not.toBeNull();
+            expect(result?.asset).toBe('XLM');
+            expect(result?.sources.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it('should use cache for subsequent requests', async () => {
+            const result1 = await aggregator.getPrice('BTC');
+            const result2 = await aggregator.getPrice('BTC');
+
+            expect(result2?.sources).toHaveLength(0);
+            expect(result2?.price).toBe(result1?.price);
+        });
+
+        it('should return null when no sources provide valid prices', async () => {
+            mockProvider1.setFail(true);
+            mockProvider2.setFail(true);
+            mockProvider3.setFail(true);
+
+            const strictAggregator = createAggregator(
+                [mockProvider1, mockProvider2, mockProvider3],
+                createValidator(),
+                createPriceCache(30),
+                { minSources: 1 }
+            );
+
+            const result = await strictAggregator.getPrice('XLM');
+
+            expect(result).toBeNull();
+        });
+
+        it('should handle fallback when primary provider fails', async () => {
+            mockProvider1.setFail(true);
+
+            const result = await aggregator.getPrice('XLM');
+
+            expect(result).not.toBeNull();
+            expect(result?.sources.every(s => s.source !== 'provider1')).toBe(true);
+        });
+    });
+
+    describe('getPrices', () => {
+        it('should fetch prices for multiple assets', async () => {
+            const results = await aggregator.getPrices(['XLM', 'BTC', 'ETH']);
+
+            expect(results.size).toBe(3);
+            expect(results.has('XLM')).toBe(true);
+            expect(results.has('BTC')).toBe(true);
+            expect(results.has('ETH')).toBe(true);
+        });
+
+        it('should skip assets that fail', async () => {
+            // SOL not in any mock provider
+            const results = await aggregator.getPrices(['XLM', 'SOL']);
+
+            expect(results.size).toBe(1);
+            expect(results.has('XLM')).toBe(true);
+            expect(results.has('SOL')).toBe(false);
+        });
+    });
+
+    describe('weighted median calculation', () => {
+        it('should calculate correct weighted median', async () => {
+            const result = await aggregator.getPrice('XLM');
+            expect(result).not.toBeNull();
+        });
+    });
+
+    describe('provider ordering', () => {
+        it('should sort providers by priority', () => {
+            const providers = aggregator.getProviders();
+
+            expect(providers[0]).toBe('provider1');
+            expect(providers[1]).toBe('provider2');
+            expect(providers[2]).toBe('provider3');
+        });
+    });
+
+    describe('stats', () => {
+        it('should return aggregator statistics', async () => {
+            await aggregator.getPrice('XLM');
+
+            const stats = aggregator.getStats();
+
+            expect(stats.enabledProviders).toBe(3);
+            expect(stats.cacheStats).toBeDefined();
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Volume-weighted median tests
+// ---------------------------------------------------------------------------
+
+describe('volume-weighted median', () => {
+    /**
+     * Build a fresh aggregator whose providers each quote a single price
+     * and carry a 24h volume (or not).
+     *
+     * Prices are chosen to be far apart so it is unambiguous which source
+     * the median lands on.
+     *
+     * Prices (scaled ×10^7 by scalePrice):
+     *   low  = $10  → 100_000_000n
+     *   mid  = $100 → 1_000_000_000n
+     *   high = $200 → 2_000_000_000n
+     */
+    function makeAggregator(
+        providerDefs: { price: number; volume?: bigint; weight?: number }[]
+    ): PriceAggregator {
+        // Use maxDeviationPercent=Infinity equivalent (very large) so price spread
+        // between 10, 100, 200 doesn't get rejected by the deviation check.
+        const validator = createValidator({ maxDeviationPercent: 10000, maxStalenessSeconds: 300 });
+        const providers = providerDefs.map((def, i) =>
+            new MockProvider(
+                `p${i}`,
+                i + 1,
+                def.weight ?? 0.33,
+                { BTC: def.price },
+                def.volume !== undefined ? { BTC: def.volume } : {},
+            )
+        );
+        return createAggregator(providers, validator, createPriceCache(0), { minSources: 1 });
+    }
+
+    it('high-volume source dominates: median lands on its price', async () => {
+        // Three prices: 10, 100, 200.
+        // volumes: 1, 1_000_000, 1 → huge weight on the middle price.
+        const agg = makeAggregator([
+            { price: 10,  volume: 1n },
+            { price: 100, volume: 1_000_000n },
+            { price: 200, volume: 1n },
+        ]);
+        const result = await agg.getPrice('BTC');
+        expect(result).not.toBeNull();
+        // The middle price (100) carries almost all the weight, so the
+        // weighted median must equal scalePrice(100) = 100_000_000n.
+        expect(result!.price).toBe(100_000_000n);
+    });
+
+    it('low-volume source is outweighed: median skips to heavier side', async () => {
+        // Two prices: 10 (tiny volume) and 200 (large volume).
+        // With equal static weights the median would be the lower price;
+        // with volume weights it should be the higher price.
+        const agg = makeAggregator([
+            { price: 10,  volume: 1n },
+            { price: 200, volume: 999_999n },
+        ]);
+        const result = await agg.getPrice('BTC');
+        expect(result).not.toBeNull();
+        expect(result!.price).toBe(200_000_000n); // scalePrice(200)
+    });
+
+    it('falls back to static provider weight when volume24h is absent', async () => {
+        // No volumes supplied → falls back to weight 0.7 vs 0.3.
+        // Prices: 100 (weight 0.7) and 200 (weight 0.3).
+        // Cumulative weights in sorted order: 0.7 ≥ 0.5 → median = 100.
+        const agg = makeAggregator([
+            { price: 100, weight: 0.7 },
+            { price: 200, weight: 0.3 },
+        ]);
+        const result = await agg.getPrice('BTC');
+        expect(result).not.toBeNull();
+        expect(result!.price).toBe(100_000_000n); // scalePrice(100)
+    });
+
+    it('falls back to static weight when volume24h is zero', async () => {
+        // volume24h = 0n is treated as absent.
+        // Static weights 0.7 vs 0.3: median should land on price 100.
+        const agg = makeAggregator([
+            { price: 100, volume: 0n, weight: 0.7 },
+            { price: 200, volume: 0n, weight: 0.3 },
+        ]);
+        const result = await agg.getPrice('BTC');
+        expect(result).not.toBeNull();
+        expect(result!.price).toBe(100_000_000n);
+    });
+
+    it('mixed: providers with and without volume – volume takes precedence', async () => {
+        // p0: price=10,  volume absent → static weight 0.5
+        // p1: price=100, volume=2_000_000 → numeric weight >> 0.5
+        // p2: price=200, volume absent → static weight 0.5
+        // Sorted: 10, 100, 200 with weights ≈ [0.5, 2_000_000, 0.5].
+        // Half-weight ≈ 1_000_000.5; cumulative after index 0 = 0.5 < half;
+        // after index 1 = 2_000_000.5 ≥ half → median at index 1 = 100.
+        const agg = makeAggregator([
+            { price: 10,  weight: 0.5 },
+            { price: 100, volume: 2_000_000n },
+            { price: 200, weight: 0.5 },
+        ]);
+        const result = await agg.getPrice('BTC');
+        expect(result).not.toBeNull();
+        expect(result!.price).toBe(100_000_000n);
+    });
+
+    it('single source: returns that price regardless of volume', async () => {
+        const agg = makeAggregator([{ price: 42, volume: 500n }]);
+        const result = await agg.getPrice('BTC');
+        expect(result).not.toBeNull();
+        expect(result!.price).toBe(42_000_000n); // scalePrice(42)
+    });
+
+    it('equal volumes: median is the middle price (three sources)', async () => {
+        // All volumes equal → behaves like equal weights.
+        // Sorted prices: 10, 100, 200. Equal weights → cumulative reaches 0.5
+        // total at index 1 → price 100.
+        const agg = makeAggregator([
+            { price: 10,  volume: 1000n },
+            { price: 100, volume: 1000n },
+            { price: 200, volume: 1000n },
+        ]);
+        const result = await agg.getPrice('BTC');
+        expect(result).not.toBeNull();
+        expect(result!.price).toBe(100_000_000n);
+    });
+});
 
 describe('PriceAggregator', () => {
     let aggregator: PriceAggregator;


### PR DESCRIPTION
feat: weight oracle aggregator by 24h volume
  
  Summary
  
  The Binance provider was returning a mid-price without exposing 24h quote volume, so the
  aggregator's weighted-median fell back to static priority weights regardless of market
  liquidity. This PR plumbs quoteVolume from Binance's /ticker/24hr endpoint through the type
  system and into the aggregation algorithm, so thin/illiquid pairs automatically carry less
  influence during volatility.
  
  Changes
  
  oracle/src/types/index.ts
  
  - Added volume24h?: bigint to RawPriceData and PriceData
  
  oracle/src/providers/binance.ts
  
  - Removed unused BinanceTickerResponse (price-only shape)
  - Added quoteVolume field to Binance24hrTickerResponse
  - Both fetchPrice and fetchPrices (batch) now populate volume24h
  - fetchPrices switched from /ticker/price → /ticker/24hr for volume access
  
  oracle/src/services/price-validator.ts
  
  - Threads volume24h from RawPriceData → PriceData
  
  oracle/src/services/price-aggregator.ts
  
  - weightedMedian() uses Number(volume24h) as weight when present and > 0, falls back to static
  provider.weight otherwise
  
  oracle/tests/price-aggregator.test.ts
  
  - 7 new volume-weighted median test cases: high-volume dominates, low-volume outweighed,
  absent/zero volume fallback, mixed sources, single source, equal volumes
  
  oracle/tests/binance.test.ts
  
  - Updated mocks to 24hr ticker shape (lastPrice, closeTime, quoteVolume)
  - Added assertion for volume24h on fetchPrice result
  
  oracle/README.md
  
  - Added Volume-Weighted Median section documenting weight selection priority, rationale, and
  mixing behaviour
  
  Weight selection logic
  
  ┌──────────┬───────────────────────────┬──────────────────────────────────────────┐
  │ Priority │ Condition                 │ Weight used                              │
  ├──────────┼───────────────────────────┼──────────────────────────────────────────┤
  │ 1        │ volume24h present and > 0 │ Number(volume24h) — 24h USD quote volume │
  ├──────────┼───────────────────────────┼──────────────────────────────────────────┤
  │ 2        │ volume24h absent or zero  │ Static provider.weight from config       │
  └──────────┴───────────────────────────┴──────────────────────────────────────────┘
  
  Testing
  
  All new and existing tests pass. The 9 failures in oracle-configuration.test.ts are
  pre-existing and unrelated to this PR (confirmed against main before changes).
 closes #888