### PR TITLE
test(multisig): timelock delay and proposal lifecycle coverage

### DIFF
--- a/docs/multisig.md
+++ b/docs/multisig.md
@@ -368,6 +368,40 @@ If a malicious proposal reaches the approval threshold:
    legitimacy is in doubt.
 
 
+## Proposal Lifecycle Test Coverage
+
+The `stellarlend-multisig` crate ships a `#[cfg(test)]` module covering every error variant and timing boundary in the proposal flow. Run with:
+
+```bash
+cargo test -p stellarlend-multisig
+```
+
+### Key scenarios
+
+| Test | Error variant asserted |
+|------|----------------------|
+| `test_execute_proposal_double_execution` | `ProposalAlreadyExecuted` |
+| `test_execute_proposal_not_found` | `ProposalNotFound` |
+| `test_execute_proposal_before_eta_rejected` | `ProposalNotReady` |
+| `test_execute_at_exact_eta_boundary` | `ProposalNotReady` (boundary −1); success (boundary) |
+| `test_execute_expired_proposal_rejected` | `ProposalExpired` |
+| `test_execute_at_expiry_boundary` | success at boundary; `ProposalExpired` at boundary +1 |
+| `test_apply_threshold_change_before_delay` | `DelayNotElapsed` |
+| `test_apply_at_exact_min_delay_boundary` | `DelayNotElapsed` (boundary −1); success (boundary) |
+| `test_queue_threshold_change_zero_threshold` | `InvalidThreshold` |
+| `test_create_proposal_invalid_threshold` | `InvalidThreshold` |
+| `test_apply_threshold_change_no_queued_change` | `NoQueuedChange` |
+| `test_initialize_already_initialized` | `AlreadyInitialized` |
+| `test_queue_threshold_change_unauthorized` | host-level abort (`#[should_panic]`) |
+| `test_apply_threshold_change_unauthorized` | host-level abort (`#[should_panic]`) |
+
+### Timing boundary invariants
+
+- `DelayNotElapsed` until `current_ledger >= eta_ledger` (where `eta_ledger = queue_ledger + 600 000`).
+- `ProposalNotReady` until `current_ledger >= proposal.eta_ledger`.
+- `ProposalExpired` when `current_ledger > proposal.expires_at_ledger`; the boundary ledger itself is still valid.
+- `ProposalAlreadyExecuted` on any second call to `execute_proposal` for an `executed = true` proposal — no amount of ledger advancement can re-enable execution.
+
 ### Snapshot Testing
 
 ## Overview

--- a/docs/multisig.md
+++ b/docs/multisig.md
@@ -132,7 +132,7 @@ Removes expired, unexecuted proposal records and their approval vectors from con
 | `get_ms_threshold(env)` | `u32` | Approval threshold (default `1`) |
 | `get_ms_proposal(env, id)` | `Option<Proposal>` | Proposal by ID |
 | `get_ms_approvals(env, id)` | `Option<Vec<Address>>` | Approvals for a proposal |
-| `get_default_proposal_expiry_ledgers(env)` | `u32` | Default proposal lifetime used by the multisig crate |
+| `get_default_expiry_ledgers(env)` | `u32` | Default proposal lifetime used by the multisig crate |
 
 ---
 

--- a/docs/timelock-governance.md
+++ b/docs/timelock-governance.md
@@ -451,6 +451,46 @@ For all queued actions:
    - Use guardian to stabilize protocol
    - Follow full recovery procedures in Emergency Response Procedures
 
+## Timelock Test Coverage
+
+The multisig crate (`stellarlend-multisig`) includes a `#[cfg(test)]` module that exercises every timing-sensitive transition in the threshold-change and proposal-lifecycle flows. All tests advance the ledger sequence to cross timelock boundaries rather than relying on wall-clock time.
+
+### Threshold-Change Timelock
+
+| Test | Ledger position | Expected outcome |
+|------|----------------|-----------------|
+| `test_queue_threshold_change_success` | at queue ledger | change queued, eta = queue + 600 000 |
+| `test_apply_threshold_change_before_delay` | queue + (MIN − 1) | `DelayNotElapsed` |
+| `test_apply_at_exact_min_delay_boundary` | queue + MIN − 1 then queue + MIN | first `DelayNotElapsed`; second succeeds |
+| `test_apply_threshold_change_after_delay` | queue + MIN | threshold updated, pending cleared |
+| `test_apply_at_exact_eta` | exactly `eta_ledger` | succeeds |
+| `test_apply_after_eta` | queue + MIN × 2 | succeeds (no upper bound on application) |
+| `test_same_ledger_protection` | same ledger as queue | `DelayNotElapsed` |
+
+**Timing boundary**: `MIN_THRESHOLD_DELAY_LEDGERS = 600 000` (≈ 7 days at 5 s/ledger).  
+Apply is valid for `current_ledger >= eta_ledger`.
+
+### Proposal Lifecycle
+
+| Test | Ledger position | Expected outcome |
+|------|----------------|-----------------|
+| `test_execute_proposal_before_eta_rejected` | before eta | `ProposalNotReady` |
+| `test_execute_at_exact_eta_boundary` | eta − 1 then eta | first `ProposalNotReady`; second succeeds |
+| `test_execute_fresh_proposal_ok` | at eta | threshold updated, `executed = true` |
+| `test_execute_proposal_double_execution` | at eta, twice | second call → `ProposalAlreadyExecuted` |
+| `test_execute_proposal_not_found` | any | `ProposalNotFound` |
+| `test_execute_expired_proposal_rejected` | expires_at + 1 | `ProposalExpired` |
+| `test_execute_proposal_at_exact_expiry_ok` | exactly `expires_at` | succeeds (boundary is inclusive) |
+| `test_execute_at_expiry_boundary` | exactly `expires_at` then +1 | first succeeds; second `ProposalExpired` |
+
+**Expiry boundary**: `current_ledger > expires_at_ledger` rejects; `current_ledger == expires_at_ledger` succeeds.
+
+### Authorization and Validation
+
+- `test_queue_threshold_change_unauthorized` / `test_apply_threshold_change_unauthorized` — `require_auth()` causes a host-level abort when auth is not mocked; tests use `#[should_panic]`.
+- `test_queue_threshold_change_zero_threshold` / `test_create_proposal_invalid_threshold` — zero threshold returns `InvalidThreshold`.
+- `test_initialize_already_initialized` — second init returns `AlreadyInitialized`.
+
 ## Integration Checklist
 
 ### Pre-deployment

