### PR TITLE
feat(lending): emit core operation events

### DIFF
--- a/docs/EVENT_SCHEMA_VERSIONING.md
+++ b/docs/EVENT_SCHEMA_VERSIONING.md
@@ -27,6 +27,7 @@ The versioning strategy is minimal by design:
 | `WithdrawEvent` | 1 | Versioned withdraw event with user and new collateral balance. |
 | `BorrowEvent` | 1 | Versioned borrow event with user and new debt balance. |
 | `RepayEvent` | 1 | Versioned repay event with user and new debt balance. |
+| `LiquidateEvent` | 1 | Versioned liquidation event with liquidator, borrower, repaid debt, seized collateral, and post-liquidation borrower snapshot. |
 | `AmmSwapEventV1` | 1 | Versioned AMM swap event with stable `amm/v1` topics. |
 | `AmmLiquidityAddedEventV1` | 1 | Versioned AMM add-liquidity event with stable `amm/v1` topics. |
 | `AmmLiquidityRemovedEventV1` | 1 | Versioned AMM remove-liquidity event with stable `amm/v1` topics. |
@@ -54,6 +55,23 @@ explicit `event` field that matches the final topic segment.
 All other events are unversioned (no `schema_version` field). They follow an
 additive-only policy: new fields may be appended but existing fields will not
 be removed or reordered within a major version.
+
+## Lending Core Operation Events
+
+The lending contract emits these versioned event structs only after the
+corresponding operation succeeds and state has been written:
+
+| Operation | Event topic | Required payload fields |
+|---|---|---|
+| `deposit` | `deposit_event` | `schema_version`, `user`, `amount`, `resulting_balance` |
+| `withdraw` | `withdraw_event` | `schema_version`, `user`, `amount`, `resulting_balance` |
+| `borrow` | `borrow_event` | `schema_version`, `borrower`, `amount`, `resulting_debt` |
+| `repay` | `repay_event` | `schema_version`, `borrower`, `amount`, `resulting_debt` |
+| `liquidate` | `liquidate_event` | `schema_version`, `liquidator`, `borrower`, `repaid_debt`, `seized_collateral`, `resulting_debt`, `resulting_collateral` |
+
+The event payload contains public accounting state only. It intentionally does
+not include signatures, oracle payloads, or other caller-supplied secret
+material.
 
 ---
 

--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -62,6 +62,19 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 | `repay` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Remaining debt principal | Reduces user debt with interest accrued up to the current timestamp. Allowed in Normal and Recovery. |
 | `liquidate` | `(env, liquidator: Address, borrower: Address, amount: i128) → Result<i128, LendingError>` | `liquidator` | Actual debt repaid | Repays up to 50% of an undercollateralized borrower's debt and seizes proportional collateral (+ 10% bonus). Reverts if position is healthy (`hf >= 10000`). |
 
+### Core Operation Events
+
+Successful user operations emit versioned, indexable events after state is
+written:
+
+| Function | Event topic | Key payload fields |
+|---|---|---|
+| `deposit` | `deposit_event` | `schema_version`, `user`, `amount`, `resulting_balance` |
+| `withdraw` | `withdraw_event` | `schema_version`, `user`, `amount`, `resulting_balance` |
+| `borrow` | `borrow_event` | `schema_version`, `borrower`, `amount`, `resulting_debt` |
+| `repay` | `repay_event` | `schema_version`, `borrower`, `amount`, `resulting_debt` |
+| `liquidate` | `liquidate_event` | `schema_version`, `liquidator`, `borrower`, `repaid_debt`, `seized_collateral`, `resulting_debt`, `resulting_collateral` |
+
 ### Flash Loans
 
 | Function | Signature | Auth | Description |

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -35,6 +35,7 @@ pub const LIQUIDATION_THRESHOLD_BPS: i128 = 8000;
 const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
 const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
