### PR TITLE
feat(lending): configure liquidation risk params

### DIFF
--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -60,7 +60,15 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 | `withdraw` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | New collateral balance | Removes `amount` from the user's collateral. Only allowed in Normal and Recovery states. |
 | `borrow` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Updated debt principal | Increases user debt; enforces `min_borrow` and protocol debt ceiling. Blocked during Shutdown/Recovery. |
 | `repay` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Remaining debt principal | Reduces user debt with interest accrued up to the current timestamp. Allowed in Normal and Recovery. |
-| `liquidate` | `(env, liquidator: Address, borrower: Address, amount: i128) → Result<i128, LendingError>` | `liquidator` | Actual debt repaid | Repays up to 50% of an undercollateralized borrower's debt and seizes proportional collateral (+ 10% bonus). Reverts if position is healthy (`hf >= 10000`). |
+| `liquidate` | `(env, liquidator: Address, borrower: Address, amount: i128) → Result<i128, LendingError>` | `liquidator` | Actual debt repaid | Repays up to the configured close factor of an undercollateralized borrower's debt and seizes proportional collateral plus the configured incentive. Reverts if position is healthy (`hf >= 10000`). |
+
+### Risk Parameter Controls
+
+| Function | Bounds | Default | Notes |
+|---|---:|---:|---|
+| `set_liquidation_threshold_bps(env, bps)` / `get_liquidation_threshold_bps(env)` | `1..=10000` | `8000` | Admin-only setter; health-factor views and liquidation eligibility read this value from storage. |
+| `set_close_factor_bps(env, bps)` / `get_close_factor_bps(env)` | `1..=10000` | `5000` | Admin-only setter; caps the maximum debt a liquidator can repay in one liquidation. |
+| `set_liquidation_incentive_bps(env, bps)` / `get_liquidation_incentive_bps(env)` | `0..=5000` | `1000` | Admin-only setter; controls the collateral bonus applied to the repaid amount. |
 
 ### Flash Loans
 
@@ -140,8 +148,6 @@ The functions listed below appear in older documentation but are **not yet imple
 |---|---|
 | `set_oracle(env, admin, oracle)` | External oracle contract adapter; signed `set_oracle_pubkey` / `set_price` flow is implemented today. |
 | `set_pause(env, admin, pause_type, paused)` | Granular per-operation pausing (currently only global via `set_emergency_state`). |
-| `set_liquidation_threshold_bps(env, admin, bps)` | Configurable liquidation threshold (currently hardcoded at 8000 BPS). |
-| `set_close_factor_bps(env, admin, bps)` | Configurable close factor (currently hardcoded at 5000 BPS). |
 | `get_collateral_value(env, user)` | USD-denominated collateral value (requires oracle). |
 | `get_debt_value(env, user)` | USD-denominated debt value (requires oracle). |
 | `get_max_liquidatable_amount(env, user)` | Convenience helper for liquidators. |

--- a/stellar-lend/contracts/lending/risk_params.md
+++ b/stellar-lend/contracts/lending/risk_params.md
@@ -1,0 +1,13 @@
+# Risk Parameters
+
+StellarLend exposes admin-only controls for liquidation risk parameters while preserving the historical defaults.
+
+| Parameter | Storage key | Default | Bounds | Used by |
+|---|---|---:|---:|---|
+| Liquidation threshold | `DataKey::LiquidationThresholdBps` | `8000` | `1..=10000` | `liquidate`, `get_position`, `get_health_factor` |
+| Close factor | `DataKey::CloseFactorBps` | `5000` | `1..=10000` | `liquidate` |
+| Liquidation incentive | `DataKey::LiquidationIncentiveBps` | `1000` | `0..=5000` | `liquidate` |
+
+Setters require the current admin signature and reject out-of-range values with `LendingError::InvalidFeeBps` before writing storage. Getters return the defaults until an admin stores an override.
+
+Operationally, risk teams can raise the liquidation threshold to make positions liquidatable sooner, lower the close factor to reduce single-transaction borrower impact, or tune the incentive to balance liquidator participation against borrower collateral loss.

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -32,6 +32,8 @@ const DEFAULT_DEPOSIT_CAP: i128 = 1_000_000_000_000;
 const HEALTH_FACTOR_SCALE: i128 = 10_000;
 const HEALTH_FACTOR_NO_DEBT: i128 = 100_000_000;
 pub const LIQUIDATION_THRESHOLD_BPS: i128 = 8000;