--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -539,16 +539,21 @@ mod tests {
         assert_eq!(result, Err(Ok(MultisigError::InvalidThreshold)));
     }
 
+    /// Verifies that queue_threshold_change panics when the admin's auth is not provided.
+    /// In Soroban, require_auth() enforces auth at the host level; the contract does not
+    /// return MultisigError::Unauthorized — the host aborts the invocation.
     #[test]
+    #[should_panic]
     fn test_queue_threshold_change_unauthorized() {
-        let (env, _admin, contract_id) = setup_initialized(3);
-        let other = Address::generate(&env);
+        // Fresh env WITHOUT mock_all_auths so require_auth() aborts at the host level.
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register_contract(None, MultisigContract);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        // Disable mock_all_auths to enforce auth check
-        env.mock_all_auths_allow_last();
-        let result = client.queue_threshold_change(&5);
-        assert_eq!(result, Err(Ok(MultisigError::Unauthorized)));
+        // initialize() has no require_auth() call, so it succeeds without auth mocking.
+        client.initialize(&admin, &3).unwrap();
+        // queue_threshold_change calls admin.require_auth() — panics without an auth mock.
+        let _ = client.queue_threshold_change(&5);
     }
 
     #[test]
@@ -597,21 +602,18 @@ mod tests {
         assert_eq!(result, Err(Ok(MultisigError::NoQueuedChange)));
     }
 
+    /// Verifies that apply_threshold_change panics when the admin's auth is not provided.
     #[test]
+    #[should_panic]
     fn test_apply_threshold_change_unauthorized() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        // Fresh env WITHOUT mock_all_auths so require_auth() aborts at the host level.
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register_contract(None, MultisigContract);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        client.queue_threshold_change(&5).unwrap();
-        let initial_ledger = env.ledger().sequence();
-        env.ledger()
-            .set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-
-        // Disable mock_all_auths to enforce auth check
-        env.mock_all_auths_allow_last();
-        let other = Address::generate(&env);
-        let result = client.apply_threshold_change();
-        assert_eq!(result, Err(Ok(MultisigError::Unauthorized)));
+        client.initialize(&admin, &3).unwrap();
+        // apply_threshold_change calls admin.require_auth() — panics without an auth mock.
+        let _ = client.apply_threshold_change();
     }
 
     #[test]
@@ -881,6 +883,209 @@ mod tests {
         assert_eq!(
             client.create_proposal(&5, &expires_too_soon),
             Err(Ok(MultisigError::InvalidProposal))
+        );
+    }
+
+    /// ProposalAlreadyExecuted: a second execute_proposal call on an already-executed
+    /// proposal must be rejected — stale quorums cannot replay governance actions.
+    #[test]
+    fn test_execute_proposal_double_execution() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let current_ledger = env.ledger().sequence();
+        let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
+        let proposal_id = client.create_proposal(&5, &expires_at).unwrap();
+
+        // Advance to eta so execution is permitted.
+        env.ledger()
+            .set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+
+        // First execution succeeds.
+        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
+        assert_eq!(client.get_threshold().unwrap(), 5);
+
+        // Second execution on the same proposal must be rejected.
+        assert_eq!(
+            client.execute_proposal(&proposal_id),
+            Err(Ok(MultisigError::ProposalAlreadyExecuted))
+        );
+
+        // Threshold must not have regressed.
+        assert_eq!(client.get_threshold().unwrap(), 5);
+    }
+
+    /// ProposalNotFound: executing a non-existent proposal id returns an error.
+    #[test]
+    fn test_execute_proposal_not_found() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let nonexistent_id: u64 = 9999;
+        assert_eq!(
+            client.execute_proposal(&nonexistent_id),
+            Err(Ok(MultisigError::ProposalNotFound))
+        );
+    }
+
+    /// create_proposal_with_default_expiry: convenience wrapper must set expires_at_ledger
+    /// at exactly current_ledger + DEFAULT_PROPOSAL_EXPIRY_LEDGERS and respect the timelock.
+    #[test]
+    fn test_create_proposal_with_default_expiry() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let current_ledger = env.ledger().sequence();
+        let proposal_id = client
+            .create_proposal_with_default_expiry(&5)
+            .unwrap();
+
+        let proposal = client.get_proposal(&proposal_id).unwrap();
+        assert_eq!(
+            proposal.expires_at_ledger,
+            current_ledger + DEFAULT_PROPOSAL_EXPIRY_LEDGERS
+        );
+        assert_eq!(proposal.new_threshold, 5);
+        assert!(!proposal.executed);
+
+        // Execute after delay — still within the default expiry window.
+        env.ledger()
+            .set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
+        assert_eq!(client.get_threshold().unwrap(), 5);
+    }
+
+    /// InvalidThreshold: create_proposal with threshold 0 must be rejected.
+    #[test]
+    fn test_create_proposal_invalid_threshold() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let current_ledger = env.ledger().sequence();
+        let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 1;
+
+        assert_eq!(
+            client.create_proposal(&0, &expires_at),
+            Err(Ok(MultisigError::InvalidThreshold))
+        );
+    }
+
+    /// cleanup_expired must keep executed proposals; only unexecuted expired ones are removed.
+    #[test]
+    fn test_cleanup_retains_executed_proposals() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let current_ledger = env.ledger().sequence();
+        let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS;
+        let proposal_id = client.create_proposal(&5, &expires_at).unwrap();
+
+        // Execute at ETA.
+        env.ledger().set_sequence_number(expires_at);
+        client.execute_proposal(&proposal_id).unwrap();
+
+        // Advance past expiry so cleanup might try to remove it.
+        env.ledger().set_sequence_number(expires_at + 1);
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(proposal_id);
+        // Executed proposals are never removed, regardless of ledger position.
+        assert_eq!(client.cleanup_expired(&ids), Ok(0));
+        assert!(client.get_proposal(&proposal_id).is_some());
+    }
+
+    /// Monotonic counter: each new proposal receives a strictly-increasing id.
+    #[test]
+    fn test_proposal_counter_increments() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let current_ledger = env.ledger().sequence();
+        let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
+
+        let id1 = client.create_proposal(&5, &expires_at).unwrap();
+        let id2 = client.create_proposal(&7, &expires_at).unwrap();
+        let id3 = client.create_proposal(&9, &expires_at).unwrap();
+
+        assert!(id1 < id2 && id2 < id3);
+    }
+
+    /// Applying a threshold change at exactly MIN_THRESHOLD_DELAY_LEDGERS (boundary).
+    #[test]
+    fn test_apply_at_exact_min_delay_boundary() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let queue_ledger = env.ledger().sequence();
+        client.queue_threshold_change(&5).unwrap();
+
+        // One ledger before the boundary — must fail.
+        env.ledger()
+            .set_sequence_number(queue_ledger + MIN_THRESHOLD_DELAY_LEDGERS - 1);
+        assert_eq!(
+            client.apply_threshold_change(),
+            Err(Ok(MultisigError::DelayNotElapsed))
+        );
+
+        // Exactly at the boundary — must succeed.
+        env.ledger()
+            .set_sequence_number(queue_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        assert_eq!(client.apply_threshold_change(), Ok(()));
+        assert_eq!(client.get_threshold().unwrap(), 5);
+    }
+
+    /// Executing a proposal at exactly eta_ledger (the boundary between NotReady and Ready).
+    #[test]
+    fn test_execute_at_exact_eta_boundary() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let current_ledger = env.ledger().sequence();
+        let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
+        let proposal_id = client.create_proposal(&7, &expires_at).unwrap();
+
+        let eta = client.get_proposal(&proposal_id).unwrap().eta_ledger;
+
+        // One ledger before eta — ProposalNotReady.
+        env.ledger().set_sequence_number(eta - 1);
+        assert_eq!(
+            client.execute_proposal(&proposal_id),
+            Err(Ok(MultisigError::ProposalNotReady))
+        );
+
+        // Exactly at eta — must succeed.
+        env.ledger().set_sequence_number(eta);
+        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
+        assert_eq!(client.get_threshold().unwrap(), 7);
+    }
+
+    /// Expiry boundary: proposal is valid at exactly expires_at_ledger, expired one ledger later.
+    ///
+    /// Both proposals are created upfront at the same ledger so that advancing time
+    /// for the first execution does not invalidate the second proposal's creation check.
+    #[test]
+    fn test_execute_at_expiry_boundary() {
+        let (env, _admin, contract_id) = setup_initialized(3);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let current_ledger = env.ledger().sequence();
+        // expires_at == eta (minimum valid expiry)
+        let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS;
+
+        // Create both proposals before advancing the ledger.
+        let proposal_id = client.create_proposal(&9, &expires_at).unwrap();
+        let proposal_id2 = client.create_proposal(&11, &expires_at).unwrap();
+
+        // At exactly expires_at — still valid (contract uses strict >).
+        env.ledger().set_sequence_number(expires_at);
+        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
+        assert_eq!(client.get_threshold().unwrap(), 9);
+
+        // One ledger past expiry — second proposal is rejected.
+        env.ledger().set_sequence_number(expires_at + 1);
+        assert_eq!(
+            client.execute_proposal(&proposal_id2),
+            Err(Ok(MultisigError::ProposalExpired))
         );
     }
 }

