### PR TITLE
fix(lending): unify health rate source

### DIFF
--- a/stellar-lend/contracts/lending/src/health_factor_consistency_test.rs
+++ b/stellar-lend/contracts/lending/src/health_factor_consistency_test.rs
@@ -1,0 +1,88 @@
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, client, id, user)
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    let mut ledger: LedgerInfo = env.ledger().get();
+    ledger.timestamp = ledger.timestamp.saturating_add(seconds);
+    ledger.sequence_number = ledger.sequence_number.saturating_add(seconds as u32);
+    env.ledger().set(ledger);
+}
+
+fn set_flat_borrow_rate(env: &Env, contract_id: &Address, rate_bps: i128) {
+    env.as_contract(contract_id, || {
+        env.storage().instance().set(
+            &DataKey::RateParams,
+            &rate_model::RateParams {
+                base_rate_bps: rate_bps,
+                kink_utilization_bps: 10_000,
+                multiplier_bps: 0,
+                jump_multiplier_bps: 0,
+                rate_floor_bps: rate_bps,
+                rate_ceiling_bps: rate_bps,
+            },
+        );
+    });
+}
+
+#[test]
+fn get_position_and_get_health_factor_share_configured_rate_source() {
+    let (env, client, id, user) = setup();
+    set_flat_borrow_rate(&env, &id, 10_000);
+
+    client.deposit(&user, &120);
+    client.borrow(&user, &80);
+    advance_time(&env, 31_536_000);
+
+    let position = client.get_position(&user);
+    let health_factor = client.get_health_factor(&user);
+
+    assert_eq!(position.health_factor, health_factor);
+    assert!(
+        position.debt > 80,
+        "configured current_borrow_rate should accrue visible interest"
+    );
+}
+
+#[test]
+fn liquidation_uses_same_configured_rate_as_health_views() {
+    let (env, client, id, borrower) = setup();
+    let liquidator = Address::generate(&env);
+    set_flat_borrow_rate(&env, &id, 10_000);
+
+    client.deposit(&borrower, &120);
+    client.borrow(&borrower, &80);
+    advance_time(&env, 31_536_000);
+
+    let viewed_health = client.get_health_factor(&borrower);
+    assert!(viewed_health < HEALTH_FACTOR_SCALE);
+
+    let repaid = client.liquidate(&liquidator, &borrower, &40);
+    assert_eq!(repaid, 40);
+}
+
+#[test]
+fn fallback_rate_keeps_position_and_health_factor_consistent() {
+    let (env, client, _id, user) = setup();
+
+    client.deposit(&user, &100);
+    client.borrow(&user, &80);
+    advance_time(&env, 31_536_000);
+
+    let position = client.get_position(&user);
+    let health_factor = client.get_health_factor(&user);
+
+    assert_eq!(position.health_factor, health_factor);
+}

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -10,6 +10,8 @@ mod deposit_accounting_test;
 #[cfg(test)]
 mod error_codes_test;
 #[cfg(test)]
+mod health_factor_consistency_test;
+#[cfg(test)]
 mod health_factor_edge_test;
 #[cfg(test)]
 mod interest_drift_regression_test;
@@ -454,8 +456,9 @@ impl LendingContract {
 
         let collateral: i128 = env.storage().persistent().get(&col_key).unwrap_or(0);
         let position = load_debt(&env, &borrower);
-        let debt = effective_debt(&position, env.ledger().timestamp(), DEFAULT_APR_BPS)
-            .unwrap_or(position.principal);
+        let rate = current_borrow_rate(&env);
+        let debt =
+            effective_debt(&position, env.ledger().timestamp(), rate).unwrap_or(position.principal);
 
         if debt == 0 {
             return Err(LendingError::PositionHealthy);
@@ -711,7 +714,8 @@ impl LendingContract {
         if position.principal != 0 {
             extend_debt_ttl(&env, &user);
         }
-        let debt = effective_debt(&position, env.ledger().timestamp(), DEFAULT_APR_BPS)
+        let rate = current_borrow_rate(&env);
+        let debt = effective_debt(&position, env.ledger().timestamp(), rate)
             .unwrap_or(position.principal)
             .max(0);
 

--- a/stellar-lend/contracts/lending/views.md
+++ b/stellar-lend/contracts/lending/views.md
@@ -17,6 +17,8 @@ This document describes the view functions for user collateral value, debt value
 - **Purpose:** Returns the user's position summary: raw collateral balance, effective debt (principal + accrued interest), and health factor.
 - **Read-only:** Yes. Extends TTL for active positions.
 - **Returns:** `PositionSummary { collateral: i128, debt: i128, health_factor: i128 }`. Zero-valued fields if the user has no position.
+- **Rate source:** Effective debt uses `current_borrow_rate(&env)`, the same
+  source used by `get_health_factor` and liquidation execution.
 - **Health factor formula:** `(collateral * LIQUIDATION_THRESHOLD_BPS) / debt` with `LIQUIDATION_THRESHOLD_BPS = 8000` (80%).
 - **Special health factor values:**
   - No debt: returns `HEALTH_FACTOR_NO_DEBT` (100_000_000), meaning "healthy".
@@ -28,6 +30,9 @@ This document describes the view functions for user collateral value, debt value
 
 - **Purpose:** Health factor for liquidations and UI. Computed from raw collateral, effective debt, and the hardcoded liquidation threshold.
 - **Read-only:** Yes. Extends TTL for active positions.
+- **Rate source:** Effective debt uses `current_borrow_rate(&env)`, matching
+  `get_position` and `liquidate` so UI and liquidation decisions agree at the
+  same ledger height.
 - **Formula:**  
   `health_factor = (collateral * LIQUIDATION_THRESHOLD_BPS) / debt`  
   with `LIQUIDATION_THRESHOLD_BPS = 8000` (80%) and implicit `HEALTH_FACTOR_SCALE = 10000`, so **10000 = 1.0**.
@@ -63,7 +68,10 @@ The `health_factor_edge_test` suite pins both `get_position().health_factor` and
 
 1. **No state change:** All view functions only read storage. They do not modify protocol or user state beyond TTL extension.
 2. **Liquidation threshold:** Currently hardcoded at 8000 BPS (80%) as `LIQUIDATION_THRESHOLD_BPS`.
-3. **Overflow:** Health factor calculations use checked arithmetic where applicable; edge cases (e.g. zero debt) are handled explicitly.
+3. **Rate source of truth:** Position views, standalone health-factor views,
+   and liquidation execution all derive effective debt from
+   `current_borrow_rate(&env)`.
+4. **Overflow:** Health factor calculations use checked arithmetic where applicable; edge cases (e.g. zero debt) are handled explicitly.
 
 ---
 
@@ -188,4 +196,3 @@ let metrics = client.get_protocol_metrics();
 // metrics.utilization_bps =>     5_000  // 50 %
 // metrics.ledger          =>    123_456
 ```
-


### PR DESCRIPTION
## Summary
- route `liquidate` and `get_health_factor` through `current_borrow_rate(&env)` like `get_position`
- add consistency tests for configured `RateParams`, fallback rate behavior, and liquidation at the viewed health boundary
- document `current_borrow_rate` as the shared effective-debt rate source for views and liquidation

## Tests
- `cargo fmt -p stellarlend-lending --check`
- `cargo test -p stellarlend-lending --lib health_factor_consistency -- --nocapture`
- `cargo test -p stellarlend-lending --lib`

Note: full `cargo test -p stellarlend-lending` is still blocked by pre-existing unrelated example/cross-contract integration failures in this repo.

Closes #965