+const DEFAULT_CLOSE_FACTOR_BPS: i128 = 5000;
+const DEFAULT_LIQUIDATION_INCENTIVE_BPS: i128 = 1000;
 const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
 const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
@@ -58,6 +60,9 @@ pub enum DataKey {
     Guardian,
     PauseState(PauseType),
     RateParams,
+    LiquidationThresholdBps,
+    CloseFactorBps,
+    LiquidationIncentiveBps,
 }
 
 #[contractevent]
@@ -322,6 +327,51 @@ impl LendingContract {
             .unwrap_or(0)
     }
 
+    /// Set the liquidation threshold in basis points (admin-only). Must be in (0, 10000].
+    pub fn set_liquidation_threshold_bps(env: Env, bps: i128) -> Result<(), LendingError> {
+        let admin = Self::get_admin(env.clone());
+        admin.require_auth();
+        validate_positive_bps(bps)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::LiquidationThresholdBps, &bps);
+        Ok(())
+    }
+
+    pub fn get_liquidation_threshold_bps(env: Env) -> i128 {
+        get_liquidation_threshold_bps(&env)
+    }
+
+    /// Set the close factor in basis points (admin-only). Must be in (0, 10000].
+    pub fn set_close_factor_bps(env: Env, bps: i128) -> Result<(), LendingError> {
+        let admin = Self::get_admin(env.clone());
+        admin.require_auth();
+        validate_positive_bps(bps)?;
+        env.storage().instance().set(&DataKey::CloseFactorBps, &bps);
+        Ok(())
+    }
+
+    pub fn get_close_factor_bps(env: Env) -> i128 {
+        get_close_factor_bps(&env)
+    }
+
+    /// Set the liquidation incentive in basis points (admin-only). Must be in [0, 5000].
+    pub fn set_liquidation_incentive_bps(env: Env, bps: i128) -> Result<(), LendingError> {
+        let admin = Self::get_admin(env.clone());
+        admin.require_auth();
+        if !(0..=5000).contains(&bps) {
+            return Err(LendingError::InvalidFeeBps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::LiquidationIncentiveBps, &bps);
+        Ok(())
+    }
+
+    pub fn get_liquidation_incentive_bps(env: Env) -> i128 {
+        get_liquidation_incentive_bps(&env)
+    }
+
     /// Deposit collateral for a user.
     pub fn deposit(env: Env, user: Address, amount: i128) -> Result<i128, LendingError> {
         check_emergency_status(&env, ProtocolAction::Deposit);
@@ -461,9 +511,9 @@ impl LendingContract {
             return Err(LendingError::PositionHealthy);
         }
 
-        const LIQUIDATION_THRESHOLD: i128 = 8000;
+        let liquidation_threshold = get_liquidation_threshold_bps(&env);
         let hf = collateral
-            .checked_mul(LIQUIDATION_THRESHOLD)
+            .checked_mul(liquidation_threshold)
             .and_then(|v| v.checked_div(debt))
             .ok_or(LendingError::Overflow)?;
 
@@ -471,9 +521,9 @@ impl LendingContract {
             return Err(LendingError::PositionHealthy);
         }
 
-        const CLOSE_FACTOR: i128 = 5000;
+        let close_factor = get_close_factor_bps(&env);
         let max_repay = debt
-            .checked_mul(CLOSE_FACTOR)
+            .checked_mul(close_factor)
             .and_then(|v| v.checked_div(10000))
             .ok_or(LendingError::Overflow)?;
         let actual_repay = if amount > max_repay {
@@ -482,9 +532,9 @@ impl LendingContract {
             amount
         };
 
-        const INCENTIVE_BPS: i128 = 1000;
+        let incentive_bps = get_liquidation_incentive_bps(&env);
         let seized_collateral = actual_repay
-            .checked_mul(10000 + INCENTIVE_BPS)
+            .checked_mul(10000 + incentive_bps)
             .and_then(|v| v.checked_div(10000))
             .ok_or(LendingError::Overflow)?;
 
@@ -683,7 +733,7 @@ impl LendingContract {
             effective_debt(&position, env.ledger().timestamp(), rate).unwrap_or(position.principal);
 
         let health_factor = if debt > 0 {
-            col.checked_mul(LIQUIDATION_THRESHOLD_BPS)
+            col.checked_mul(get_liquidation_threshold_bps(&env))
                 .map(|v| v / debt)
                 .unwrap_or(i128::MAX)
         } else {
@@ -698,7 +748,7 @@ impl LendingContract {
     }
 
     /// Get the health factor for a user. Read-only view.
-    /// Computed as: `(collateral * LIQUIDATION_THRESHOLD_BPS) / debt`
+    /// Computed as: `(collateral * liquidation_threshold_bps) / debt`
     /// Returns `HEALTH_FACTOR_NO_DEBT` sentinel if user has no debt.
     /// Scale: `HEALTH_FACTOR_SCALE` (10000 = 1.0).
     pub fn get_health_factor(env: Env, user: Address) -> i128 {
@@ -716,7 +766,7 @@ impl LendingContract {
             .max(0);
 
         if debt > 0 {
-            col.checked_mul(LIQUIDATION_THRESHOLD_BPS)
+            col.checked_mul(get_liquidation_threshold_bps(&env))
                 .map(|v| v / debt)
                 .unwrap_or(i128::MAX)
         } else {
@@ -835,6 +885,34 @@ fn set_emergency_state_internal(env: &Env, state: EmergencyState) {
     env.storage()
         .instance()
         .set(&DataKey::EmergencyState, &state);
+}
+
+fn validate_positive_bps(bps: i128) -> Result<(), LendingError> {
+    if bps <= 0 || bps > BPS_DENOM {
+        return Err(LendingError::InvalidFeeBps);
+    }
+    Ok(())
+}
+
+fn get_liquidation_threshold_bps(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::LiquidationThresholdBps)
+        .unwrap_or(LIQUIDATION_THRESHOLD_BPS)
+}
+
+fn get_close_factor_bps(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::CloseFactorBps)
+        .unwrap_or(DEFAULT_CLOSE_FACTOR_BPS)
+}
+
+fn get_liquidation_incentive_bps(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::LiquidationIncentiveBps)
+        .unwrap_or(DEFAULT_LIQUIDATION_INCENTIVE_BPS)
 }
 
 fn check_emergency_status(env: &Env, action: ProtocolAction) {
@@ -1054,6 +1132,86 @@ mod test {
             "expected InvalidFeeBps, got {:?}",
             res
         );
+    }
+
+    #[test]
+    fn test_liquidation_param_getters_default_and_update() {
+        let (_env, client, _admin, _user) = setup();
+        assert_eq!(
+            client.get_liquidation_threshold_bps(),
+            LIQUIDATION_THRESHOLD_BPS
+        );
+        assert_eq!(client.get_close_factor_bps(), DEFAULT_CLOSE_FACTOR_BPS);
+        assert_eq!(
+            client.get_liquidation_incentive_bps(),
+            DEFAULT_LIQUIDATION_INCENTIVE_BPS
+        );
+
+        client.set_liquidation_threshold_bps(&9_000);
+        client.set_close_factor_bps(&7_500);
+        client.set_liquidation_incentive_bps(&500);
+
+        assert_eq!(client.get_liquidation_threshold_bps(), 9_000);
+        assert_eq!(client.get_close_factor_bps(), 7_500);
+        assert_eq!(client.get_liquidation_incentive_bps(), 500);
+    }
+
+    #[test]
+    fn test_liquidation_param_bounds() {
+        let (_env, client, _admin, _user) = setup();
+        assert_eq!(
+            client.try_set_liquidation_threshold_bps(&0),
+            Err(Ok(LendingError::InvalidFeeBps))
+        );
+        assert_eq!(
+            client.try_set_liquidation_threshold_bps(&10_001),
+            Err(Ok(LendingError::InvalidFeeBps))
+        );
+        assert_eq!(
+            client.try_set_close_factor_bps(&0),
+            Err(Ok(LendingError::InvalidFeeBps))
+        );
+        assert_eq!(
+            client.try_set_close_factor_bps(&10_001),
+            Err(Ok(LendingError::InvalidFeeBps))
+        );
+        assert_eq!(
+            client.try_set_liquidation_incentive_bps(&-1),
+            Err(Ok(LendingError::InvalidFeeBps))
+        );
+        assert_eq!(
+            client.try_set_liquidation_incentive_bps(&5_001),
+            Err(Ok(LendingError::InvalidFeeBps))
+        );
+
+        assert_eq!(
+            client.try_set_liquidation_threshold_bps(&10_000),
+            Ok(Ok(()))
+        );
+        assert_eq!(client.try_set_close_factor_bps(&10_000), Ok(Ok(())));
+        assert_eq!(client.try_set_liquidation_incentive_bps(&5_000), Ok(Ok(())));
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized")]
+    fn test_random_caller_cannot_set_liquidation_params() {
+        let env2 = Env::default();
+        let id2 = env2.register(LendingContract, ());
+        let client2 = LendingContractClient::new(&env2, &id2);
+        let admin2 = Address::generate(&env2);
+        let attacker = Address::generate(&env2);
+        env2.mock_all_auths();
+        client2.initialize(&admin2);
+        env2.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &id2,
+                fn_name: "set_close_factor_bps",
+                args: (7_500i128,).into_val(&env2),
+                sub_invokes: &[],
+            },
+        }]);
+        client2.set_close_factor_bps(&7_500);
     }
 
     // -----------------------------------------------------------------------
@@ -1289,6 +1447,38 @@ mod test {
         let hf = client.get_health_factor(&user);
         let pos = client.get_position(&user);
         assert_eq!(hf, pos.health_factor);
+    }
+
+    #[test]
+    fn test_configured_liquidation_threshold_drives_health_views() {
+        let (_env, client, _admin, user) = setup();
+        client.deposit(&user, &100);
+        client.borrow(&user, &90);
+
+        assert!(client.get_health_factor(&user) < HEALTH_FACTOR_SCALE);
+
+        client.set_liquidation_threshold_bps(&10_000);
+        let hf = client.get_health_factor(&user);
+        let pos = client.get_position(&user);
+        assert!(hf > HEALTH_FACTOR_SCALE);
+        assert_eq!(hf, pos.health_factor);
+    }
+
+    #[test]
+    fn test_configured_close_factor_and_incentive_drive_liquidation() {
+        let (env, client, _admin, borrower) = setup();
+        let liquidator = Address::generate(&env);
+        client.deposit(&borrower, &100);
+        client.borrow(&borrower, &200);
+        client.set_close_factor_bps(&2_500);
+        client.set_liquidation_incentive_bps(&0);
+
+        let actual_repay = client.liquidate(&liquidator, &borrower, &200);
+        let pos = client.get_position(&borrower);
+
+        assert_eq!(actual_repay, 50);
+        assert_eq!(pos.debt, 150);
+        assert_eq!(pos.collateral, 50);
     }
 
     #[test]

--- a/stellar-lend/contracts/lending/views.md
+++ b/stellar-lend/contracts/lending/views.md
@@ -17,7 +17,7 @@ This document describes the view functions for user collateral value, debt value
 - **Purpose:** Returns the user's position summary: raw collateral balance, effective debt (principal + accrued interest), and health factor.
 - **Read-only:** Yes. Extends TTL for active positions.
 - **Returns:** `PositionSummary { collateral: i128, debt: i128, health_factor: i128 }`. Zero-valued fields if the user has no position.
-- **Health factor formula:** `(collateral * LIQUIDATION_THRESHOLD_BPS) / debt` with `LIQUIDATION_THRESHOLD_BPS = 8000` (80%).
+- **Health factor formula:** `(collateral * liquidation_threshold_bps) / debt`, where `liquidation_threshold_bps` is storage-backed and defaults to 8000 (80%).
 - **Special health factor values:**
   - No debt: returns `HEALTH_FACTOR_NO_DEBT` (100_000_000), meaning "healthy".
   - Overflow in calculation: returns `i128::MAX`.
@@ -26,11 +26,11 @@ This document describes the view functions for user collateral value, debt value
 
 ## 2. `get_health_factor(user: Address) -> i128`
 
-- **Purpose:** Health factor for liquidations and UI. Computed from raw collateral, effective debt, and the hardcoded liquidation threshold.
+- **Purpose:** Health factor for liquidations and UI. Computed from raw collateral, effective debt, and the configured liquidation threshold.
 - **Read-only:** Yes. Extends TTL for active positions.
 - **Formula:**  
-  `health_factor = (collateral * LIQUIDATION_THRESHOLD_BPS) / debt`  
-  with `LIQUIDATION_THRESHOLD_BPS = 8000` (80%) and implicit `HEALTH_FACTOR_SCALE = 10000`, so **10000 = 1.0**.
+  `health_factor = (collateral * liquidation_threshold_bps) / debt`  
+  with `liquidation_threshold_bps` defaulting to 8000 (80%) and implicit `HEALTH_FACTOR_SCALE = 10000`, so **10000 = 1.0**.
 - **Interpretation:**
   - **> 10000:** Healthy (above liquidation threshold).
   - **< 10000:** Liquidatable.
@@ -62,7 +62,7 @@ The `health_factor_edge_test` suite pins both `get_position().health_factor` and
 ## Security Assumptions
 
 1. **No state change:** All view functions only read storage. They do not modify protocol or user state beyond TTL extension.
-2. **Liquidation threshold:** Currently hardcoded at 8000 BPS (80%) as `LIQUIDATION_THRESHOLD_BPS`.
+2. **Liquidation threshold:** Storage-backed and admin-configurable through `set_liquidation_threshold_bps`; defaults to 8000 BPS (80%).
 3. **Overflow:** Health factor calculations use checked arithmetic where applicable; edge cases (e.g. zero debt) are handled explicitly.
 
 ---
@@ -188,4 +188,3 @@ let metrics = client.get_protocol_metrics();
 // metrics.utilization_bps =>     5_000  // 50 %
 // metrics.ledger          =>    123_456
 ```
-


### PR DESCRIPTION
## Summary
- add storage-backed liquidation threshold, close factor, and liquidation incentive params with admin-only setters/getters
- wire `liquidate`, `get_position`, and `get_health_factor` to the configured values while preserving the historical defaults
- add bounds/auth/behavior coverage and document the shipped risk controls

Closes #966

## Validation
- `cargo fmt -p stellarlend-lending --check`
- `cargo test -p stellarlend-lending --lib liquidation_param -- --nocapture`
- `cargo test -p stellarlend-lending --lib configured_liquidation -- --nocapture`
- `cargo test -p stellarlend-lending --lib close_factor -- --nocapture`
- `cargo test -p stellarlend-lending --lib`

Note: workspace-wide formatting is currently blocked by unrelated pre-existing `hello-world` parser/module issues in this repository's CI path. The lending package formatting and library test suite pass locally.