--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -245,7 +245,7 @@ impl MultisigContract {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
 
-        let change = env
+        let change: ThresholdChange = env
             .storage()
             .instance()
             .get(&DataKey::PendingThresholdChange)
@@ -334,7 +334,7 @@ impl MultisigContract {
     }
 
     /// Create a proposal with the default 14-day expiry window.
-    pub fn create_proposal_with_default_expiry(
+    pub fn create_proposal_default_expiry(
         env: Env,
         new_threshold: u32,
     ) -> Result<u64, MultisigError> {
@@ -424,7 +424,7 @@ impl MultisigContract {
     }
 
     /// Get the default proposal expiry window in ledgers.
-    pub fn get_default_proposal_expiry_ledgers(_env: Env) -> u32 {
+    pub fn get_default_expiry_ledgers(_env: Env) -> u32 {
         DEFAULT_PROPOSAL_EXPIRY_LEDGERS
     }
 
@@ -443,7 +443,7 @@ impl MultisigContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Address as AddressTestUtils;
+    use soroban_sdk::testutils::Address as _;
     use soroban_sdk::testutils::Ledger;
 
     fn setup() -> (Env, Address, Address) {
@@ -457,7 +457,7 @@ mod tests {
     fn setup_initialized(threshold: u32) -> (Env, Address, Address) {
         let (env, admin, contract_id) = setup();
         let client = MultisigContractClient::new(&env, &contract_id);
-        client.initialize(&admin, &threshold).unwrap();
+        client.initialize(&admin, &threshold);
         (env, admin, contract_id)
     }
 
@@ -465,328 +465,257 @@ mod tests {
     fn test_initialize_success() {
         let (env, admin, contract_id) = setup();
         let client = MultisigContractClient::new(&env, &contract_id);
-        let result = client.initialize(&admin, &5);
-        assert!(result.is_ok());
-        assert_eq!(client.get_threshold().unwrap(), 5);
-        assert_eq!(client.get_admin().unwrap(), admin);
+        client.initialize(&admin, &5);
+        assert_eq!(client.get_threshold(), 5);
+        assert_eq!(client.get_admin(), admin);
     }
 
     #[test]
     fn test_initialize_with_zero_threshold() {
         let (env, admin, contract_id) = setup();
         let client = MultisigContractClient::new(&env, &contract_id);
-        let result = client.initialize(&admin, &0);
-        assert_eq!(result, Err(Ok(MultisigError::InvalidThreshold)));
+        assert_eq!(
+            client.try_initialize(&admin, &0),
+            Err(Ok(MultisigError::InvalidThreshold))
+        );
     }
 
     #[test]
     fn test_initialize_already_initialized() {
         let (env, admin, contract_id) = setup();
         let client = MultisigContractClient::new(&env, &contract_id);
-        client.initialize(&admin, &3).unwrap();
-        let result = client.initialize(&admin, &5);
-        assert_eq!(result, Err(Ok(MultisigError::AlreadyInitialized)));
+        client.initialize(&admin, &3);
+        assert_eq!(
+            client.try_initialize(&admin, &5),
+            Err(Ok(MultisigError::AlreadyInitialized))
+        );
     }
 
     #[test]
     fn test_get_threshold_not_initialized() {
         let (env, _admin, contract_id) = setup();
         let client = MultisigContractClient::new(&env, &contract_id);
-        let result = client.get_threshold();
-        assert_eq!(result, Err(Ok(MultisigError::NotInitialized)));
+        assert_eq!(
+            client.try_get_threshold(),
+            Err(Ok(MultisigError::NotInitialized))
+        );
     }
 
     #[test]
     fn test_get_admin_not_initialized() {
         let (env, _admin, contract_id) = setup();
         let client = MultisigContractClient::new(&env, &contract_id);
-        let result = client.get_admin();
-        assert_eq!(result, Err(Ok(MultisigError::NotInitialized)));
+        assert_eq!(
+            client.try_get_admin(),
+            Err(Ok(MultisigError::NotInitialized))
+        );
     }
 
     #[test]
     fn test_queue_threshold_change_success() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
 
         let initial_ledger = env.ledger().sequence();
-        let result = client.queue_threshold_change(&5);
-        assert!(result.is_ok());
+        client.queue_threshold_change(&5);
 
         let pending = client.get_pending_threshold_change();
         assert!(pending.is_some());
         let change = pending.unwrap();
         assert_eq!(change.new_threshold, 5);
-        assert_eq!(
-            change.eta_ledger,
-            initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS
-        );
+        assert_eq!(change.eta_ledger, initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
     }
 
     #[test]
     fn test_queue_threshold_change_not_initialized() {
         let (env, _admin, contract_id) = setup();
         let client = MultisigContractClient::new(&env, &contract_id);
-        let result = client.queue_threshold_change(&5);
-        assert_eq!(result, Err(Ok(MultisigError::NotInitialized)));
+        assert_eq!(
+            client.try_queue_threshold_change(&5),
+            Err(Ok(MultisigError::NotInitialized))
+        );
     }
 
     #[test]
     fn test_queue_threshold_change_zero_threshold() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-        let result = client.queue_threshold_change(&0);
-        assert_eq!(result, Err(Ok(MultisigError::InvalidThreshold)));
+        assert_eq!(
+            client.try_queue_threshold_change(&0),
+            Err(Ok(MultisigError::InvalidThreshold))
+        );
     }
 
-    /// Verifies that queue_threshold_change panics when the admin's auth is not provided.
-    /// In Soroban, require_auth() enforces auth at the host level; the contract does not
-    /// return MultisigError::Unauthorized — the host aborts the invocation.
+    /// Verifies that queue_threshold_change panics when admin auth is not provided.
+    /// require_auth() enforces auth at the host level; the invocation aborts rather
+    /// than returning MultisigError::Unauthorized.
     #[test]
     #[should_panic]
     fn test_queue_threshold_change_unauthorized() {
-        // Fresh env WITHOUT mock_all_auths so require_auth() aborts at the host level.
         let env = Env::default();
         let admin = Address::generate(&env);
         let contract_id = env.register_contract(None, MultisigContract);
         let client = MultisigContractClient::new(&env, &contract_id);
-        // initialize() has no require_auth() call, so it succeeds without auth mocking.
-        client.initialize(&admin, &3).unwrap();
-        // queue_threshold_change calls admin.require_auth() — panics without an auth mock.
-        let _ = client.queue_threshold_change(&5);
+        client.initialize(&admin, &3);
+        client.queue_threshold_change(&5);
     }
 
     #[test]
     fn test_apply_threshold_change_before_delay() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        client.queue_threshold_change(&5).unwrap();
-
-        // Try to apply before delay elapsed
-        let result = client.apply_threshold_change();
-        assert_eq!(result, Err(Ok(MultisigError::DelayNotElapsed)));
-
-        // Threshold should not have changed
-        assert_eq!(client.get_threshold().unwrap(), 3);
+        client.queue_threshold_change(&5);
+        assert_eq!(
+            client.try_apply_threshold_change(),
+            Err(Ok(MultisigError::DelayNotElapsed))
+        );
+        assert_eq!(client.get_threshold(), 3);
     }
 
     #[test]
     fn test_apply_threshold_change_after_delay() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        client.queue_threshold_change(&5).unwrap();
+        client.queue_threshold_change(&5);
         let initial_ledger = env.ledger().sequence();
-
-        // Jump past the delay
-        env.ledger()
-            .set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-
-        let result = client.apply_threshold_change();
-        assert!(result.is_ok());
-
-        // Threshold should have changed
-        assert_eq!(client.get_threshold().unwrap(), 5);
-
-        // Pending change should be cleared
+        env.ledger().set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.apply_threshold_change();
+        assert_eq!(client.get_threshold(), 5);
         assert!(client.get_pending_threshold_change().is_none());
     }
 
     #[test]
     fn test_apply_threshold_change_no_queued_change() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        let result = client.apply_threshold_change();
-        assert_eq!(result, Err(Ok(MultisigError::NoQueuedChange)));
+        assert_eq!(
+            client.try_apply_threshold_change(),
+            Err(Ok(MultisigError::NoQueuedChange))
+        );
     }
 
-    /// Verifies that apply_threshold_change panics when the admin's auth is not provided.
+    /// Verifies that apply_threshold_change panics when admin auth is not provided.
     #[test]
     #[should_panic]
     fn test_apply_threshold_change_unauthorized() {
-        // Fresh env WITHOUT mock_all_auths so require_auth() aborts at the host level.
         let env = Env::default();
         let admin = Address::generate(&env);
         let contract_id = env.register_contract(None, MultisigContract);
         let client = MultisigContractClient::new(&env, &contract_id);
-        client.initialize(&admin, &3).unwrap();
-        // apply_threshold_change calls admin.require_auth() — panics without an auth mock.
-        let _ = client.apply_threshold_change();
+        client.initialize(&admin, &3);
+        client.apply_threshold_change();
     }
 
     #[test]
     fn test_multiple_threshold_changes() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
 
-        // Queue first change
-        client.queue_threshold_change(&5).unwrap();
+        client.queue_threshold_change(&5);
         let initial_ledger = env.ledger().sequence();
+        env.ledger().set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.apply_threshold_change();
+        assert_eq!(client.get_threshold(), 5);
 
-        // Jump to after delay
-        env.ledger()
-            .set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-
-        // Apply first change
-        client.apply_threshold_change().unwrap();
-        assert_eq!(client.get_threshold().unwrap(), 5);
-
-        // Queue second change
-        client.queue_threshold_change(&7).unwrap();
+        client.queue_threshold_change(&7);
         let second_ledger = env.ledger().sequence();
-
-        // Jump to after delay
-        env.ledger()
-            .set_sequence_number(second_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-
-        // Apply second change
-        client.apply_threshold_change().unwrap();
-        assert_eq!(client.get_threshold().unwrap(), 7);
+        env.ledger().set_sequence_number(second_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.apply_threshold_change();
+        assert_eq!(client.get_threshold(), 7);
     }
 
     #[test]
     fn test_overwrite_pending_change() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
 
-        // Queue first change
-        client.queue_threshold_change(&5).unwrap();
-        let pending1 = client.get_pending_threshold_change().unwrap();
-        assert_eq!(pending1.new_threshold, 5);
+        client.queue_threshold_change(&5);
+        assert_eq!(client.get_pending_threshold_change().unwrap().new_threshold, 5);
 
-        // Queue second change (overwrites first)
-        client.queue_threshold_change(&7).unwrap();
-        let pending2 = client.get_pending_threshold_change().unwrap();
-        assert_eq!(pending2.new_threshold, 7);
+        client.queue_threshold_change(&7);
+        assert_eq!(client.get_pending_threshold_change().unwrap().new_threshold, 7);
 
-        // Apply should use the second change
         let initial_ledger = env.ledger().sequence();
-        env.ledger()
-            .set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-        client.apply_threshold_change().unwrap();
-        assert_eq!(client.get_threshold().unwrap(), 7);
+        env.ledger().set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.apply_threshold_change();
+        assert_eq!(client.get_threshold(), 7);
     }
 
     #[test]
     fn test_same_ledger_protection() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        // Queue a threshold change
-        client.queue_threshold_change(&1).unwrap();
-
-        // Try to apply on the same ledger
-        let result = client.apply_threshold_change();
-        assert_eq!(result, Err(Ok(MultisigError::DelayNotElapsed)));
-
-        // Verify threshold unchanged
-        assert_eq!(client.get_threshold().unwrap(), 3);
+        client.queue_threshold_change(&1);
+        assert_eq!(
+            client.try_apply_threshold_change(),
+            Err(Ok(MultisigError::DelayNotElapsed))
+        );
+        assert_eq!(client.get_threshold(), 3);
     }
 
     #[test]
     fn test_get_min_threshold_delay_ledgers() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-        assert_eq!(
-            client.get_min_threshold_delay_ledgers(),
-            MIN_THRESHOLD_DELAY_LEDGERS
-        );
+        assert_eq!(client.get_min_threshold_delay_ledgers(), MIN_THRESHOLD_DELAY_LEDGERS);
     }
 
     #[test]
     fn test_queue_then_apply_reduces_takeover_window() {
-        // This test demonstrates that once threshold is lowered, it cannot be used
-        // in the same transaction where it was queued, preventing immediate takeover
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        let initial_ledger = env.ledger().sequence();
-
-        // Queue threshold change to 1 (hypothetical takeover attempt)
-        client.queue_threshold_change(&1).unwrap();
-
-        // On same ledger, threshold is still 3
-        assert_eq!(client.get_threshold().unwrap(), 3);
-
-        // Cannot apply on same ledger
+        client.queue_threshold_change(&1);
+        assert_eq!(client.get_threshold(), 3);
         assert_eq!(
-            client.apply_threshold_change(),
+            client.try_apply_threshold_change(),
             Err(Ok(MultisigError::DelayNotElapsed))
         );
     }
 
     #[test]
     fn test_apply_at_exact_eta() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        let initial_ledger = env.ledger().sequence();
-        client.queue_threshold_change(&5).unwrap();
-
-        // Get the exact ETA
-        let pending = client.get_pending_threshold_change().unwrap();
-        let eta = pending.eta_ledger;
-
-        // Jump to exactly the ETA ledger
+        client.queue_threshold_change(&5);
+        let eta = client.get_pending_threshold_change().unwrap().eta_ledger;
         env.ledger().set_sequence_number(eta);
-
-        // Should succeed at exact ETA
-        let result = client.apply_threshold_change();
-        assert!(result.is_ok());
-        assert_eq!(client.get_threshold().unwrap(), 5);
+        client.apply_threshold_change();
+        assert_eq!(client.get_threshold(), 5);
     }
 
     #[test]
     fn test_apply_after_eta() {
-        let (env, admin, contract_id) = setup_initialized(3);
+        let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let initial_ledger = env.ledger().sequence();
-        client.queue_threshold_change(&5).unwrap();
-
-        // Jump far past the delay
-        env.ledger()
-            .set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS * 2);
-
-        // Should still succeed
-        let result = client.apply_threshold_change();
-        assert!(result.is_ok());
-        assert_eq!(client.get_threshold().unwrap(), 5);
+        client.queue_threshold_change(&5);
+        env.ledger().set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS * 2);
+        client.apply_threshold_change();
+        assert_eq!(client.get_threshold(), 5);
     }
 
     #[test]
     fn test_large_threshold_values() {
-        let (env, admin, contract_id) = setup_initialized(1);
+        let (env, _admin, contract_id) = setup_initialized(1);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let large_threshold = 1_000_000u32;
-        client.queue_threshold_change(&large_threshold).unwrap();
-
+        client.queue_threshold_change(&large_threshold);
         let initial_ledger = env.ledger().sequence();
-        env.ledger()
-            .set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-
-        client.apply_threshold_change().unwrap();
-        assert_eq!(client.get_threshold().unwrap(), large_threshold);
+        env.ledger().set_sequence_number(initial_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.apply_threshold_change();
+        assert_eq!(client.get_threshold(), large_threshold);
     }
 
     #[test]
     fn test_execute_fresh_proposal_ok() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
-        let proposal_id = client.create_proposal(&5, &expires_at).unwrap();
-
-        env.ledger()
-            .set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-
-        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
-        assert_eq!(client.get_threshold().unwrap(), 5);
-
+        let proposal_id = client.create_proposal(&5, &expires_at);
+        env.ledger().set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.execute_proposal(&proposal_id);
+        assert_eq!(client.get_threshold(), 5);
         let proposal = client.get_proposal(&proposal_id).unwrap();
         assert!(proposal.executed);
         assert_eq!(proposal.expires_at_ledger, expires_at);
@@ -796,75 +725,61 @@ mod tests {
     fn test_execute_expired_proposal_rejected() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS;
-        let proposal_id = client.create_proposal(&5, &expires_at).unwrap();
-
+        let proposal_id = client.create_proposal(&5, &expires_at);
         env.ledger().set_sequence_number(expires_at + 1);
-
         assert_eq!(
-            client.execute_proposal(&proposal_id),
+            client.try_execute_proposal(&proposal_id),
             Err(Ok(MultisigError::ProposalExpired))
         );
-        assert_eq!(client.get_threshold().unwrap(), 3);
-
-        let proposal = client.get_proposal(&proposal_id).unwrap();
-        assert!(!proposal.executed);
+        assert_eq!(client.get_threshold(), 3);
+        assert!(!client.get_proposal(&proposal_id).unwrap().executed);
     }
 
     #[test]
     fn test_execute_proposal_at_exact_expiry_ok() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS;
-        let proposal_id = client.create_proposal(&5, &expires_at).unwrap();
-
+        let proposal_id = client.create_proposal(&5, &expires_at);
         env.ledger().set_sequence_number(expires_at);
-
-        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
-        assert_eq!(client.get_threshold().unwrap(), 5);
+        client.execute_proposal(&proposal_id);
+        assert_eq!(client.get_threshold(), 5);
     }
 
     #[test]
     fn test_execute_proposal_before_eta_rejected() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
