### PR TITLE
Feature/workspace dependency pinning

### DIFF
--- a/stellar-lend/Cargo.lock
+++ b/stellar-lend/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -142,7 +142,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.10.7",
+ "digest",
  "num-bigint",
 ]
 
@@ -192,15 +192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,32 +214,11 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bridge"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bincode",
- "ed25519-dalek 1.0.1",
- "hex",
- "rand 0.7.3",
- "serde",
 ]
 
 [[package]]
@@ -395,19 +365,6 @@ checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
@@ -415,7 +372,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -552,20 +509,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -605,19 +553,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature 1.6.4",
+ "signature",
 ]
 
 [[package]]
@@ -627,21 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "ed25519 1.5.3",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "zeroize",
+ "signature",
 ]
 
 [[package]]
@@ -650,11 +575,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
+ "curve25519-dalek",
+ "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -673,7 +598,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -788,17 +713,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -806,7 +720,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -929,7 +843,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1033,7 +947,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1144,12 +1058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,7 +1066,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1274,19 +1182,6 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -1304,16 +1199,6 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1338,15 +1223,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -1361,15 +1237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1589,26 +1456,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1617,7 +1471,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -1629,17 +1483,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -1707,9 +1555,9 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "ecdsa",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
  "getrandom 0.2.17",
@@ -1723,7 +1571,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "sec1",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
@@ -1773,7 +1621,7 @@ dependencies = [
  "crate-git-revision",
  "ctor",
  "derive_arbitrary",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "rand 0.8.6",
  "rustc_version",
  "serde",
@@ -1798,7 +1646,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
@@ -1813,7 +1661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa02e07f507cc27406ae0834db4dcf309b78c4cc8776eb3b2d662d66e8859d25"
 dependencies = [
  "base64",
- "sha2 0.10.9",
+ "sha2",
  "stellar-xdr",
  "thiserror",
  "wasmparser 0.116.1",
@@ -1828,7 +1676,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "soroban-spec",
  "stellar-xdr",
  "syn 2.0.117",
@@ -1877,6 +1725,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stellar-lend-common"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "stellar-strkey"
 version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,7 +1767,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "stellar-strkey 0.0.13",
 ]
 
@@ -1921,6 +1776,14 @@ name = "stellarlend-lending"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "soroban-sdk",
+ "stellar-lend-common",
+]
+
+[[package]]
+name = "stellarlend-multisig"
+version = "0.1.0"
+dependencies = [
  "soroban-sdk",
 ]
 
@@ -2086,12 +1949,6 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/stellar-lend/Cargo.toml
+++ b/stellar-lend/Cargo.toml
@@ -8,8 +8,10 @@ members = [
 ]
 
 [workspace.dependencies]
+# Keep shared Soroban and test dependency versions pinned in one place.
 soroban-sdk = "=25.3.0"
-soroban-token-sdk = { version = "=25.3.0" }
+soroban-token-sdk = "=25.3.0"
+proptest = "1.5"
 
 [profile.release]
 opt-level = "z"

--- a/stellar-lend/contracts/ARCHITECTURE.md
+++ b/stellar-lend/contracts/ARCHITECTURE.md
@@ -94,7 +94,7 @@ implementation errors and revert on violation.
 
 ### `hello-world`
 
-`hello-world` combines lending, AMM, bridge, governance, analytics, and monitoring concerns in one crate. Because it is outside the active workspace and duplicates functionality now split across maintained crates, it should be treated as historical/reference code rather than the deployment artifact.
+`hello-world` combines lending, AMM, bridge, governance, analytics, and monitoring concerns in one crate. Because it remains in the active workspace only for compatibility and duplicates functionality now split across maintained crates, it should be treated as historical/reference code rather than the deployment artifact.
 
 ## Trust Boundaries
 

--- a/stellar-lend/contracts/ARCHITECTURE.md
+++ b/stellar-lend/contracts/ARCHITECTURE.md
@@ -8,7 +8,7 @@ This note documents the contract boundaries under `stellar-lend/contracts/` and 
 
 `contracts/amm` is a separate optional deployment for AMM integration. It is not the source of truth for lending positions.
 
