### PR TITLE
fix(lending): replace unchecked arithmetic with checked_mul/checked_div in liquidate

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -8,19 +8,19 @@ pub mod rounding_strategy;
 #[cfg(test)]
 mod deposit_accounting_test;
 #[cfg(test)]
-mod interest_drift_regression_test;
-#[cfg(test)]
 mod error_codes_test;
+#[cfg(test)]
+mod interest_drift_regression_test;
 
 use debt::{
     borrow_amount, effective_debt, load_debt, repay_amount, save_debt, DebtPosition,
     DEFAULT_APR_BPS,
 };
+use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, BytesN,
     Env, IntoVal, Symbol, Val,
 };
-use soroban_sdk::xdr::ToXdr;
 
 const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
 const DEFAULT_DEPOSIT_CAP: i128 = 1_000_000_000_000;
@@ -574,7 +574,9 @@ impl LendingContract {
         if fee_bps < 0 || fee_bps > 1000 {
             return Err(LendingError::InvalidFeeBps);
         }
-        env.storage().instance().set(&DataKey::FlashFeeBps, &fee_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::FlashFeeBps, &fee_bps);
         Ok(())
     }
 
@@ -972,7 +974,7 @@ mod test {
         let mut payload_bytes = [0u8; 1024];
         let len = payload.len() as usize;
         payload.copy_into_slice(&mut payload_bytes[..len]);
-        
+
         let signature = keypair.sign(&payload_bytes[..len]);
         BytesN::from_array(env, &signature.to_bytes())
     }
@@ -1081,7 +1083,9 @@ mod test {
         let signature = sign_oracle_update(&env, &keypair, &asset, price, timestamp);
 
         client.set_price(&admin, &asset, &price, &timestamp, &signature);
-        let record = client.get_price_record(&asset).expect("price record stored");
+        let record = client
+            .get_price_record(&asset)
+            .expect("price record stored");
         assert_eq!(record.price, price);
         assert_eq!(record.timestamp, timestamp);
     }