-        let proposal_id = client.create_proposal(&5, &expires_at).unwrap();
-
+        let proposal_id = client.create_proposal(&5, &expires_at);
         assert_eq!(
-            client.execute_proposal(&proposal_id),
+            client.try_execute_proposal(&proposal_id),
             Err(Ok(MultisigError::ProposalNotReady))
         );
-        assert_eq!(client.get_threshold().unwrap(), 3);
+        assert_eq!(client.get_threshold(), 3);
     }
 
     #[test]
     fn test_cleanup_expired_frees_keys() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS;
-        let expired_id = client.create_proposal(&5, &expires_at).unwrap();
-        let fresh_id = client
-            .create_proposal(&7, &(expires_at + MIN_THRESHOLD_DELAY_LEDGERS))
-            .unwrap();
+        let expired_id = client.create_proposal(&5, &expires_at);
+        let fresh_id = client.create_proposal(&7, &(expires_at + MIN_THRESHOLD_DELAY_LEDGERS));
 
         assert!(client.get_proposal(&expired_id).is_some());
         assert!(client.get_proposal_approvals(&expired_id).is_some());
 
         env.ledger().set_sequence_number(expires_at + 1);
-
         let mut ids = Vec::new(&env);
         ids.push_back(expired_id);
         ids.push_back(fresh_id);
