### PR TITLE
fix: require auth on hello-world set_admin and block silent overwrite

### DIFF
--- a/stellar-lend/contracts/hello-world/INITIALIZATION_SECURITY_NOTES.md
+++ b/stellar-lend/contracts/hello-world/INITIALIZATION_SECURITY_NOTES.md
@@ -16,6 +16,7 @@ This document outlines the security assumptions, trust boundaries, and critical 
 - **Implementation**: Centralized admin module with role-based access control
 - **Risk**: Unauthorized access to privileged operations
 - **Mitigation**: Require admin authentication for all privileged functions
+- **Note**: `set_admin` bootstraps the first admin once, but any subsequent admin rotation must be authorized by the current admin to prevent silent takeover.
 
 ### 3. Storage Persistence and Isolation
 - **Requirement**: Initialization data must persist across ledger advancements

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -14,9 +14,16 @@ pub struct HelloContract;
 
 #[contractimpl]
 impl HelloContract {
-    /// Set the admin (one-time).
+    /// Set or rotate the admin.
+    ///
+    /// - If no admin exists yet, this bootstraps the contract.
+    /// - If an admin already exists, the current admin must authorize the change.
     pub fn set_admin(env: Env, admin: Address) {
-        env.storage().instance().set(&"admin", &admin);
+        let storage = env.storage().instance();
+        if let Some(current_admin) = storage.get::<_, Address>(&"admin") {
+            current_admin.require_auth();
+        }
+        storage.set(&"admin", &admin);
     }
 
     /// Get the admin (panics if not set).
@@ -89,7 +96,7 @@ impl HelloContract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
     use soroban_sdk::Symbol;
 
     fn setup() -> (Env, HelloContractClient<'static>, Address, Address) {
@@ -147,5 +154,41 @@ mod test {
         let s = client.get_state(&user);
         assert_eq!(s.balance, 500);
         assert_eq!(s.debt, 100);
+    }
+
+    #[test]
+    fn test_set_admin_requires_current_admin_auth_for_rotation() {
+        let env = Env::default();
+        let id = env.register(HelloContract, ());
+        let client = HelloContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        client.set_admin(&admin);
+
+        let new_admin = Address::generate(&env);
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &id,
+                fn_name: "set_admin",
+                args: (new_admin.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        client.set_admin(&new_admin);
+        assert_eq!(client.get_admin(), new_admin);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_admin_rejects_unauthorized_rotation() {
+        let env = Env::default();
+        let id = env.register(HelloContract, ());
+        let client = HelloContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        client.set_admin(&admin);
+
+        let attacker = Address::generate(&env);
+        client.set_admin(&attacker);
     }
 }


### PR DESCRIPTION
#closes #866

```markdown
## Fix: Require admin auth on hello-world set_admin and block silent overwrite

### Issue
#866 – `set_admin` in `stellar-lend/contracts/hello-world/src/lib.rs` was vulnerable to silent takeover.

**Problem:**
- `set_admin` had no `require_auth()` call and no "already set" check
- Any caller could overwrite the admin on a deployed instance
- Doc comment claimed "one-time" but code did not enforce it

### Solution
Updated `set_admin` to:
1. **Bootstrap phase**: Accept the first admin without auth (no admin set yet)
2. **Rotation phase**: Require `current_admin.require_auth()` for any subsequent change

### Changes
- `stellar-lend/contracts/hello-world/src/lib.rs`
  - Added conditional auth check: `if let Some(current_admin) = storage.get(...) { current_admin.require_auth(); }`
  - Updated doc comment to clarify bootstrap vs rotation semantics
  - Added two new tests for authorization boundary

- `stellar-lend/contracts/hello-world/INITIALIZATION_SECURITY_NOTES.md`
  - Documented the auth boundary in Admin Authority Establishment section

### Tests Added
- `test_set_admin_requires_current_admin_auth_for_rotation`: Validates that authorized admin can rotate to new admin
- `test_set_admin_rejects_unauthorized_rotation`: Validates that unauthorized caller is rejected with panic

### Security Notes
- Prevents any caller from silently overwriting the admin after initialization
- Bootstrap remains permissionless (first admin set succeeds without auth)
- Aligns with Soroban best practices for privileged operations
- Cross-referenced in `INITIALIZATION_SECURITY_NOTES.md` as documented security boundary

### Testing
Run tests locally:
```bash
cd stellar-lend/contracts/hello-world
cargo test
```

Expected: All tests pass, including the two new authorization tests.

### References
- INITIALIZATION_SECURITY_NOTES.md
- Authorization Primitives
#closes 