### PR TITLE
feat: HMAC-authenticate api indexer hook routes

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -14,6 +14,7 @@ CONTRACT_ID=
 # Authentication
 JWT_SECRET=your-secret-key-change-in-production
 JWT_EXPIRES_IN=24h
+STELLAR_API_HOOK_SECRET=your-hook-secret-change-in-production
 
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=900000

--- a/api/README.md
+++ b/api/README.md
@@ -31,6 +31,7 @@ HORIZON_URL=https://horizon-testnet.stellar.org
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 CONTRACT_ID=<your_deployed_contract_id>
 JWT_SECRET=<your_secret_key>
+STELLAR_API_HOOK_SECRET=<your_hook_secret>
 ```
 
 Circuit breaker tuning (optional, environment variables):
@@ -133,6 +134,28 @@ npm test -- --coverage  # With coverage report
 ```
 
 Test coverage: 95%+ (branches, functions, lines, statements)
+
+## Indexer write hook authentication
+
+The API now protects internal indexer write hooks using HMAC-SHA256 and a shared secret. Every request to `/api/lending/hooks/*` must include the following headers:
+
+- `X-Hook-Timestamp`: the request timestamp in milliseconds since epoch
+- `X-Hook-Signature`: hex-encoded HMAC-SHA256 over the string `timestamp + '.' + requestBody`
+
+The middleware rejects requests when:
+
+- the hook secret is not configured
+- either header is missing or malformed
+- the timestamp is outside a 5-minute window
+- the signature does not match the computed HMAC
+
+### Secret rotation
+
+1. Generate a new strong secret and set it as `STELLAR_API_HOOK_SECRET` in the API deployment.
+2. Update the hook sender(s) to sign requests with the new secret.
+3. Deploy the sender and API together or with an overlap window.
+4. Validate that hook requests are accepted and monitor for authentication failures.
+5. Remove the previous secret from all systems once the new secret is active.
 
 ## Production Build
 

--- a/api/src/__tests__/hookAuth.test.ts
+++ b/api/src/__tests__/hookAuth.test.ts
@@ -1,0 +1,68 @@
+import crypto from 'crypto';
+import request from 'supertest';
+
+let app: any;
+
+const HOOK_SECRET = 'test-hook-secret-rotation-ready';
+
+beforeAll(() => {
+  process.env.STELLAR_API_HOOK_SECRET = HOOK_SECRET;
+  jest.resetModules();
+  app = require('../app').default;
+});
+
+describe('Hook HMAC middleware', () => {
+  const hookPath = '/api/lending/hooks/indexer';
+  const payload = { event: 'indexer.write', data: { id: 'abc123' } };
+  const rawBody = JSON.stringify(payload);
+
+  const sign = (timestamp: string, body: string) =>
+    crypto
+      .createHmac('sha256', HOOK_SECRET)
+      .update(`${timestamp}.${body}`)
+      .digest('hex');
+
+  it('accepts valid hook requests with matching signature and timestamp', async () => {
+    const timestamp = Date.now().toString();
+    const response = await request(app)
+      .post(hookPath)
+      .set('X-Hook-Timestamp', timestamp)
+      .set('X-Hook-Signature', sign(timestamp, rawBody))
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true, message: 'Hook authenticated' });
+  });
+
+  it('rejects hook requests with missing headers', async () => {
+    const response = await request(app).post(hookPath).send(payload);
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/signature and timestamp/i);
+  });
+
+  it('rejects hook requests with invalid signature', async () => {
+    const timestamp = Date.now().toString();
+    const response = await request(app)
+      .post(hookPath)
+      .set('X-Hook-Timestamp', timestamp)
+      .set('X-Hook-Signature', 'invalidsignature')
+      .send(payload);
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toMatch(/invalid hook signature/i);
+  });
+
+  it('rejects hook requests outside the 5-minute timestamp window', async () => {
+    const timestamp = (Date.now() - 10 * 60 * 1000).toString();
+    const response = await request(app)
+      .post(hookPath)
+      .set('X-Hook-Timestamp', timestamp)
+      .set('X-Hook-Signature', sign(timestamp, rawBody))
+      .send(payload);
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toMatch(/timestamp outside allowable window/i);
+  });
+});

--- a/api/src/__tests__/validation.test.ts
+++ b/api/src/__tests__/validation.test.ts
@@ -81,3 +81,44 @@ describe('Validation Middleware', () => {
     });
   });
 });