-        assert_eq!(client.cleanup_expired(&ids), Ok(1));
+        assert_eq!(client.cleanup_expired(&ids), 1u32);
 
         assert!(client.get_proposal(&expired_id).is_none());
         assert!(client.get_proposal_approvals(&expired_id).is_none());
@@ -876,43 +791,30 @@ mod tests {
     fn test_create_proposal_rejects_expiry_before_eta() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_too_soon = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS - 1;
-
         assert_eq!(
-            client.create_proposal(&5, &expires_too_soon),
+            client.try_create_proposal(&5, &expires_too_soon),
             Err(Ok(MultisigError::InvalidProposal))
         );
     }
 
-    /// ProposalAlreadyExecuted: a second execute_proposal call on an already-executed
-    /// proposal must be rejected — stale quorums cannot replay governance actions.
+    /// ProposalAlreadyExecuted: a second execute_proposal call must be rejected.
     #[test]
     fn test_execute_proposal_double_execution() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
-        let proposal_id = client.create_proposal(&5, &expires_at).unwrap();
-
-        // Advance to eta so execution is permitted.
-        env.ledger()
-            .set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-
-        // First execution succeeds.
-        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
-        assert_eq!(client.get_threshold().unwrap(), 5);
-
-        // Second execution on the same proposal must be rejected.
+        let proposal_id = client.create_proposal(&5, &expires_at);
+        env.ledger().set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.execute_proposal(&proposal_id);
+        assert_eq!(client.get_threshold(), 5);
         assert_eq!(
-            client.execute_proposal(&proposal_id),
+            client.try_execute_proposal(&proposal_id),
             Err(Ok(MultisigError::ProposalAlreadyExecuted))
         );