+const EVENT_SCHEMA_VERSION: u32 = 1;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -73,6 +74,54 @@ pub struct PauseStateChangedEvent {
     pub operation: PauseType,
     pub old_state: PauseState,
     pub new_state: PauseState,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DepositEvent {
+    pub schema_version: u32,
+    pub user: Address,
+    pub amount: i128,
+    pub resulting_balance: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WithdrawEvent {
+    pub schema_version: u32,
+    pub user: Address,
+    pub amount: i128,
+    pub resulting_balance: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BorrowEvent {
+    pub schema_version: u32,
+    pub borrower: Address,
+    pub amount: i128,
+    pub resulting_debt: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RepayEvent {
+    pub schema_version: u32,
+    pub borrower: Address,
+    pub amount: i128,
+    pub resulting_debt: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiquidateEvent {
+    pub schema_version: u32,
+    pub liquidator: Address,
+    pub borrower: Address,
+    pub repaid_debt: i128,
+    pub seized_collateral: i128,
+    pub resulting_debt: i128,
+    pub resulting_collateral: i128,
 }
 
 #[contracttype]
@@ -364,6 +413,13 @@ impl LendingContract {
             .persistent()
             .set(&DataKey::TotalDeposits, &new_total);
         extend_collateral_ttl(&env, &user);
+        DepositEvent {
+            schema_version: EVENT_SCHEMA_VERSION,
+            user,
+            amount,
+            resulting_balance: new_balance,
+        }
+        .publish(&env);
         Ok(new_balance)
     }
 
@@ -401,6 +457,13 @@ impl LendingContract {
                 .expect("withdraw: total deposits underflow"),
         );
         extend_collateral_ttl(&env, &user);
+        WithdrawEvent {
+            schema_version: EVENT_SCHEMA_VERSION,
+            user,
+            amount,
+            resulting_balance: new_balance,
+        }
+        .publish(&env);
         Ok(new_balance)
     }
 
@@ -440,6 +503,13 @@ impl LendingContract {
         env.storage()
             .persistent()
             .set(&DataKey::TotalDebt, &new_total_debt);
+        BorrowEvent {
+            schema_version: EVENT_SCHEMA_VERSION,
+            borrower: user,
+            amount,
+            resulting_debt: updated.principal,
+        }
+        .publish(&env);
         Ok(updated.principal)
     }
 
@@ -505,6 +575,16 @@ impl LendingContract {
         };
         save_debt(&env, &borrower, &updated_position);
         env.storage().persistent().set(&col_key, &new_col);
+        LiquidateEvent {
+            schema_version: EVENT_SCHEMA_VERSION,
+            liquidator,
+            borrower,
+            repaid_debt: actual_repay,
+            seized_collateral: final_seized,
+            resulting_debt: new_debt,
+            resulting_collateral: new_col,
+        }
+        .publish(&env);
 
         Ok(actual_repay)
     }
@@ -547,6 +627,13 @@ impl LendingContract {
             .persistent()
             .set(&DataKey::TotalDebt, &new_total_debt);
         extend_debt_ttl(&env, &user);
+        RepayEvent {
+            schema_version: EVENT_SCHEMA_VERSION,
+            borrower: user,
+            amount: repaid,
+            resulting_debt: updated.principal,
+        }
+        .publish(&env);
         Ok(updated.principal)
     }
 

--- a/stellar-lend/contracts/lending/tests/events_test.rs
+++ b/stellar-lend/contracts/lending/tests/events_test.rs
@@ -1,0 +1,160 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env,
+};
+use stellarlend_lending::{LendingContract, LendingContractClient};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, client, contract_id)
+}
+
+fn assert_last_event_contains(env: &Env, contract_id: &Address, expected_fragments: &[&str]) {
+    let all = env.events().all();
+    let filtered = all.filter_by_contract(contract_id);
+    let event = filtered.events().last().expect("expected event");
+    let debug = format!("{event:?}");
+    for fragment in expected_fragments {
+        assert!(
+            debug.contains(fragment),
+            "event debug output missing {fragment:?}: {debug}"
+        );
+    }
+}
+
+#[test]
+fn deposit_emits_versioned_event_with_resulting_balance() {
+    let (env, client, contract_id) = setup();
+    let user = Address::generate(&env);
+
+    let balance = client.deposit(&user, &125);
+
+    assert_eq!(balance, 125);
+    assert_last_event_contains(
+        &env,
+        &contract_id,
+        &[
+            "deposit_event",
+            "schema_version",
+            "U32(1)",
+            "amount",
+            "125",
+            "resulting_balance",
+            "user",
+        ],
+    );
+}
+
+#[test]
+fn withdraw_emits_versioned_event_with_resulting_balance() {
+    let (env, client, contract_id) = setup();
+    let user = Address::generate(&env);
+
+    client.deposit(&user, &500);
+    let balance = client.withdraw(&user, &175);
+
+    assert_eq!(balance, 325);
+    assert_last_event_contains(
+        &env,
+        &contract_id,
+        &[
+            "withdraw_event",
+            "schema_version",
+            "U32(1)",
+            "amount",
+            "175",
+            "resulting_balance",
+            "325",
+            "user",
+        ],
+    );
+}
+
+#[test]
+fn borrow_emits_versioned_event_with_resulting_debt() {
+    let (env, client, contract_id) = setup();
+    let borrower = Address::generate(&env);
+
+    let debt = client.borrow(&borrower, &240);
+
+    assert_eq!(debt, 240);
+    assert_last_event_contains(
+        &env,
+        &contract_id,
+        &[
+            "borrow_event",
+            "schema_version",
+            "U32(1)",
+            "amount",
+            "240",
+            "resulting_debt",
+            "borrower",
+        ],
+    );
+}
+
+#[test]
+fn full_repay_emits_versioned_event_with_zero_resulting_debt() {
+    let (env, client, contract_id) = setup();
+    let borrower = Address::generate(&env);
+
+    client.borrow(&borrower, &300);
+    let debt = client.repay(&borrower, &300);
+
+    assert_eq!(debt, 0);
+    assert_last_event_contains(
+        &env,
+        &contract_id,
+        &[
+            "repay_event",
+            "schema_version",
+            "U32(1)",
+            "amount",
+            "300",
+            "resulting_debt",
+            "0",
+            "borrower",
+        ],
+    );
+}
+
+#[test]
+fn liquidate_emits_versioned_event_with_repaid_and_seized_amounts() {
+    let (env, client, contract_id) = setup();
+    let liquidator = Address::generate(&env);
+    let borrower = Address::generate(&env);
+
+    client.deposit(&borrower, &100);
+    client.borrow(&borrower, &200);
+    let repaid = client.liquidate(&liquidator, &borrower, &40);
+
+    assert_eq!(repaid, 40);
+    assert_last_event_contains(
+        &env,
+        &contract_id,
+        &[
+            "liquidate_event",
+            "schema_version",
+            "U32(1)",
+            "liquidator",
+            "borrower",
+            "repaid_debt",
+            "40",
+            "seized_collateral",
+            "44",
+            "resulting_debt",
+            "160",
+            "resulting_collateral",
+            "56",
+        ],
+    );
+}


### PR DESCRIPTION
## Summary
- add versioned `DepositEvent`, `WithdrawEvent`, `BorrowEvent`, `RepayEvent`, and `LiquidateEvent` contract events
- publish events only after successful core-operation state writes
- cover deposit, withdraw, borrow, full repay, and partial liquidation event payloads in `events_test.rs`
- document topics and payload fields in the lending README and event schema guide

## Tests
- `cargo fmt -p stellarlend-lending --check`
- `cargo test -p stellarlend-lending --test events_test -- --nocapture`
- `cargo test -p stellarlend-lending --lib`

Note: `cargo test -p stellarlend-lending` still hits pre-existing unrelated failures in `examples/scaling_demo.rs` (missing `main`) and `tests/cross_contract_invocation.rs` (missing prebuilt WASM / old SDK test-event assumptions).

Closes #973