### PR TITLE
feat: enforce per-asset price bounds in oracle validator

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -41,6 +41,9 @@ cp .env.example .env
 | `CACHE_TTL_SECONDS` | Cache TTL in seconds (default: 30) | No |
 | `UPDATE_INTERVAL_MS` | Price update interval (default: 60000) | No |
 | `MAX_PRICE_DEVIATION_PERCENT` | Max price deviation % (default: 10) | No |
+| `PRICE_BOUNDS_JSON` | Optional JSON map of per-asset min/max bounds | No |
+| `ADMIN_API_PORT` | HTTP port for secure admin operations | No |
+| `ADMIN_HMAC_SECRET` | HMAC secret used to sign admin reload requests | No |
 | `LOG_LEVEL` | Logging: debug, info, warn, error | No |
 
 ## Usage
@@ -57,6 +60,24 @@ npm run dev
 npm run build
 npm start
 ```
+
+### Admin reload endpoint
+
+The oracle service can expose a secure admin endpoint when `ADMIN_API_PORT` is configured.
+Requests to `POST /reload-config` must include an `x-signature` header containing a hex HMAC-SHA256 over the raw request body using `ADMIN_HMAC_SECRET`.
+The payload may include `validatorConfig` updates and/or asset-specific `bounds` to tighten min/max price ranges.
+
+Example payload:
+
+```json
+{
+  "bounds": {
+    "XLM": { "minPrice": 0.1, "maxPrice": 1000000 }
+  }
+}
+```
+
+This endpoint is intended for emergency tightening of bounds without restarting the service.
 
 ### Testing
 

--- a/oracle/src/config.ts
+++ b/oracle/src/config.ts
@@ -13,14 +13,35 @@ export type { OracleServiceConfig } from './types/index.js';
 
 dotenv.config();
 
-/**
- * Environment variable validation schema
- */
+export interface AssetPriceBounds {
+    minPrice: number;
+    maxPrice: number;
+}
+
+const boundsSchema = z.record(
+    z.enum(['XLM', 'USDC', 'USDT', 'BTC', 'ETH']),
+    z.object({
+        minPrice: z.coerce.number().positive(),
+        maxPrice: z.coerce.number().positive(),
+    }),
+).refine(
+    (bounds) =>
+        Object.values(bounds).every(
+            (entry) => entry.maxPrice > entry.minPrice,
+        ),
+    {
+        message: 'Each asset bound must have maxPrice > minPrice',
+    },
+);
+
 const envSchema = z.object({
     STELLAR_NETWORK: z.enum(['testnet', 'mainnet']).default('testnet'),
     STELLAR_RPC_URL: z.string().url().default('https://soroban-testnet.stellar.org'),
     CONTRACT_ID: z.string().min(1, 'CONTRACT_ID is required'),
     ADMIN_SECRET_KEY: z.string().min(1, 'ADMIN_SECRET_KEY is required'),
+    ADMIN_API_PORT: z.coerce.number().int().nonnegative().default(0),
+    ADMIN_HMAC_SECRET: z.string().min(1).optional(),
+    PRICE_BOUNDS_JSON: z.string().optional(),
     COINGECKO_API_KEY: z.string().optional(),
     COINMARKETCAP_API_KEY: z.string().optional(),
     REDIS_URL: z.string().url().optional().or(z.literal('')),
@@ -46,6 +67,26 @@ function parseEnv() {
     }
 
     return result.data;
+}
+
+function parsePriceBounds(raw?: string) {
+    if (!raw) {
+        return {} as Partial<Record<SupportedAsset, AssetPriceBounds>>;
+    }
+
+    try {
+        const parsed = JSON.parse(raw);
+        const parsedResult = boundsSchema.safeParse(parsed);
+
+        if (!parsedResult.success) {
+            throw parsedResult.error;
+        }
+
+        return parsedResult.data;
+    } catch (error) {
+        console.error('❌ PRICE_BOUNDS_JSON validation failed:', error);
+        throw new Error('Invalid PRICE_BOUNDS_JSON configuration');
+    }
 }
 
 /**
@@ -129,6 +170,18 @@ export const ASSET_MAPPINGS: AssetMapping[] = [
     },
 ];
 
+export const DEFAULT_PRICE_BOUNDS: Record<SupportedAsset, AssetPriceBounds> = {
+    XLM: { minPrice: 0.00001, maxPrice: 1000000 },
+    USDC: { minPrice: 0.9, maxPrice: 1.1 },
+    USDT: { minPrice: 0.9, maxPrice: 1.1 },
+    BTC: { minPrice: 1000, maxPrice: 200000 },
+    ETH: { minPrice: 100, maxPrice: 20000 },
+};
+
+export function getPriceBounds(asset: string): AssetPriceBounds | undefined {
+    return DEFAULT_PRICE_BOUNDS[asset.toUpperCase() as SupportedAsset];
+}
+
 /**
  * Get asset mapping by symbol
  */
@@ -148,12 +201,18 @@ export function isSupportedAsset(symbol: string): symbol is SupportedAsset {
  */
 export function loadConfig(): OracleServiceConfig {
     const env = parseEnv();
+    const priceBounds = {
+        ...DEFAULT_PRICE_BOUNDS,
+        ...parsePriceBounds(env.PRICE_BOUNDS_JSON),
+    };
 
     return {
         stellarNetwork: env.STELLAR_NETWORK,
         stellarRpcUrl: env.STELLAR_RPC_URL,
         contractId: env.CONTRACT_ID,
         adminSecretKey: env.ADMIN_SECRET_KEY,
+        adminApiPort: env.ADMIN_API_PORT,
+        adminHmacSecret: env.ADMIN_HMAC_SECRET,
         updateIntervalMs: env.UPDATE_INTERVAL_MS,
         maxPriceDeviationPercent: env.MAX_PRICE_DEVIATION_PERCENT,
         priceStaleThresholdSeconds: env.PRICE_STALENESS_THRESHOLD_SECONDS,
@@ -161,6 +220,7 @@ export function loadConfig(): OracleServiceConfig {
         redisUrl: env.REDIS_URL,
         logLevel: env.LOG_LEVEL,
         providers: getProviderConfigs(env),
+        priceBounds,
     };
 }
 

--- a/oracle/src/index.ts
+++ b/oracle/src/index.ts
@@ -21,6 +21,7 @@ import {
     type PriceAggregator,
     type ContractUpdater,
 } from './services/index.js';
+import { AdminServer } from './services/admin-server.js';
 import type { ProviderConfig } from './types/index.js';
 
 /**
@@ -36,6 +37,7 @@ export class OracleService {
     private aggregator: PriceAggregator;
     private contractUpdater: ContractUpdater;
     private intervalId?: ReturnType<typeof setInterval>;
+    private adminServer?: AdminServer;
     private isRunning: boolean = false;
 
     constructor(config: OracleServiceConfig) {
@@ -54,10 +56,13 @@ export class OracleService {
 
 
         // Create services
-        const validator = createValidator({
-            maxDeviationPercent: config.maxPriceDeviationPercent,
-            maxStalenessSeconds: config.priceStaleThresholdSeconds,
-        });
+        const validator = createValidator(
+            {
+                maxDeviationPercent: config.maxPriceDeviationPercent,
+                maxStalenessSeconds: config.priceStaleThresholdSeconds,
+            },
+            config.priceBounds,
+        );
 
         const cache = createPriceCache(config.cacheTtlSeconds);
 
@@ -71,6 +76,18 @@ export class OracleService {
             maxRetries: 3,
             retryDelayMs: 1000,
         });
+
+        if (config.adminApiPort > 0) {
+            if (!config.adminHmacSecret) {
+                throw new Error('ADMIN_HMAC_SECRET is required when ADMIN_API_PORT is configured');
+            }
+
+            this.adminServer = new AdminServer({
+                port: config.adminApiPort,
+                hmacSecret: config.adminHmacSecret,
+                validator,
+            });
+        }
 
         logger.info('Oracle service initialized', {
             network: config.stellarNetwork,
@@ -103,12 +120,16 @@ export class OracleService {
         logger.info('Oracle service started', {
             intervalMs: this.config.updateIntervalMs,
         });
+
+        if (this.adminServer) {
+            await this.adminServer.start();
+        }
     }
 
     /**
      * Stop the oracle service
      */
-    stop(): void {
+    async stop(): Promise<void> {
         if (!this.isRunning) {
             logger.warn('Oracle service is not running');
             return;
@@ -117,6 +138,10 @@ export class OracleService {
         if (this.intervalId) {
             clearInterval(this.intervalId);
             this.intervalId = undefined;
+        }
+
+        if (this.adminServer) {
+            await this.adminServer.stop();
         }
 
         this.isRunning = false;

--- a/oracle/src/services/admin-server.ts
+++ b/oracle/src/services/admin-server.ts
@@ -1,0 +1,199 @@
+/**
+ * Admin HTTP server for oracle runtime operations.
+ */
+
+import http from 'node:http';
+import crypto from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { PriceValidator, ValidatorConfig } from './price-validator.js';
+import { logger } from '../utils/logger.js';
+import { isSupportedAsset } from '../config.js';
+
+export interface AdminServerOptions {
+    port: number;
+    hmacSecret: string;
+    validator: PriceValidator;
+}
+
+export class AdminServer {
+    private server?: http.Server;
+    private readonly port: number;
+    private readonly hmacSecret: string;
+    private readonly validator: PriceValidator;
+
+    constructor(options: AdminServerOptions) {
+        this.port = options.port;
+        this.hmacSecret = options.hmacSecret;
+        this.validator = options.validator;
+    }
+
+    start(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.server = http.createServer(this.requestHandler.bind(this));
+
+            this.server.once('error', reject);
+            this.server.listen(this.port, () => {
+                logger.info('Admin server listening', { port: this.port });
+                resolve();
+            });
+        });
+    }
+
+    stop(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            if (!this.server) {
+                resolve();
+                return;
+            }
+
+            this.server.close((error) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    logger.info('Admin server stopped');
+                    resolve();
+                }
+            });
+        });
+    }
+
+    private async requestHandler(req: IncomingMessage, res: ServerResponse) {
+        const { url, method, headers } = req;
+
+        if (url !== '/reload-config' || method !== 'POST') {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Not found' }));
+            return;
+        }
+
+        const signature = headers['x-signature'];
+        if (!signature || Array.isArray(signature)) {
+            this.sendResponse(res, 401, { error: 'Missing signature header' });
+            return;
+        }
+
+        const rawBody = await this.readBody(req);
+        if (!rawBody) {
+            this.sendResponse(res, 400, { error: 'Empty request body' });
+            return;
+        }
+
+        if (!this.verifySignature(rawBody, signature)) {
+            this.sendResponse(res, 403, { error: 'Invalid signature' });
+            return;
+        }
+
+        let payload: unknown;
+        try {
+            payload = JSON.parse(rawBody.toString('utf8'));
+        } catch (error) {
+            this.sendResponse(res, 400, { error: 'Invalid JSON body' });
+            return;
+        }
+
+        if (typeof payload !== 'object' || payload === null) {
+            this.sendResponse(res, 400, { error: 'Payload must be an object' });
+            return;
+        }
+
+        const body = payload as {
+            validatorConfig?: Partial<ValidatorConfig>;
+            bounds?: Record<string, { minPrice: number; maxPrice: number }>;
+        };
+
+        if (!body.validatorConfig && !body.bounds) {
+            this.sendResponse(res, 400, {
+                error: 'Payload must include validatorConfig or bounds',
+            });
+            return;
+        }
+
+        const bounds = this.normalizeBounds(body.bounds ?? {});
+        if (body.bounds && bounds instanceof Error) {
+            this.sendResponse(res, 400, { error: bounds.message });
+            return;
+        }
+
+        try {
+            this.validator.reloadConfig(body.validatorConfig ?? {}, bounds as Record<string, { minPrice: number; maxPrice: number }>);
+            this.sendResponse(res, 200, {
+                status: 'ok',
+                updatedBounds: Object.keys(bounds as Record<string, { minPrice: number; maxPrice: number }>),
+            });
+        } catch (error) {
+            logger.error('Failed to reload validator config', { error });
+            this.sendResponse(res, 500, { error: 'Unable to reload config' });
+        }
+    }
+
+    private readBody(req: IncomingMessage): Promise<Buffer> {
+        return new Promise((resolve, reject) => {
+            const chunks: Buffer[] = [];
+
+            req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+            req.on('end', () => resolve(Buffer.concat(chunks)));
+            req.on('error', reject);
+        });
+    }
+
+    private verifySignature(body: Buffer, signature: string): boolean {
+        try {
+            const expected = crypto
+                .createHmac('sha256', this.hmacSecret)
+                .update(body)
+                .digest('hex');
+
+            const signatureBuffer = Buffer.from(signature, 'utf8');
+            const expectedBuffer = Buffer.from(expected, 'utf8');
+
+            if (signatureBuffer.length !== expectedBuffer.length) {
+                return false;
+            }
+
+            return crypto.timingSafeEqual(signatureBuffer, expectedBuffer);
+        } catch (error) {
+            logger.error('Signature verification failed', { error });
+            return false;
+        }
+    }
+
+    private normalizeBounds(
+        bounds: Record<string, { minPrice: number; maxPrice: number }>,
+    ): Record<string, { minPrice: number; maxPrice: number }> | Error {
+        const normalized: Record<string, { minPrice: number; maxPrice: number }> = {};
+
+        for (const [asset, range] of Object.entries(bounds)) {
+            const upperAsset = asset.toUpperCase();
+            if (!isSupportedAsset(upperAsset)) {
+                return new Error(`Unsupported asset in bounds: ${asset}`);
+            }
+
+            if (
+                typeof range.minPrice !== 'number' ||
+                typeof range.maxPrice !== 'number' ||
+                Number.isNaN(range.minPrice) ||
+                Number.isNaN(range.maxPrice)
+            ) {
+                return new Error('Bounds must contain numeric minPrice and maxPrice values');
+            }
+
+            if (range.maxPrice <= range.minPrice) {
+                return new Error(
+                    `Invalid bounds for ${upperAsset}: maxPrice must be greater than minPrice`,
+                );
+            }
+
+            normalized[upperAsset] = {
+                minPrice: range.minPrice,
+                maxPrice: range.maxPrice,
+            };
+        }
+
+        return normalized;
+    }
+
+    private sendResponse(res: ServerResponse, statusCode: number, body: unknown) {
+        res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(body));
+    }
+}

--- a/oracle/src/services/price-validator.ts
+++ b/oracle/src/services/price-validator.ts
@@ -11,6 +11,7 @@ import type {
     ValidationResult,
     ValidationError,
     ValidationErrorCode,
+    AssetPriceBounds,
 } from '../types/index.js';
 import { scalePrice } from '../config.js';
 import { logger } from '../utils/logger.js';
@@ -41,13 +42,19 @@ const DEFAULT_CONFIG: ValidatorConfig = {
 export class PriceValidator {
     private config: ValidatorConfig;
     private cachedPrices: Map<string, number> = new Map();
+    private assetBounds: Record<string, AssetPriceBounds>;
 
-    constructor(config: Partial<ValidatorConfig> = {}) {
+    constructor(
+        config: Partial<ValidatorConfig> = {},
+        assetBounds: Record<string, AssetPriceBounds> = {},
+    ) {
         this.config = { ...DEFAULT_CONFIG, ...config };
+        this.assetBounds = this.normalizeBounds(assetBounds);
 
         logger.info('Price validator initialized', {
             maxDeviationPercent: this.config.maxDeviationPercent,
             maxStalenessSeconds: this.config.maxStalenessSeconds,
+            assetBounds: Object.keys(this.assetBounds).length,
         });
     }
 
@@ -89,7 +96,32 @@ export class PriceValidator {
             });
         }
 
-        const cachedPrice = this.cachedPrices.get(raw.asset);
+        const asset = raw.asset.toUpperCase();
+        const bounds = this.getBounds(asset);
+
+        if (raw.price < bounds.minPrice) {
+            errors.push({
+                code: 'PRICE_BELOW_MIN' as ValidationErrorCode,
+                message: `Price ${raw.price} below minimum ${bounds.minPrice} for ${asset}`,
+                details: {
+                    asset,
+                    minPrice: bounds.minPrice,
+                },
+            });
+        }
+
+        if (raw.price > bounds.maxPrice) {
+            errors.push({
+                code: 'PRICE_ABOVE_MAX' as ValidationErrorCode,
+                message: `Price ${raw.price} exceeds maximum ${bounds.maxPrice} for ${asset}`,
+                details: {
+                    asset,
+                    maxPrice: bounds.maxPrice,
+                },
+            });
+        }
+
+        const cachedPrice = this.cachedPrices.get(asset);
         if (cachedPrice !== undefined) {
             const deviation = Math.abs((raw.price - cachedPrice) / cachedPrice) * 100;
 
@@ -108,14 +140,14 @@ export class PriceValidator {
 
         if (errors.length === 0) {
             const validatedPrice: PriceData = {
-                asset: raw.asset.toUpperCase(),
+                asset,
                 price: scalePrice(raw.price),
                 timestamp: raw.timestamp,
                 source: raw.source,
                 confidence: this.calculateConfidence(raw, cachedPrice),
             };
 
-            this.cachedPrices.set(raw.asset, raw.price);
+            this.cachedPrices.set(asset, raw.price);
 
             return {
                 isValid: true,
@@ -178,6 +210,26 @@ export class PriceValidator {
     }
 
     /**
+     * Reload validator settings and optional bounds at runtime
+     */
+    reloadConfig(
+        config: Partial<ValidatorConfig> = {},
+        assetBounds?: Record<string, AssetPriceBounds>,
+    ): void {
+        this.config = { ...this.config, ...config };
+
+        if (assetBounds) {
+            this.assetBounds = this.normalizeBounds(assetBounds);
+        }
+
+        logger.info('Price validator configuration reloaded', {
+            maxDeviationPercent: this.config.maxDeviationPercent,
+            maxStalenessSeconds: this.config.maxStalenessSeconds,
+            boundsUpdated: assetBounds ? Object.keys(assetBounds).length : 0,
+        });
+    }
+
+    /**
      * Clear cached price for an asset
      */
     clearCache(asset?: string): void {
@@ -194,11 +246,35 @@ export class PriceValidator {
     getCacheState(): Record<string, number> {
         return Object.fromEntries(this.cachedPrices);
     }
+
+    private getBounds(asset: string): AssetPriceBounds {
+        return this.assetBounds[asset] ?? {
+            minPrice: this.config.minPrice,
+            maxPrice: this.config.maxPrice,
+        };
+    }
+
+    private normalizeBounds(
+        bounds: Record<string, AssetPriceBounds>,
+    ): Record<string, AssetPriceBounds> {
+        return Object.fromEntries(
+            Object.entries(bounds).map(([asset, value]) => [
+                asset.toUpperCase(),
+                {
+                    minPrice: value.minPrice,
+                    maxPrice: value.maxPrice,
+                },
+            ]),
+        );
+    }
 }
 
 /**
  * Create a validator with custom configuration
  */
-export function createValidator(config?: Partial<ValidatorConfig>): PriceValidator {
-    return new PriceValidator(config);
+export function createValidator(
+    config?: Partial<ValidatorConfig>,
+    assetBounds: Record<string, AssetPriceBounds> = {},
+): PriceValidator {
+    return new PriceValidator(config, assetBounds);
 }

--- a/oracle/src/types/index.ts
+++ b/oracle/src/types/index.ts
@@ -63,6 +63,8 @@ export enum ValidationErrorCode {
     PRICE_NEGATIVE = 'PRICE_NEGATIVE',
     PRICE_STALE = 'PRICE_STALE',
     PRICE_DEVIATION_TOO_HIGH = 'PRICE_DEVIATION_TOO_HIGH',
+    PRICE_BELOW_MIN = 'PRICE_BELOW_MIN',
+    PRICE_ABOVE_MAX = 'PRICE_ABOVE_MAX',
     INVALID_ASSET = 'INVALID_ASSET',
     SOURCE_UNAVAILABLE = 'SOURCE_UNAVAILABLE',
 }
@@ -107,11 +109,18 @@ export interface ContractUpdateResult {
 /**
  * Service configuration
  */
+export interface AssetPriceBounds {
+    minPrice: number;
+    maxPrice: number;
+}
+
 export interface OracleServiceConfig {
     stellarNetwork: 'testnet' | 'mainnet';
     stellarRpcUrl: string;
     contractId: string;
     adminSecretKey: string;
+    adminApiPort: number;
+    adminHmacSecret?: string;
     updateIntervalMs: number;
     maxPriceDeviationPercent: number;
     priceStaleThresholdSeconds: number;
@@ -119,6 +128,7 @@ export interface OracleServiceConfig {
     redisUrl?: string;
     logLevel: 'debug' | 'info' | 'warn' | 'error';
     providers: ProviderConfig[];
+    priceBounds: Record<SupportedAsset, AssetPriceBounds>;
 }
 
 /**

--- a/oracle/tests/price-validator.test.ts
+++ b/oracle/tests/price-validator.test.ts
@@ -4,18 +4,22 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { PriceValidator, createValidator } from '../src/services/price-validator.js';
+import { DEFAULT_PRICE_BOUNDS } from '../src/config.js';
 import type { RawPriceData } from '../src/types/index.js';
 
 describe('PriceValidator', () => {
     let validator: PriceValidator;
 
     beforeEach(() => {
-        validator = createValidator({
-            maxDeviationPercent: 10,
-            maxStalenessSeconds: 300,
-            minPrice: 0.0001,
-            maxPrice: 1000000,
-        });
+        validator = createValidator(
+            {
+                maxDeviationPercent: 10,
+                maxStalenessSeconds: 300,
+                minPrice: 0.0001,
+                maxPrice: 1000000,
+            },
+            DEFAULT_PRICE_BOUNDS,
+        );
     });
 
     describe('validate', () => {
@@ -146,6 +150,38 @@ describe('PriceValidator', () => {
             const result = validator.validate(rawPrice);
 
             expect(result.isValid).toBe(false);
+        });
+
+        it('should reject price outside asset-specific bounds', () => {
+            const rawPrice: RawPriceData = {
+                asset: 'BTC',
+                price: 500,
+                timestamp: Math.floor(Date.now() / 1000),
+                source: 'coingecko',
+            };
+
+            const result = validator.validate(rawPrice);
+
+            expect(result.isValid).toBe(false);
+            expect(result.errors.some((e) => e.code === 'PRICE_BELOW_MIN')).toBe(true);
+        });
+
+        it('should reload bounds and enforce tighter limits', () => {
+            validator.reloadConfig({}, {
+                XLM: { minPrice: 0.2, maxPrice: 1_000_000 },
+            });
+
+            const rawPrice: RawPriceData = {
+                asset: 'XLM',
+                price: 0.15,
+                timestamp: Math.floor(Date.now() / 1000),
+                source: 'coingecko',
+            };
+
+            const result = validator.validate(rawPrice);
+
+            expect(result.isValid).toBe(false);
+            expect(result.errors.some((e) => e.code === 'PRICE_BELOW_MIN')).toBe(true);
         });
     });
 


### PR DESCRIPTION
closes #871 


Summary
Add per-asset oracle price bounds and enforce them in price-validator.ts
Add secure admin reload endpoint POST /reload-config with HMAC protection for runtime bounds/config updates
Update README.md and add regression coverage for bound enforcement and reload behavior
Type of change
 Bug fix
 New feature / functionality
 Refactor (no functional change)
 Documentation only
 Contract storage / upgrade change
Contracts Release Checklist
Functional tests
 New public functions have success-path and failure-path tests
 All new error codes are reachable through a test
 Zero/negative/boundary values tested for numeric inputs
 cargo test passes — no new failures beyond the known baseline
Verified npx vitest run tests/price-validator.test.ts --reporter=verbose

Invariants
 Cross-asset view guarantees G-1..G-10 hold (if cross_asset touched)
N/A, feature is oracle/admin-service related

 Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
N/A

 Interest ceiling division unchanged (interest ≥ 1 for any principal > 0 && elapsed > 0)
N/A

Upgrade safety (skip if no storage / signature changes)
 No storage key renamed or removed without a migration path
 New persistent entries documented in storage.md
N/A, no contract storage changes

 initialize still idempotent (second call → AlreadyInitialized)
N/A

Monitoring / events (skip if no event changes)
 New operations emit an event with topic + data
N/A

 No existing topic string renamed silently
N/A

Security notes
Auth / access control

 require_auth() called for every entry point that modifies user state
N/A for off-chain oracle service

 No new function bypasses the pause guard without justification
N/A for off-chain oracle service

Arithmetic

 No unchecked arithmetic on untrusted values
 No new division site can produce divide-by-zero
Reentrancy

 State updated before external call (Checks-Effects-Interactions)
N/A for off-chain oracle service

Rounding

 Floor for collateral capacity; ceiling for interest owed
N/A

Docs
 Public functions have a doc comment (error codes, params, return)
 Relevant docs sections updated (README.md)
CI
 cargo fmt --check passes
N/A for oracle package

 cargo clippy -- -D warnings passes
N/A for oracle package

 No secrets or key material committed
Raptor mini (Preview) • 0.4 credits