@@ -1095,8 +1099,11 @@ mod test {
         let bad_seed = [43u8; 32];
         let bad_secret = ed25519_dalek::SecretKey::from_bytes(&bad_seed).unwrap();
         let bad_public = ed25519_dalek::PublicKey::from(&bad_secret);
-        let bad_keypair = Keypair { secret: bad_secret, public: bad_public };
-        
+        let bad_keypair = Keypair {
+            secret: bad_secret,
+            public: bad_public,
+        };
+
         let pubkey = BytesN::from_array(&env, &keypair.public.to_bytes());
         client.set_oracle_pubkey(&pubkey);
 

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -458,14 +458,20 @@ impl LendingContract {
         }
 
         const LIQUIDATION_THRESHOLD: i128 = 8000;
-        let hf = (collateral * LIQUIDATION_THRESHOLD) / debt;
+        let hf = collateral
+            .checked_mul(LIQUIDATION_THRESHOLD)
+            .and_then(|v| v.checked_div(debt))
+            .ok_or(LendingError::Overflow)?;
 
         if hf >= 10000 {
             return Err(LendingError::PositionHealthy);
         }
 
         const CLOSE_FACTOR: i128 = 5000;
-        let max_repay = (debt * CLOSE_FACTOR) / 10000;
+        let max_repay = debt
+            .checked_mul(CLOSE_FACTOR)
+            .and_then(|v| v.checked_div(10000))
+            .ok_or(LendingError::Overflow)?;
         let actual_repay = if amount > max_repay {
             max_repay
         } else {
@@ -473,7 +479,10 @@ impl LendingContract {
         };
 
         const INCENTIVE_BPS: i128 = 1000;
-        let seized_collateral = (actual_repay * (10000 + INCENTIVE_BPS)) / 10000;
+        let seized_collateral = actual_repay
+            .checked_mul(10000 + INCENTIVE_BPS)
+            .and_then(|v| v.checked_div(10000))
+            .ok_or(LendingError::Overflow)?;
 
         // Ensure we don't seize more than available
         let final_seized = if seized_collateral > collateral {

--- a/stellar-lend/contracts/lending/src/math.rs
+++ b/stellar-lend/contracts/lending/src/math.rs
@@ -67,9 +67,7 @@ pub fn compute_compound_interest(
     let seconds_per_year: i128 = 31_536_000; // 365 * 24 * 3600
 
     // Step 1: principal * rate_bps (checked)
-    let step1 = principal
-        .checked_mul(rate_bps)
-        .ok_or(MathError::Overflow)?;
+    let step1 = principal.checked_mul(rate_bps).ok_or(MathError::Overflow)?;
 
     // Step 2: step1 * elapsed (checked)
     let step2 = step1
@@ -190,26 +188,31 @@ pub fn compute_borrow_rate(
             util.checked_mul(mult)
                 .ok_or(MathError::Overflow)?
                 .checked_div(scale)
-                .ok_or(MathError::DivisionByZero)?
-        ).ok_or(MathError::Overflow)?
+                .ok_or(MathError::DivisionByZero)?,
+        )
+        .ok_or(MathError::Overflow)?
     } else {
         // rate = base + kink * multiplier / SCALE + (util - kink) * jump_multiplier / SCALE
-        let base_plus_kink = base.checked_add(
-            kink.checked_mul(mult)
-                .ok_or(MathError::Overflow)?
-                .checked_div(scale)
-                .ok_or(MathError::DivisionByZero)?
-        ).ok_or(MathError::Overflow)?;
+        let base_plus_kink = base
+            .checked_add(
+                kink.checked_mul(mult)
+                    .ok_or(MathError::Overflow)?
+                    .checked_div(scale)
+                    .ok_or(MathError::DivisionByZero)?,
+            )
+            .ok_or(MathError::Overflow)?;
 
-        let excess_util = util.checked_sub(kink)
-            .ok_or(MathError::NegativeResult)?;
+        let excess_util = util.checked_sub(kink).ok_or(MathError::NegativeResult)?;
 
-        base_plus_kink.checked_add(
-            excess_util.checked_mul(jump_mult)
-                .ok_or(MathError::Overflow)?
-                .checked_div(scale)
-                .ok_or(MathError::DivisionByZero)?
-        ).ok_or(MathError::Overflow)?
+        base_plus_kink
+            .checked_add(
+                excess_util
+                    .checked_mul(jump_mult)
+                    .ok_or(MathError::Overflow)?
+                    .checked_div(scale)
+                    .ok_or(MathError::DivisionByZero)?,
+            )
+            .ok_or(MathError::Overflow)?
     };
 
     // Clamp to MAX_RATE_BPS
@@ -256,7 +259,8 @@ pub fn compute_supply_rate(
         .ok_or(MathError::DivisionByZero)?;
 
     // (1 - reserve_factor) = (SCALE - reserve) / SCALE
-    let one_minus_reserve = scale.checked_sub(reserve)
+    let one_minus_reserve = scale
+        .checked_sub(reserve)
         .ok_or(MathError::NegativeResult)?;
 
     // rate_util * one_minus_reserve / SCALE
@@ -312,10 +316,7 @@ pub fn compute_liquidation_bonus(
 /// # Returns
 /// * `Ok(max_borrow)` - Maximum borrowable amount
 /// * `Err(MathError)` - On overflow or invalid input
-pub fn compute_max_borrow(
-    collateral_value: i128,
-    ltv_bps: u32,
-) -> Result<i128, MathError> {
+pub fn compute_max_borrow(collateral_value: i128, ltv_bps: u32) -> Result<i128, MathError> {
     if collateral_value < 0 {
         return Err(MathError::OutOfRange);
     }
@@ -354,10 +355,7 @@ pub fn is_liquidatable(health_factor: i128) -> bool {
 /// # Returns
 /// * `Ok(utilization_bps)` - Utilization in basis points
 /// * `Err(MathError)` - On overflow or invalid input
-pub fn compute_utilization(
-    total_borrows: i128,
-    total_deposits: i128,
-) -> Result<u32, MathError> {
+pub fn compute_utilization(total_borrows: i128, total_deposits: i128) -> Result<u32, MathError> {
     if total_borrows < 0 || total_deposits < 0 {
         return Err(MathError::OutOfRange);
     }

--- a/stellar-lend/contracts/lending/tests/interest_drift_regression_test.rs
+++ b/stellar-lend/contracts/lending/tests/interest_drift_regression_test.rs
@@ -2,14 +2,8 @@ use soroban_sdk::{testutils::Address as _, Address, Env};
 use stellar_lend_contract::LendingContract;
 
 // Import the live module paths from the lending crate
-use stellar_lend_contract::rounding_strategy::{
-    compute_compound_interest, 
-    RoundingMode,
-};
-use stellar_lend_contract::interest_model::{
-    InterestRateModel,
-    AccrualConfig,
-};
+use stellar_lend_contract::interest_model::{AccrualConfig, InterestRateModel};
+use stellar_lend_contract::rounding_strategy::{compute_compound_interest, RoundingMode};
 
 /// Maximum acceptable drift per year of accrual (1 basis point = 0.01%)
 const MAX_DRIFT_BPS: i128 = 1;
@@ -18,14 +12,14 @@ const MAX_DRIFT_BPS: i128 = 1;
 #[test]
 fn test_daily_accrual_drift_over_one_year() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000_000_000_000; // 1,000,000.000000
     let annual_rate_bps: u32 = 1000; // 10% APR
     let daily_rate = annual_rate_bps / 365;
-    
+
     let mut accumulated = principal;
     let model = InterestRateModel::default();
-    
+
     // Simulate 365 daily accruals
     for day in 0..365 {
         let interest = compute_compound_interest(
@@ -35,10 +29,11 @@ fn test_daily_accrual_drift_over_one_year() {
             1, // 1 day
             RoundingMode::HalfUp,
         );
-        accumulated = accumulated.checked_add(interest)
+        accumulated = accumulated
+            .checked_add(interest)
             .expect("accumulation overflow");
     }
-    
+
     // Expected: principal * (1 + 0.10) = 1,100,000.000000
     let expected = principal * 11000 / 10000;
     let drift = if accumulated > expected {
@@ -46,9 +41,9 @@ fn test_daily_accrual_drift_over_one_year() {
     } else {
         expected - accumulated
     };
-    
+
     let drift_bps = drift * 10000 / principal;
-    
+
     assert!(
         drift_bps <= MAX_DRIFT_BPS,
         "Interest drift exceeded {} bps over 365 accruals: got {} bps (accumulated={}, expected={})",
@@ -63,10 +58,10 @@ fn test_daily_accrual_drift_over_one_year() {
 #[test]
 fn test_hourly_vs_daily_accrual_convergence() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000_000_000_000;
     let annual_rate_bps: u32 = 1000;
-    
+
     // Daily path: 365 accruals
     let daily_rate = annual_rate_bps / 365;
     let mut daily_accumulated = principal;
@@ -80,7 +75,7 @@ fn test_hourly_vs_daily_accrual_convergence() {
         );
         daily_accumulated = daily_accumulated.checked_add(interest).unwrap();
     }
-    
+
     // Hourly path: 365 * 24 = 8760 accruals
     let hourly_rate = annual_rate_bps / (365 * 24);
     let mut hourly_accumulated = principal;
@@ -94,15 +89,15 @@ fn test_hourly_vs_daily_accrual_convergence() {
         );
         hourly_accumulated = hourly_accumulated.checked_add(interest).unwrap();
     }
-    
+
     let diff = if daily_accumulated > hourly_accumulated {
         daily_accumulated - hourly_accumulated
     } else {
         hourly_accumulated - daily_accumulated
     };
-    
+
     let diff_bps = diff * 10000 / principal;
-    
+
     assert!(
         diff_bps <= MAX_DRIFT_BPS,
         "Hourly vs daily accrual divergence exceeded {} bps: got {} bps",
@@ -115,13 +110,13 @@ fn test_hourly_vs_daily_accrual_convergence() {
 #[test]
 fn test_small_principal_high_rate_drift() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000; // Very small
     let annual_rate_bps: u32 = 5000; // 50% APR
     let daily_rate = annual_rate_bps / 365;
-    
+
     let mut accumulated = principal;
-    
+
     for _ in 0..365 {
         let interest = compute_compound_interest(
             &env,
@@ -132,31 +127,28 @@ fn test_small_principal_high_rate_drift() {
         );
         accumulated = accumulated.checked_add(interest).unwrap_or(accumulated);
     }
-    
+
     // With small principals, rounding dominates; ensure no negative drift
-    assert!(accumulated >= principal, "Interest must never reduce principal");
+    assert!(
+        accumulated >= principal,
+        "Interest must never reduce principal"
+    );
 }
 
 /// Test edge case: zero rate produces no drift.
 #[test]
 fn test_zero_rate_no_drift() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000_000_000_000;
     let mut accumulated = principal;
-    
+
     for _ in 0..365 {
-        let interest = compute_compound_interest(
-            &env,
-            accumulated,
-            0,
-            1,
-            RoundingMode::HalfUp,
-        );
+        let interest = compute_compound_interest(&env, accumulated, 0, 1, RoundingMode::HalfUp);
         assert_eq!(interest, 0, "Zero rate must produce zero interest");
         accumulated = accumulated.checked_add(interest).unwrap();
     }
-    
+
     assert_eq!(accumulated, principal, "Zero rate must produce no drift");
 }
 
@@ -164,32 +156,29 @@ fn test_zero_rate_no_drift() {
 #[test]
 fn test_rounding_mode_divergence_bound() {
     let env = Env::default();
-    
+
     let principal: i128 = 1_000_000_000_000;
     let rate: i128 = 100; // 1% per period
     let periods = 100;
-    
+
     let mut half_up_acc = principal;
     let mut down_acc = principal;
-    
+
     for _ in 0..periods {
-        let half_up_interest = compute_compound_interest(
-            &env, half_up_acc, rate, 1, RoundingMode::HalfUp,
-        );
-        let down_interest = compute_compound_interest(
-            &env, down_acc, rate, 1, RoundingMode::Down,
-        );
-        
+        let half_up_interest =
+            compute_compound_interest(&env, half_up_acc, rate, 1, RoundingMode::HalfUp);
+        let down_interest = compute_compound_interest(&env, down_acc, rate, 1, RoundingMode::Down);
+
         half_up_acc = half_up_acc.checked_add(half_up_interest).unwrap();
         down_acc = down_acc.checked_add(down_interest).unwrap();
     }
-    
+
     let diff = if half_up_acc > down_acc {
         half_up_acc - down_acc
     } else {
         down_acc - half_up_acc
     };
-    
+
     // Divergence should be bounded by number of periods * 1 unit
     assert!(
         diff <= periods as i128,


### PR DESCRIPTION
## Summary
Fixes #963 — replaces unchecked `*` and `/` operations in `liquidate()` with `checked_mul()` and `checked_div()` to prevent arithmetic overflow panics.

## Changes
- **Health factor**: `collateral * LIQUIDATION_THRESHOLD / debt` → `collateral.checked_mul(THRESHOLD).and_then(|v| v.checked_div(debt)).ok_or(Overflow)?`
- **Max repay**: `debt * CLOSE_FACTOR / 10000` → `debt.checked_mul(CLOSE_FACTOR).and_then(|v| v.checked_div(10000)).ok_or(Overflow)?`
- **Seized collateral**: `actual_repay * INCENTIVE / 10000` → `actual_repay.checked_mul(INCENTIVE).and_then(|v| v.checked_div(10000)).ok_or(Overflow)?`

## Rationale
The `liquidate` function was the only fund-moving path in the lending contract that used raw, unchecked arithmetic. Other paths (flash_loan, get_position, get_health_factor, repay) already use `checked_mul`/`checked_div`. This fix aligns the liquidate path with the codebase's defensive arithmetic convention, returning `LendingError::Overflow` instead of trapping on overflow.

## Testing
Existing tests cover the liquidate path. No behavioral change — only replaces arithmetic operators with their checked variants.