-
-        // Threshold must not have regressed.
-        assert_eq!(client.get_threshold().unwrap(), 5);
+        assert_eq!(client.get_threshold(), 5);
     }
 
     /// ProposalNotFound: executing a non-existent proposal id returns an error.
@@ -920,39 +822,26 @@ mod tests {
     fn test_execute_proposal_not_found() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
-        let nonexistent_id: u64 = 9999;
         assert_eq!(
-            client.execute_proposal(&nonexistent_id),
+            client.try_execute_proposal(&9999u64),
             Err(Ok(MultisigError::ProposalNotFound))
         );
     }
 
-    /// create_proposal_with_default_expiry: convenience wrapper must set expires_at_ledger
-    /// at exactly current_ledger + DEFAULT_PROPOSAL_EXPIRY_LEDGERS and respect the timelock.
+    /// create_proposal_default_expiry: sets expires_at_ledger = current + DEFAULT_PROPOSAL_EXPIRY_LEDGERS.
     #[test]
-    fn test_create_proposal_with_default_expiry() {
+    fn test_create_proposal_default_expiry() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
-        let proposal_id = client
-            .create_proposal_with_default_expiry(&5)
-            .unwrap();
-
+        let proposal_id = client.create_proposal_default_expiry(&5);
         let proposal = client.get_proposal(&proposal_id).unwrap();
-        assert_eq!(
-            proposal.expires_at_ledger,
-            current_ledger + DEFAULT_PROPOSAL_EXPIRY_LEDGERS
-        );
+        assert_eq!(proposal.expires_at_ledger, current_ledger + DEFAULT_PROPOSAL_EXPIRY_LEDGERS);
         assert_eq!(proposal.new_threshold, 5);
         assert!(!proposal.executed);
-
-        // Execute after delay — still within the default expiry window.
-        env.ledger()
-            .set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
-        assert_eq!(client.get_threshold().unwrap(), 5);
+        env.ledger().set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.execute_proposal(&proposal_id);
+        assert_eq!(client.get_threshold(), 5);
     }
 
     /// InvalidThreshold: create_proposal with threshold 0 must be rejected.
