### PR TITLE
test(lending): cover health factor edge cases

### DIFF
--- a/stellar-lend/contracts/lending/src/health_factor_edge_test.rs
+++ b/stellar-lend/contracts/lending/src/health_factor_edge_test.rs
@@ -1,0 +1,84 @@
+use super::*;
+use soroban_sdk::testutils::Address as _;
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, client, id, user)
+}
+
+fn assert_health_factor_consistency(
+    client: &LendingContractClient<'static>,
+    user: &Address,
+    expected: i128,
+) {
+    let position = client.get_position(user);
+    let health_factor = client.get_health_factor(user);
+
+    assert_eq!(position.health_factor, expected);
+    assert_eq!(health_factor, expected);
+}
+
+/// Pins the no-debt sentinel on both view paths, including the case where
+/// collateral exists but the debt denominator is zero.
+#[test]
+fn health_factor_no_debt_uses_healthy_sentinel() {
+    let (_env, client, _id, user) = setup();
+    client.deposit(&user, &250);
+
+    let position = client.get_position(&user);
+    assert_eq!(position.collateral, 250);
+    assert_eq!(position.debt, 0);
+    assert_health_factor_consistency(&client, &user, HEALTH_FACTOR_NO_DEBT);
+}
+
+/// Zero collateral with non-zero debt must be liquidatable at an exact zero
+/// health factor, not the no-debt sentinel.
+#[test]
+fn health_factor_zero_collateral_nonzero_debt_is_zero() {
+    let (_env, client, _id, user) = setup();
+    client.borrow(&user, &125);
+
+    let position = client.get_position(&user);
+    assert_eq!(position.collateral, 0);
+    assert_eq!(position.debt, 125);
+    assert_health_factor_consistency(&client, &user, 0);
+}
+
+/// The liquidation threshold boundary is exact: 100 collateral and 80 debt
+/// produce health factor 10000, the 1.0 scale value documented in views.md.
+#[test]
+fn health_factor_at_liquidation_threshold_is_exactly_scaled_one() {
+    let (_env, client, _id, user) = setup();
+    client.deposit(&user, &100);
+    client.borrow(&user, &80);
+
+    assert_health_factor_consistency(&client, &user, HEALTH_FACTOR_SCALE);
+}
+
+/// A collateral amount just past the checked-multiply boundary must not wrap;
+/// both view paths intentionally return i128::MAX as the overflow sentinel.
+#[test]
+fn health_factor_overflow_returns_i128_max_sentinel() {
+    let (env, client, id, user) = setup();
+    let overflowing_collateral = i128::MAX / LIQUIDATION_THRESHOLD_BPS + 1;
+
+    env.as_contract(&id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user.clone()), &overflowing_collateral);
+    });
+    client.borrow(&user, &1);
+
+    let position = client.get_position(&user);
+    assert_eq!(position.collateral, overflowing_collateral);
+    assert_eq!(position.debt, 1);
+    assert_health_factor_consistency(&client, &user, i128::MAX);
+}

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -8,19 +8,21 @@ pub mod rounding_strategy;
 #[cfg(test)]
 mod deposit_accounting_test;
 #[cfg(test)]
-mod interest_drift_regression_test;
-#[cfg(test)]
 mod error_codes_test;
+#[cfg(test)]
+mod health_factor_edge_test;
+#[cfg(test)]
+mod interest_drift_regression_test;
 
 use debt::{
     borrow_amount, effective_debt, load_debt, repay_amount, save_debt, DebtPosition,
     DEFAULT_APR_BPS,
 };
+use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, BytesN,
     Env, IntoVal, Symbol, Val,
 };
-use soroban_sdk::xdr::ToXdr;
 
 const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
 const DEFAULT_DEPOSIT_CAP: i128 = 1_000_000_000_000;
@@ -565,7 +567,9 @@ impl LendingContract {
         if fee_bps < 0 || fee_bps > 1000 {
             return Err(LendingError::InvalidFeeBps);
         }
-        env.storage().instance().set(&DataKey::FlashFeeBps, &fee_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::FlashFeeBps, &fee_bps);
         Ok(())
     }
 
@@ -963,7 +967,7 @@ mod test {
         let mut payload_bytes = [0u8; 1024];
         let len = payload.len() as usize;
         payload.copy_into_slice(&mut payload_bytes[..len]);
-        
+
         let signature = keypair.sign(&payload_bytes[..len]);
         BytesN::from_array(env, &signature.to_bytes())
     }
@@ -1072,7 +1076,9 @@ mod test {
         let signature = sign_oracle_update(&env, &keypair, &asset, price, timestamp);
 
         client.set_price(&admin, &asset, &price, &timestamp, &signature);
-        let record = client.get_price_record(&asset).expect("price record stored");
+        let record = client
+            .get_price_record(&asset)
+            .expect("price record stored");
         assert_eq!(record.price, price);
         assert_eq!(record.timestamp, timestamp);
     }