-`contracts/hello-world` is legacy and not canonical for deployment. It is not included in the active workspace at `stellar-lend/Cargo.toml`, while `contracts/lending`, `contracts/amm`, `contracts/bridge`, and `contracts/common` are.
+`contracts/hello-world` is legacy and not canonical for deployment. It remains in the active workspace at `stellar-lend/Cargo.toml` only so it compiles against the same shared Soroban SDK pin as the maintained contracts.
 
 ## Boundary Map
 
@@ -19,6 +19,39 @@ This note documents the contract boundaries under `stellar-lend/contracts/` and 
 | `hello-world` | Older all-in-one prototype with overlapping responsibilities | No |
 | `bridge` | Bridge-specific contract | Separate concern |
 | `common` | Shared library code | Library only |
+
+## Workspace Dependency Pinning
+
+The active Rust workspace is defined in `stellar-lend/Cargo.toml`. Soroban SDK
+and other shared Rust dependencies must be pinned once under
+`[workspace.dependencies]` and inherited by member crates with
+`{ workspace = true }`.
+
+Current workspace members:
+
+- `contracts/common`
+- `contracts/hello-world`
+- `contracts/lending`
+- `contracts/multisig`
+
+Policy:
+
+- do not pin `soroban-sdk` independently inside member crates
+- do not introduce a second Soroban SDK version through direct crate-level version specs
+- keep shared test dependencies, such as `proptest`, in the workspace dependency table when more than one member uses them
+- treat `contracts/hello-world` as a compatibility consumer of the shared pin, not as the canonical deployment artifact
+
+### Soroban SDK Version Bump Procedure
+
+When upgrading Soroban-related dependencies:
+
+1. Update the pinned versions in `stellar-lend/Cargo.toml` under `[workspace.dependencies]`.
+2. Keep member crates on `workspace = true` instead of adding crate-local versions.
+3. Refresh `Cargo.lock` from the workspace root and verify only the intended Soroban versions remain selected.
+4. Run `cargo build --workspace` and `cargo test --workspace` from `stellar-lend/` before merging.
+
+This keeps `Env`, `Address`, test utilities, and generated host types aligned
+across all workspace members and makes upgrade review a single-file audit.
 
 ## Ownership Boundaries
 

--- a/stellar-lend/contracts/amm/Cargo.toml
+++ b/stellar-lend/contracts/amm/Cargo.toml
@@ -13,7 +13,7 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-proptest = "1.5"
+proptest = { workspace = true }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/stellar-lend/contracts/lending/Cargo.toml
+++ b/stellar-lend/contracts/lending/Cargo.toml
@@ -15,7 +15,7 @@ stellar-lend-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-proptest = "1.5"
+proptest = { workspace = true }
 
 [features]
 testutils = ["soroban-sdk/testutils"]


### PR DESCRIPTION
Closes: #914 
## Summary

Centralize Soroban SDK pinning at the workspace level and document the policy so all active workspace members inherit the same SDK and shared test dependency versions.

## What Changed

- pinned shared versions once in `stellar-lend/Cargo.toml` under `[workspace.dependencies]`
- kept `soroban-sdk` and `soroban-token-sdk` pinned at `25.3.0`
- moved shared `proptest` to the workspace dependency table
- updated `contracts/lending/Cargo.toml` and `contracts/amm/Cargo.toml` to inherit `proptest` with `{ workspace = true }`
- refreshed `stellar-lend/Cargo.lock` so it matches the active workspace members and single Soroban SDK resolution
- documented the dependency pinning policy and version bump procedure in `stellar-lend/contracts/ARCHITECTURE.md`
- corrected stale architecture notes about which crates are in the active workspace and how `hello-world` should be treated

## Why

This avoids per-crate SDK drift, keeps Soroban `Env`/`Address` types aligned across members, and makes future SDK audits a single-file review at the workspace root.

## Verification

Succeeded:
- `cargo metadata --format-version 1 --no-deps`
  - confirmed active workspace members inherit `soroban-sdk = "=25.3.0"` from the workspace root

Blocked by local environment:
- `cargo build --workspace`
  - failed during dependency compilation with `No space left on device` on `C:`
- `cargo test --workspace`
  - could not be completed; one attempt hit an offline cache miss for `bitflags v2.11.1`

## Notes

- `Cargo.lock` now reflects the active workspace instead of carrying stale resolution state for non-member crates.
- Coverage was not measurable in this environment because the full test suite could not be executed locally.