@@ -960,12 +849,10 @@ mod tests {
     fn test_create_proposal_invalid_threshold() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 1;
-
         assert_eq!(
-            client.create_proposal(&0, &expires_at),
+            client.try_create_proposal(&0, &expires_at),
             Err(Ok(MultisigError::InvalidThreshold))
         );
     }
@@ -975,22 +862,15 @@ mod tests {
     fn test_cleanup_retains_executed_proposals() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS;
-        let proposal_id = client.create_proposal(&5, &expires_at).unwrap();
-
-        // Execute at ETA.
+        let proposal_id = client.create_proposal(&5, &expires_at);
         env.ledger().set_sequence_number(expires_at);
-        client.execute_proposal(&proposal_id).unwrap();
-
-        // Advance past expiry so cleanup might try to remove it.
+        client.execute_proposal(&proposal_id);
         env.ledger().set_sequence_number(expires_at + 1);
-
         let mut ids = Vec::new(&env);
         ids.push_back(proposal_id);
-        // Executed proposals are never removed, regardless of ledger position.
-        assert_eq!(client.cleanup_expired(&ids), Ok(0));
+        assert_eq!(client.cleanup_expired(&ids), 0u32);
         assert!(client.get_proposal(&proposal_id).is_some());
     }
 
@@ -999,14 +879,11 @@ mod tests {
     fn test_proposal_counter_increments() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
-
-        let id1 = client.create_proposal(&5, &expires_at).unwrap();
-        let id2 = client.create_proposal(&7, &expires_at).unwrap();
-        let id3 = client.create_proposal(&9, &expires_at).unwrap();
-
+        let id1 = client.create_proposal(&5, &expires_at);
+        let id2 = client.create_proposal(&7, &expires_at);
+        let id3 = client.create_proposal(&9, &expires_at);
         assert!(id1 < id2 && id2 < id3);
     }
 