@@ -1086,8 +1092,11 @@ mod test {
         let bad_seed = [43u8; 32];
         let bad_secret = ed25519_dalek::SecretKey::from_bytes(&bad_seed).unwrap();
         let bad_public = ed25519_dalek::PublicKey::from(&bad_secret);
-        let bad_keypair = Keypair { secret: bad_secret, public: bad_public };
-        
+        let bad_keypair = Keypair {
+            secret: bad_secret,
+            public: bad_public,
+        };
+
         let pubkey = BytesN::from_array(&env, &keypair.public.to_bytes());
         client.set_oracle_pubkey(&pubkey);
 

--- a/stellar-lend/contracts/lending/src/math.rs
+++ b/stellar-lend/contracts/lending/src/math.rs
@@ -67,9 +67,7 @@ pub fn compute_compound_interest(
     let seconds_per_year: i128 = 31_536_000; // 365 * 24 * 3600
 
     // Step 1: principal * rate_bps (checked)
-    let step1 = principal
-        .checked_mul(rate_bps)
-        .ok_or(MathError::Overflow)?;
+    let step1 = principal.checked_mul(rate_bps).ok_or(MathError::Overflow)?;
 
     // Step 2: step1 * elapsed (checked)
     let step2 = step1
@@ -190,26 +188,31 @@ pub fn compute_borrow_rate(
             util.checked_mul(mult)
                 .ok_or(MathError::Overflow)?
                 .checked_div(scale)
-                .ok_or(MathError::DivisionByZero)?
-        ).ok_or(MathError::Overflow)?
+                .ok_or(MathError::DivisionByZero)?,
+        )
+        .ok_or(MathError::Overflow)?
     } else {
         // rate = base + kink * multiplier / SCALE + (util - kink) * jump_multiplier / SCALE
-        let base_plus_kink = base.checked_add(
-            kink.checked_mul(mult)
-                .ok_or(MathError::Overflow)?
-                .checked_div(scale)
-                .ok_or(MathError::DivisionByZero)?
-        ).ok_or(MathError::Overflow)?;
+        let base_plus_kink = base
+            .checked_add(
+                kink.checked_mul(mult)
+                    .ok_or(MathError::Overflow)?
+                    .checked_div(scale)
+                    .ok_or(MathError::DivisionByZero)?,
+            )
+            .ok_or(MathError::Overflow)?;
 
-        let excess_util = util.checked_sub(kink)
-            .ok_or(MathError::NegativeResult)?;
+        let excess_util = util.checked_sub(kink).ok_or(MathError::NegativeResult)?;
 
-        base_plus_kink.checked_add(
-            excess_util.checked_mul(jump_mult)
-                .ok_or(MathError::Overflow)?
-                .checked_div(scale)
-                .ok_or(MathError::DivisionByZero)?
-        ).ok_or(MathError::Overflow)?
+        base_plus_kink
+            .checked_add(
+                excess_util
+                    .checked_mul(jump_mult)
+                    .ok_or(MathError::Overflow)?
+                    .checked_div(scale)
+                    .ok_or(MathError::DivisionByZero)?,
+            )
+            .ok_or(MathError::Overflow)?
     };
 
     // Clamp to MAX_RATE_BPS