+
+describe('Hook HMAC Validation', () => {
+  const mockReq = {
+    headers: {},
+    body: {},
+    rawBody: '{}',
+  } as any;
+  const mockRes = {} as any;
+  const next = jest.fn();
+
+  beforeEach(() => {
+    process.env.STELLAR_API_HOOK_SECRET = 'validation-hook-secret';
+  });
+
+  it('rejects missing hook headers', () => {
+    jest.isolateModules(() => {
+      const { verifyHookHmac } = require('../middleware/auth');
+      expect(() => verifyHookHmac(mockReq, mockRes, next)).toThrow(
+        'Hook signature and timestamp headers are required'
+      );
+    });
+  });
+
+  it('rejects invalid hook timestamp', () => {
+    jest.isolateModules(() => {
+      const { verifyHookHmac } = require('../middleware/auth');
+      const req = {
+        headers: {
+          'x-hook-timestamp': 'not-a-number',
+          'x-hook-signature': 'abcd',
+        },
+        body: {},
+        rawBody: '{}',
+      } as any;
+
+      expect(() => verifyHookHmac(req, mockRes, next)).toThrow(
+        'Invalid hook timestamp'
+      );
+    });
+  });
+});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -12,7 +12,11 @@ const app: Application = express();
 
 app.use(helmet());
 app.use(cors());
-app.use(express.json());
+app.use(express.json({
+  verify: (req, res, buf) => {
+    (req as any).rawBody = buf.toString('utf8');
+  },
+}));
 app.use(express.urlencoded({ extended: true }));
 
 const limiter = rateLimit({

--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -17,6 +17,7 @@ export const config = {
   auth: {
     jwtSecret: process.env.JWT_SECRET || 'default-secret-change-me',
     jwtExpiresIn: process.env.JWT_EXPIRES_IN || '24h',
+    hookSecret: process.env.STELLAR_API_HOOK_SECRET || '',
   },
   rateLimit: {
     windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || '900000', 10),

--- a/api/src/controllers/lending.controller.ts
+++ b/api/src/controllers/lending.controller.ts
@@ -109,6 +109,14 @@ export const withdraw = async (req: Request, res: Response, next: NextFunction) 
   }
 };
 
+export const processHook = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    return res.status(200).json({ success: true, message: 'Hook authenticated' });
+  } catch (error) {
+    next(error);
+  }
+};
+
 export const healthCheck = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const services = await stellarService.healthCheck();

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { config } from '../config';
@@ -7,7 +8,12 @@ export interface AuthRequest extends Request {
   user?: {
     address: string;
   };
+  rawBody?: string;
 }
+
+const HOOK_SIGNATURE_HEADER = 'x-hook-signature';
+const HOOK_TIMESTAMP_HEADER = 'x-hook-timestamp';
+const HOOK_WINDOW_MS = 5 * 60 * 1000;
 
 export const authenticateToken = (
   req: AuthRequest,
@@ -34,4 +40,56 @@ export const generateToken = (address: string): string => {
   return jwt.sign({ address }, config.auth.jwtSecret, {
     expiresIn: config.auth.jwtExpiresIn,
   } as jwt.SignOptions);
+};
+
+export const verifyHookHmac = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  const signatureHeader = req.headers[HOOK_SIGNATURE_HEADER];
+  const timestampHeader = req.headers[HOOK_TIMESTAMP_HEADER];
+  const signature = Array.isArray(signatureHeader)
+    ? signatureHeader[0]
+    : signatureHeader;
+  const timestampValue = Array.isArray(timestampHeader)
+    ? timestampHeader[0]
+    : timestampHeader;
+
+  if (!config.auth.hookSecret) {
+    throw new UnauthorizedError('Hook authentication secret is not configured');
+  }
+
+  if (!signature || !timestampValue) {
+    throw new UnauthorizedError('Hook signature and timestamp headers are required');
+  }
+
+  const timestamp = Number(timestampValue);
+
+  if (!Number.isFinite(timestamp)) {
+    throw new UnauthorizedError('Invalid hook timestamp');
+  }
+
+  if (Math.abs(Date.now() - timestamp) > HOOK_WINDOW_MS) {
+    throw new UnauthorizedError('Hook timestamp outside allowable window');
+  }
+
+  const rawBody = req.rawBody ?? JSON.stringify(req.body ?? {});
+  const payload = `${timestampValue}.${rawBody}`;
+  const expectedSignature = crypto
+    .createHmac('sha256', config.auth.hookSecret)
+    .update(payload)
+    .digest('hex');
+
+  const signatureBuffer = Buffer.from(signature, 'hex');
+  const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+
+  if (
+    signatureBuffer.length !== expectedBuffer.length ||
+    !crypto.timingSafeEqual(signatureBuffer, expectedBuffer)
+  ) {
+    throw new UnauthorizedError('Invalid hook signature');
+  }
+
+  next();
 };

--- a/api/src/routes/lending.routes.ts
+++ b/api/src/routes/lending.routes.ts
@@ -6,8 +6,13 @@ import {
   repayValidation,
   withdrawValidation,
 } from '../middleware/validation';
+import { verifyHookHmac } from '../middleware/auth';
 
 const router = Router();
+
+router.use('/hooks', verifyHookHmac);
+router.post('/hooks', lendingController.processHook);
+router.post('/hooks/*', lendingController.processHook);
 
 router.post('/deposit', depositValidation, lendingController.deposit);
 router.post('/borrow', borrowValidation, lendingController.borrow);


### PR DESCRIPTION
Closes #890 

## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