@@ -1015,23 +892,18 @@ mod tests {
     fn test_apply_at_exact_min_delay_boundary() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let queue_ledger = env.ledger().sequence();
-        client.queue_threshold_change(&5).unwrap();
-
+        client.queue_threshold_change(&5);
         // One ledger before the boundary — must fail.
-        env.ledger()
-            .set_sequence_number(queue_ledger + MIN_THRESHOLD_DELAY_LEDGERS - 1);
+        env.ledger().set_sequence_number(queue_ledger + MIN_THRESHOLD_DELAY_LEDGERS - 1);
         assert_eq!(
-            client.apply_threshold_change(),
+            client.try_apply_threshold_change(),
             Err(Ok(MultisigError::DelayNotElapsed))
         );
-
         // Exactly at the boundary — must succeed.
-        env.ledger()
-            .set_sequence_number(queue_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
-        assert_eq!(client.apply_threshold_change(), Ok(()));
-        assert_eq!(client.get_threshold().unwrap(), 5);
+        env.ledger().set_sequence_number(queue_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+        client.apply_threshold_change();
+        assert_eq!(client.get_threshold(), 5);
     }
 
     /// Executing a proposal at exactly eta_ledger (the boundary between NotReady and Ready).
@@ -1039,52 +911,42 @@ mod tests {
     fn test_execute_at_exact_eta_boundary() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
-        let proposal_id = client.create_proposal(&7, &expires_at).unwrap();
-
+        let proposal_id = client.create_proposal(&7, &expires_at);
         let eta = client.get_proposal(&proposal_id).unwrap().eta_ledger;
-
         // One ledger before eta — ProposalNotReady.
         env.ledger().set_sequence_number(eta - 1);
         assert_eq!(
-            client.execute_proposal(&proposal_id),
+            client.try_execute_proposal(&proposal_id),
             Err(Ok(MultisigError::ProposalNotReady))
         );
-
         // Exactly at eta — must succeed.
         env.ledger().set_sequence_number(eta);
-        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
-        assert_eq!(client.get_threshold().unwrap(), 7);
+        client.execute_proposal(&proposal_id);
+        assert_eq!(client.get_threshold(), 7);
     }
 
     /// Expiry boundary: proposal is valid at exactly expires_at_ledger, expired one ledger later.
     ///
-    /// Both proposals are created upfront at the same ledger so that advancing time
-    /// for the first execution does not invalidate the second proposal's creation check.
+    /// Both proposals are created upfront so that advancing the ledger for the first
+    /// execution does not affect the second proposal's creation validity check.
     #[test]
     fn test_execute_at_expiry_boundary() {
         let (env, _admin, contract_id) = setup_initialized(3);
         let client = MultisigContractClient::new(&env, &contract_id);
-
         let current_ledger = env.ledger().sequence();
-        // expires_at == eta (minimum valid expiry)
         let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS;
-
-        // Create both proposals before advancing the ledger.
-        let proposal_id = client.create_proposal(&9, &expires_at).unwrap();
-        let proposal_id2 = client.create_proposal(&11, &expires_at).unwrap();
-
+        let proposal_id = client.create_proposal(&9, &expires_at);
+        let proposal_id2 = client.create_proposal(&11, &expires_at);
         // At exactly expires_at — still valid (contract uses strict >).
         env.ledger().set_sequence_number(expires_at);
-        assert_eq!(client.execute_proposal(&proposal_id), Ok(()));
-        assert_eq!(client.get_threshold().unwrap(), 9);
-
-        // One ledger past expiry — second proposal is rejected.
+        client.execute_proposal(&proposal_id);
+        assert_eq!(client.get_threshold(), 9);
+        // One ledger past expiry — rejected.
         env.ledger().set_sequence_number(expires_at + 1);
         assert_eq!(
-            client.execute_proposal(&proposal_id2),
+            client.try_execute_proposal(&proposal_id2),
             Err(Ok(MultisigError::ProposalExpired))
         );
     }


### PR DESCRIPTION
Closes #984

## Summary

This PR adds a complete test suite for the threshold-change timelock and proposal lifecycle in `stellar-lend/contracts/multisig/src/lib.rs`, satisfying all requirements from issue #984. It also fixes three pre-existing compile errors that prevented the crate from building at all.

---

## Pre-existing bugs fixed

Before any tests could run, the crate had three compile errors:

| Bug | Location | Fix |
|-----|----------|-----|
| `E0282` — type annotation needed | `apply_threshold_change`, `let change = env.storage()...` | Added explicit `: ThresholdChange` annotation |
| Function name too long (35 > 32 chars) | `create_proposal_with_default_expiry` | Renamed → `create_proposal_default_expiry` |
| Function name too long (35 > 32 chars) | `get_default_proposal_expiry_ledgers` | Renamed → `get_default_expiry_ledgers` |

Soroban enforces a hard 32-character limit on exported contract function names.

---

## Test suite — 36 tests, all passing

`cargo test -p stellarlend-multisig` → **36 passed; 0 failed**

### Threshold-change timelock

| Test | Scenario | Error asserted |
|------|----------|---------------|
| `test_queue_threshold_change_success` | Queue stores pending change at `queue_ledger + 600_000` | — |
| `test_apply_threshold_change_before_delay` | Apply before delay | `DelayNotElapsed` |
| `test_apply_at_exact_min_delay_boundary` | Apply at `MIN − 1` then at `MIN` | `DelayNotElapsed` / success |
| `test_apply_threshold_change_after_delay` | Apply after delay | threshold updated, pending cleared |
| `test_apply_at_exact_eta` | Apply at exactly `eta_ledger` | success |
| `test_apply_after_eta` | Apply at `MIN × 2` | success (no upper bound) |
| `test_same_ledger_protection` | Queue and apply in same ledger | `DelayNotElapsed` |
| `test_multiple_threshold_changes` | Two sequential queue → apply cycles | correct thresholds |
| `test_overwrite_pending_change` | Queue twice — second overwrites first | second value applied |
| `test_apply_threshold_change_no_queued_change` | Apply with nothing queued | `NoQueuedChange` |

### Proposal lifecycle

| Test | Scenario | Error asserted |
|------|----------|---------------|
| `test_execute_fresh_proposal_ok` | Execute after ETA, within expiry | success, `executed = true` |
| `test_execute_proposal_before_eta_rejected` | Execute before ETA | `ProposalNotReady` |
| `test_execute_at_exact_eta_boundary` | Execute at `eta − 1` then at `eta` | `ProposalNotReady` / success |
| `test_execute_expired_proposal_rejected` | Execute at `expires_at + 1` | `ProposalExpired` |
| `test_execute_proposal_at_exact_expiry_ok` | Execute at exactly `expires_at` | success (inclusive boundary) |
| `test_execute_at_expiry_boundary` | Execute at `expires_at` and `expires_at + 1` | success / `ProposalExpired` |
| `test_execute_proposal_double_execution` | Execute same proposal twice | `ProposalAlreadyExecuted` |
| `test_execute_proposal_not_found` | Execute non-existent id | `ProposalNotFound` |
| `test_create_proposal_rejects_expiry_before_eta` | `expires_at < eta_ledger` | `InvalidProposal` |
| `test_create_proposal_invalid_threshold` | Threshold = 0 | `InvalidThreshold` |
| `test_create_proposal_default_expiry` | Convenience wrapper sets correct expiry | `expires_at = current + 1_200_000` |
| `test_cleanup_expired_frees_keys` | Expired unexecuted proposals removed | count = 1, fresh kept |
| `test_cleanup_retains_executed_proposals` | Executed proposals never removed by cleanup | count = 0 |
| `test_proposal_counter_increments` | IDs are strictly monotonically increasing | `id1 < id2 < id3` |

### Authorization and validation

| Test | Scenario |
|------|----------|
| `test_queue_threshold_change_unauthorized` (`#[should_panic]`) | `require_auth()` host-abort without auth mock |
| `test_apply_threshold_change_unauthorized` (`#[should_panic]`) | Same for apply |
| `test_queue_threshold_change_zero_threshold` | `InvalidThreshold` |
| `test_initialize_with_zero_threshold` | `InvalidThreshold` |
| `test_initialize_already_initialized` | `AlreadyInitialized` |
| `test_get_threshold_not_initialized` | `NotInitialized` |
| `test_get_admin_not_initialized` | `NotInitialized` |
| `test_queue_threshold_change_not_initialized` | `NotInitialized` |

---

## soroban-sdk 25.3.0 API note

In SDK 25.x the generated test client returns `T` directly on success (panicking on error). Error assertions must use `try_*` variants which return `Result<T, Result<E, HostError>>` — this is the `Err(Ok(MultisigError::X))` pattern used throughout. The original test stubs used `.unwrap()` on `()` / `u32` return values and called a non-existent `mock_all_auths_allow_last()` method — both corrected here.

---

## Documentation updates

- **`docs/timelock-governance.md`** — new *Timelock Test Coverage* section with complete tables of test scenarios and timing boundary invariants (`MIN_THRESHOLD_DELAY_LEDGERS`, expiry strict-`>` rule).
- **`docs/multisig.md`** — new *Proposal Lifecycle Test Coverage* section; view-function table updated to reflect renamed functions.

---

## Test run

```
running 36 tests
test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```