@@ -256,7 +259,8 @@ pub fn compute_supply_rate(
         .ok_or(MathError::DivisionByZero)?;
 
     // (1 - reserve_factor) = (SCALE - reserve) / SCALE
-    let one_minus_reserve = scale.checked_sub(reserve)
+    let one_minus_reserve = scale
+        .checked_sub(reserve)
         .ok_or(MathError::NegativeResult)?;
 
     // rate_util * one_minus_reserve / SCALE
@@ -312,10 +316,7 @@ pub fn compute_liquidation_bonus(
 /// # Returns
 /// * `Ok(max_borrow)` - Maximum borrowable amount
 /// * `Err(MathError)` - On overflow or invalid input
-pub fn compute_max_borrow(
-    collateral_value: i128,
-    ltv_bps: u32,
-) -> Result<i128, MathError> {
+pub fn compute_max_borrow(collateral_value: i128, ltv_bps: u32) -> Result<i128, MathError> {
     if collateral_value < 0 {
         return Err(MathError::OutOfRange);
     }
@@ -354,10 +355,7 @@ pub fn is_liquidatable(health_factor: i128) -> bool {
 /// # Returns
 /// * `Ok(utilization_bps)` - Utilization in basis points
 /// * `Err(MathError)` - On overflow or invalid input
-pub fn compute_utilization(
-    total_borrows: i128,
-    total_deposits: i128,
-) -> Result<u32, MathError> {
+pub fn compute_utilization(total_borrows: i128, total_deposits: i128) -> Result<u32, MathError> {
     if total_borrows < 0 || total_deposits < 0 {
         return Err(MathError::OutOfRange);
     }

--- a/stellar-lend/contracts/lending/tests/interest_drift_regression_test.rs
+++ b/stellar-lend/contracts/lending/tests/interest_drift_regression_test.rs
@@ -2,14 +2,8 @@ use soroban_sdk::{testutils::Address as _, Address, Env};
 use stellar_lend_contract::LendingContract;
 
 // Import the live module paths from the lending crate
-use stellar_lend_contract::rounding_strategy::{
-    compute_compound_interest, 
-    RoundingMode,
-};
-use stellar_lend_contract::interest_model::{
-    InterestRateModel,
-    AccrualConfig,
-};
+use stellar_lend_contract::interest_model::{AccrualConfig, InterestRateModel};
+use stellar_lend_contract::rounding_strategy::{compute_compound_interest, RoundingMode};
 
 /// Maximum acceptable drift per year of accrual (1 basis point = 0.01%)
 const MAX_DRIFT_BPS: i128 = 1;
@@ -18,14 +12,14 @@ const MAX_DRIFT_BPS: i128 = 1;
 #[test]
 fn test_daily_accrual_drift_over_one_year() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000_000_000_000; // 1,000,000.000000
     let annual_rate_bps: u32 = 1000; // 10% APR
     let daily_rate = annual_rate_bps / 365;
-    
+
     let mut accumulated = principal;
     let model = InterestRateModel::default();
-    
+
     // Simulate 365 daily accruals
     for day in 0..365 {
         let interest = compute_compound_interest(
@@ -35,10 +29,11 @@ fn test_daily_accrual_drift_over_one_year() {
             1, // 1 day
             RoundingMode::HalfUp,
         );
-        accumulated = accumulated.checked_add(interest)
+        accumulated = accumulated
+            .checked_add(interest)
             .expect("accumulation overflow");
     }
-    
+
     // Expected: principal * (1 + 0.10) = 1,100,000.000000
     let expected = principal * 11000 / 10000;
     let drift = if accumulated > expected {
@@ -46,9 +41,9 @@ fn test_daily_accrual_drift_over_one_year() {
     } else {
         expected - accumulated
     };
-    
+
     let drift_bps = drift * 10000 / principal;
-    
+
     assert!(
         drift_bps <= MAX_DRIFT_BPS,
         "Interest drift exceeded {} bps over 365 accruals: got {} bps (accumulated={}, expected={})",
@@ -63,10 +58,10 @@ fn test_daily_accrual_drift_over_one_year() {
 #[test]
 fn test_hourly_vs_daily_accrual_convergence() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000_000_000_000;
     let annual_rate_bps: u32 = 1000;
-    
+
     // Daily path: 365 accruals
     let daily_rate = annual_rate_bps / 365;
     let mut daily_accumulated = principal;
@@ -80,7 +75,7 @@ fn test_hourly_vs_daily_accrual_convergence() {
         );
         daily_accumulated = daily_accumulated.checked_add(interest).unwrap();
     }
-    
+
     // Hourly path: 365 * 24 = 8760 accruals
     let hourly_rate = annual_rate_bps / (365 * 24);
     let mut hourly_accumulated = principal;
@@ -94,15 +89,15 @@ fn test_hourly_vs_daily_accrual_convergence() {
         );
         hourly_accumulated = hourly_accumulated.checked_add(interest).unwrap();
     }
-    
+
     let diff = if daily_accumulated > hourly_accumulated {
         daily_accumulated - hourly_accumulated
     } else {
         hourly_accumulated - daily_accumulated
     };
-    
+
     let diff_bps = diff * 10000 / principal;
-    
+
     assert!(
         diff_bps <= MAX_DRIFT_BPS,
         "Hourly vs daily accrual divergence exceeded {} bps: got {} bps",
@@ -115,13 +110,13 @@ fn test_hourly_vs_daily_accrual_convergence() {
 #[test]
 fn test_small_principal_high_rate_drift() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000; // Very small
     let annual_rate_bps: u32 = 5000; // 50% APR
     let daily_rate = annual_rate_bps / 365;
-    
+
     let mut accumulated = principal;
-    
+
     for _ in 0..365 {
         let interest = compute_compound_interest(
             &env,
@@ -132,31 +127,28 @@ fn test_small_principal_high_rate_drift() {
         );
         accumulated = accumulated.checked_add(interest).unwrap_or(accumulated);
     }
-    
+
     // With small principals, rounding dominates; ensure no negative drift
-    assert!(accumulated >= principal, "Interest must never reduce principal");
+    assert!(
+        accumulated >= principal,
+        "Interest must never reduce principal"
+    );
 }
 
 /// Test edge case: zero rate produces no drift.
 #[test]
 fn test_zero_rate_no_drift() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000_000_000_000;
     let mut accumulated = principal;
-    
+
     for _ in 0..365 {
-        let interest = compute_compound_interest(
-            &env,
-            accumulated,
-            0,
-            1,
-            RoundingMode::HalfUp,
-        );
+        let interest = compute_compound_interest(&env, accumulated, 0, 1, RoundingMode::HalfUp);
         assert_eq!(interest, 0, "Zero rate must produce zero interest");
         accumulated = accumulated.checked_add(interest).unwrap();
     }
-    
+
     assert_eq!(accumulated, principal, "Zero rate must produce no drift");
 }
 
@@ -164,32 +156,29 @@ fn test_zero_rate_no_drift() {
 #[test]
 fn test_rounding_mode_divergence_bound() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000_000_000_000;
     let rate: i128 = 100; // 1% per period
     let periods = 100;
-    
+
     let mut half_up_acc = principal;
     let mut down_acc = principal;
-    
+
     for _ in 0..periods {
-        let half_up_interest = compute_compound_interest(
-            &env, half_up_acc, rate, 1, RoundingMode::HalfUp,
-        );
-        let down_interest = compute_compound_interest(
-            &env, down_acc, rate, 1, RoundingMode::Down,
-        );
-        
+        let half_up_interest =
+            compute_compound_interest(&env, half_up_acc, rate, 1, RoundingMode::HalfUp);
+        let down_interest = compute_compound_interest(&env, down_acc, rate, 1, RoundingMode::Down);
+
         half_up_acc = half_up_acc.checked_add(half_up_interest).unwrap();
         down_acc = down_acc.checked_add(down_interest).unwrap();
     }
-    
+
     let diff = if half_up_acc > down_acc {
         half_up_acc - down_acc
     } else {
         down_acc - half_up_acc
     };
-    
+
     // Divergence should be bounded by number of periods * 1 unit
     assert!(
         diff <= periods as i128,

--- a/stellar-lend/contracts/lending/views.md
+++ b/stellar-lend/contracts/lending/views.md
@@ -39,6 +39,16 @@ This document describes the view functions for user collateral value, debt value
   - No debt: returns `HEALTH_FACTOR_NO_DEBT` (100_000_000), meaning "healthy".
   - Overflow in calculation: returns `i128::MAX`.
 
+### Pinned edge cases
+
+The `health_factor_edge_test` suite pins both `get_position().health_factor` and
+`get_health_factor(user)` for the boundary cases liquidation bots depend on:
+
+- zero collateral with non-zero debt returns exactly `0`;
+- collateral exactly at the 80% liquidation threshold returns `10000`;
+- collateral just past the checked-multiply boundary returns `i128::MAX` instead of wrapping;
+- zero debt returns the `HEALTH_FACTOR_NO_DEBT` sentinel even when collateral exists.
+
 ---
 
 ## 3. `get_debt_position(user: Address) -> DebtPosition`


### PR DESCRIPTION
## Summary

Adds focused coverage for the health-factor boundary cases requested in #977 and documents the pinned edge cases in `views.md`.

## Changes

- Added `health_factor_edge_test` covering:
  - zero collateral + non-zero debt => `0`
  - collateral exactly at the liquidation threshold => `10000`
  - checked-multiply overflow => `i128::MAX`
  - zero debt with collateral => `HEALTH_FACTOR_NO_DEBT`
- Asserts `get_position().health_factor` and `get_health_factor(user)` agree for every case.
- Cross-linked the edge cases from `contracts/lending/views.md`.

Closes #977.

## Validation

- `RUSTUP_TOOLCHAIN=stable cargo test -p stellarlend-lending --lib health_factor_edge -- --nocapture`
  - 4 passed, 0 failed.
- `RUSTUP_TOOLCHAIN=stable cargo test -p stellarlend-lending --lib`
  - 93 passed, 0 failed.
- `git diff --cached --check` before commit and `git diff --check` after commit passed.

## Notes

- Full `cargo test -p stellarlend-lending` is blocked by pre-existing integration-test setup failures in this checkout: missing `target/wasm32-unknown-unknown/release/stellar_lend.wasm`, unresolved `stellar_lend_contract` imports, and current `cross_contract_invocation` API mismatches. The new coverage is in the library test suite and passes there.
- `cargo fmt --check`/workspace formatting is blocked by pre-existing repository issues, including an unexpected closing delimiter in `contracts/hello-world/src/lib.rs` and existing rustfmt drift in unrelated files. This PR does not touch those files.
