### PR TITLE
feat(lending): split accrued interest into protocol reserve

### DIFF
--- a/docs/RESERVE_ACCOUNTING.md
+++ b/docs/RESERVE_ACCOUNTING.md
@@ -2,15 +2,17 @@
 
 ## Overview
 
-The reserve factor determines what fraction of borrower interest is retained by
-the protocol. The remainder flows to lenders.
+The reserve factor determines what fraction of borrower interest is retained by the
+protocol when lending debt is settled. The borrower still owes the full accrued
+interest. The reserve share is credited to protocol reserves, and the remainder
+compounds into borrower principal.
 
 ```
-reserve_amount = interest_amount × reserve_factor_bps ÷ 10_000   (integer division)
-lender_amount  = interest_amount − reserve_amount
+reserve_amount = ceil(interest_amount * reserve_factor_bps / 10_000)
+lender_amount  = interest_amount - reserve_amount
 ```
 
-**Range:** 0–5000 bps (0%–50%). Default: 1000 bps (10%).
+**Range:** 0-5000 bps (0%-50%). Default: 0 bps.
 
 ---
 
@@ -18,28 +20,28 @@ lender_amount  = interest_amount − reserve_amount
 
 | Key | Type | Description |
 |---|---|---|
-| `ReserveDataKey::ReserveBalance(asset)` | `i128` | Accumulated reserve per asset (interest accrual path) |
-| `ReserveDataKey::ReserveFactor(asset)` | `i128` | Reserve factor in bps |
-| `ReserveDataKey::TotalReservesV1` | `i128` | Aggregate across all assets |
-| `ReserveDataKey::ProtocolRevenueV1` | `i128` | Cumulative revenue (never decremented) |
+| `DataKey::ReserveFactorBps` | `i128` | Admin-configured reserve factor in bps |
+| `DataKey::TotalReserve` | `i128` | Aggregate reserve accrued from lending interest |
+| `DataKey::Debt(user)` | `DebtPosition` | Borrower principal after the non-reserve interest share compounds |
 | `DepositDataKey::ProtocolReserve(asset)` | `i128` | Flash-loan fee bucket (separate from above) |
 
 > **Important:** Flash-loan fees are credited to `DepositDataKey::ProtocolReserve`,
-> not to `ReserveDataKey::ReserveBalance`. `get_total_reserves()` and
-> `get_reserve_balance()` do **not** include flash-loan fees.
+> not to `DataKey::TotalReserve`. `get_total_reserve()` does **not** include
+> flash-loan fees.
 
 ---
 
 ## Interest Accrual Path
 
-Called by the repay module on each repayment:
+Called by borrow and repay when an existing position is settled:
 
 ```
-accrue_reserve(env, asset, interest_amount)
-  → reserve_amount = interest_amount * factor / 10_000
-  → ReserveBalance += reserve_amount
-  → TotalReservesV1 += reserve_amount
-  → ProtocolRevenueV1 += reserve_amount   (monotonically non-decreasing)
+settle_accrual_with_reserve(position, now, rate, factor)
+  -> interest = accrue_interest(position.principal, elapsed, rate)
+  -> reserve_amount = ceil(interest * factor / 10_000)
+  -> compounded_interest = interest - reserve_amount
+  -> position.principal += compounded_interest
+  -> TotalReserve += reserve_amount
 ```
 
 ---
@@ -54,31 +56,29 @@ DepositDataKey::ProtocolReserve(asset) += fee
 ```
 
 Flash-loan fees are **not** routed through `accrue_reserve` and therefore do
-not appear in `get_total_reserves()` or `get_reserve_balance()`.
+not appear in `get_total_reserve()`.
 
 ---
 
 ## Rounding Semantics
 
-Integer division truncates toward zero. Consequences:
+Reserve splitting rounds up in the protocol's favor when the factor is non-zero.
+Consequences:
 
 - `reserve_amount + lender_amount == interest_amount` always (no value created or destroyed).
-- Sub-threshold interest (e.g. 1 stroop at 10% factor) yields `reserve_amount = 0`.
-- Minimum non-zero reserve: `ceil(10_000 / factor_bps)` stroops of interest.
+- Sub-threshold interest (e.g. 1 stroop at 10% factor) yields `reserve_amount = 1`.
+- Zero factor always yields `reserve_amount = 0`.
 - Flash-loan minimum non-zero fee at 9 bps: 1_112 stroops.
 
 ---
 
 ## Security Invariants
 
-1. `reserve_balance >= 0` at all times.
-2. `total_reserves == Σ per-asset reserve balances`.
-3. `protocol_revenue` is monotonically non-decreasing (withdrawals do not reduce it).
-4. Withdrawals are bounded by `reserve_balance`; excess is rejected with `InsufficientReserve`.
-5. Reserve factor is capped at 5000 bps; values above are rejected with `InvalidReserveFactor`.
-6. All arithmetic uses `checked_*` operations; overflow returns `ReserveError::Overflow`.
-7. Treasury address cannot be the contract itself (`InvalidTreasury`).
-8. Withdrawals respect the `pause_reserve` pause switch.
+1. `total_reserve >= 0` at all times.
+2. `total_reserve` is monotonically non-decreasing until a guarded reserve withdrawal is added.
+3. Reserve factor is capped at 5000 bps; values outside `[0, 5000]` are rejected.
+4. All reserve split and reserve-credit arithmetic uses checked operations.
+5. Borrower principal only receives `interest - reserve_amount`; reserve interest is not double-counted.
 
 ---
 
@@ -87,8 +87,8 @@ Integer division truncates toward zero. Consequences:
 ### 10% factor, 10_000 stroops interest
 
 ```
-reserve_amount = 10_000 × 1_000 ÷ 10_000 = 1_000
-lender_amount  = 10_000 − 1_000           = 9_000
+reserve_amount = ceil(10_000 * 1_000 / 10_000) = 1_000
+lender_amount  = 10_000 - 1_000                 = 9_000
 ```
 
 ### 9 bps flash-loan fee, 100_000 stroops loan
@@ -101,14 +101,17 @@ total_repayment = 100_000 + 90 = 100_090
 ### Near-zero rounding (10% factor, 9 stroops interest)
 
 ```
-reserve_amount = 9 × 1_000 ÷ 10_000 = 0   (truncated)
-lender_amount  = 9 − 0               = 9
+reserve_amount = ceil(9 * 1_000 / 10_000) = 1
+lender_amount  = 9 - 1                       = 8
 ```
 
 ---
 
 ## References
 
+- `contracts/lending/src/debt.rs` - reserve split and settlement helpers
+- `contracts/lending/src/lib.rs` - reserve factor setter and total reserve view
+- `contracts/lending/src/reserve_factor_test.rs` - reserve factor tests
 - `contracts/hello-world/src/reserve.rs` — accrual, withdrawal, view functions
 - `contracts/hello-world/src/flash_loan.rs` — fee calculation and fee bucket write
 - `contracts/hello-world/src/tests/reserve_test.rs` — full test suite including

--- a/docs/RESERVE_FEATURE_STATUS.md
+++ b/docs/RESERVE_FEATURE_STATUS.md
@@ -1,0 +1,40 @@
+# Reserve Feature Status
+
+## Lending Reserve Factor
+
+Implemented in `contracts/lending`.
+
+| Capability | Status | Notes |
+|---|---:|---|
+| Admin reserve factor | Done | `set_reserve_factor_bps`, bounded to `[0, 5000]` bps |
+| Reserve factor view | Done | `get_reserve_factor_bps` returns `0` when unset |
+| Total reserve view | Done | `get_total_reserve` reads `DataKey::TotalReserve` |
+| Borrow/repay accrual split | Done | Settled interest is split before principal is updated |
+| Protocol-favor rounding | Done | Positive reserve splits use ceiling division |
+| Reserve withdrawal | Not included | No withdrawal entrypoint exists in the lending contract yet |
+
+## Accounting Rule
+
+On each debt settlement:
+
+```
+interest = accrue_interest(principal, elapsed, rate_bps)
+reserve_share = ceil(interest * reserve_factor_bps / 10_000)
+principal += interest - reserve_share
+total_reserve += reserve_share
+```
+
+The borrower still owes the full accrued interest. The reserve share is separated
+into protocol accounting, while the remaining interest compounds into borrower
+principal.
+
+## Validation
+
+Covered by `contracts/lending/src/reserve_factor_test.rs`:
+
+- default zero reserve factor
+- admin-set factor bounds
+- repayment accrual split
+- accumulation across multiple settlements
+- max factor behavior
+- tiny-interest rounding in the protocol's favor

--- a/stellar-lend/contracts/lending/src/debt.rs
+++ b/stellar-lend/contracts/lending/src/debt.rs
@@ -4,6 +4,8 @@ use crate::rounding_strategy::{calculate_interest_with_rounding, RoundingError, 
 use crate::DataKey;
 
 pub const DEFAULT_APR_BPS: i128 = 500;
+pub const MAX_RESERVE_FACTOR_BPS: i128 = 5_000;
+const BPS_DENOMINATOR: i128 = 10_000;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -83,6 +85,49 @@ pub fn settle_accrual(
     })
 }
 
+pub fn split_reserve_share(interest: i128, reserve_factor_bps: i128) -> Result<i128, DebtError> {
+    if interest <= 0 || reserve_factor_bps == 0 {
+        return Ok(0);
+    }
+    if !(0..=MAX_RESERVE_FACTOR_BPS).contains(&reserve_factor_bps) {
+        return Err(DebtError::InvalidAmount);
+    }
+
+    let product = interest
+        .checked_mul(reserve_factor_bps)
+        .ok_or(DebtError::Overflow)?;
+    product
+        .checked_add(BPS_DENOMINATOR - 1)
+        .and_then(|v| v.checked_div(BPS_DENOMINATOR))
+        .ok_or(DebtError::Overflow)
+}
+
+pub fn settle_accrual_with_reserve(
+    position: &DebtPosition,
+    now: u64,
+    rate_bps: i128,
+    reserve_factor_bps: i128,
+) -> Result<(DebtPosition, i128), DebtError> {
+    let elapsed = elapsed_seconds(now, position.last_update);
+    let interest = accrue_interest(position.principal, elapsed, rate_bps)?;
+    let reserve_share = split_reserve_share(interest, reserve_factor_bps)?;
+    let compounded_interest = interest
+        .checked_sub(reserve_share)
+        .ok_or(DebtError::Overflow)?;
+    let principal = position
+        .principal
+        .checked_add(compounded_interest)
+        .ok_or(DebtError::Overflow)?;
+
+    Ok((
+        DebtPosition {
+            principal,
+            last_update: now,
+        },
+        reserve_share,
+    ))
+}
+
 pub fn effective_debt(
     position: &DebtPosition,
     now: u64,
@@ -101,18 +146,20 @@ pub fn borrow_amount(
     now: u64,
     amount: i128,
     rate_bps: i128,
-) -> Result<DebtPosition, DebtError> {
+    reserve_factor_bps: i128,
+) -> Result<(DebtPosition, i128), DebtError> {
     if amount <= 0 {
         return Err(DebtError::InvalidAmount);
     }
 
-    let mut settled = settle_accrual(&position, now, rate_bps)?;
+    let (mut settled, reserve_share) =
+        settle_accrual_with_reserve(&position, now, rate_bps, reserve_factor_bps)?;
     settled.principal = settled
         .principal
         .checked_add(amount)
         .ok_or(DebtError::Overflow)?;
     settled.last_update = now;
-    Ok(settled)
+    Ok((settled, reserve_share))
 }
 
 pub fn repay_amount(
@@ -120,17 +167,19 @@ pub fn repay_amount(
     now: u64,
     amount: i128,
     rate_bps: i128,
-) -> Result<DebtPosition, DebtError> {
+    reserve_factor_bps: i128,
+) -> Result<(DebtPosition, i128), DebtError> {
     if amount <= 0 {
         return Err(DebtError::InvalidAmount);
     }
 
-    let mut settled = settle_accrual(&position, now, rate_bps)?;
+    let (mut settled, reserve_share) =
+        settle_accrual_with_reserve(&position, now, rate_bps, reserve_factor_bps)?;
     settled.principal = if amount >= settled.principal {
         0
     } else {
         settled.principal - amount
     };
     settled.last_update = now;
-    Ok(settled)
+    Ok((settled, reserve_share))
 }

--- a/stellar-lend/contracts/lending/src/interest_ordering_time_test.rs
+++ b/stellar-lend/contracts/lending/src/interest_ordering_time_test.rs
@@ -461,8 +461,9 @@ mod interest_ordering_time_tests {
         let now = 1000 + SECONDS_PER_YEAR;
 
         // Call repay_amount directly
-        let updated = repay_amount(initial_position, now, 1_000, DEFAULT_APR_BPS)
+        let (updated, reserve_share) = repay_amount(initial_position, now, 1_000, DEFAULT_APR_BPS, 0)
             .expect("repay should succeed");
+        assert_eq!(reserve_share, 0);
 
         // Expected interest: 10,000 * 5% = 500
         let expected_interest = calculate_expected_interest(10_000, SECONDS_PER_YEAR, DEFAULT_APR_BPS);
@@ -487,17 +488,20 @@ mod interest_ordering_time_tests {
         };
 
         // Borrow 5,000 at t=1000
-        let after_borrow = borrow_amount(initial, 1000, 5_000, DEFAULT_APR_BPS)
+        let (after_borrow, reserve_share) = borrow_amount(initial, 1000, 5_000, DEFAULT_APR_BPS, 0)
             .expect("borrow should succeed");
         assert_eq!(after_borrow.principal, 5_000);
+        assert_eq!(reserve_share, 0);
 
         // Wait 6 months
         let six_months = SECONDS_PER_YEAR / 2;
         let repay_time = 1000 + six_months;
 
         // Repay 1,000
-        let after_repay = repay_amount(after_borrow, repay_time, 1_000, DEFAULT_APR_BPS)
+        let (after_repay, reserve_share) =
+            repay_amount(after_borrow, repay_time, 1_000, DEFAULT_APR_BPS, 0)
             .expect("repay should succeed");
+        assert_eq!(reserve_share, 0);
 
         // Expected interest: 5,000 * 2.5% = 125
         let interest = calculate_expected_interest(5_000, six_months, DEFAULT_APR_BPS);

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -14,11 +14,13 @@ mod health_factor_edge_test;
 #[cfg(test)]
 mod interest_drift_regression_test;
 #[cfg(test)]
+mod reserve_factor_test;
+#[cfg(test)]
 mod rounding_drift_test;
 
 use debt::{
     borrow_amount, effective_debt, load_debt, repay_amount, save_debt, DebtPosition,
-    DEFAULT_APR_BPS,
+    DEFAULT_APR_BPS, MAX_RESERVE_FACTOR_BPS,
 };
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
@@ -44,6 +46,8 @@ pub enum DataKey {
     Balance(Address, Address),
     Treasury(Address),
     TotalDebt,
+    TotalReserve,
+    ReserveFactorBps,
     TotalDeposits,
     DebtCeiling,
     DepositCap,
@@ -419,11 +423,16 @@ impl LendingContract {
         let position = load_debt(&env, &user);
         let prev_principal = position.principal;
         let rate = current_borrow_rate(&env);
-        let updated = borrow_amount(position, now, amount, rate).map_err(|e| match e {
-            debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
-            debt::DebtError::Overflow => LendingError::Overflow,
-        })?;
+        let reserve_factor_bps = Self::get_reserve_factor_bps(env.clone());
+        let (updated, reserve_share) =
+            borrow_amount(position, now, amount, rate, reserve_factor_bps).map_err(
+                |e| match e {
+                    debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
+                    debt::DebtError::Overflow => LendingError::Overflow,
+                },
+            )?;
         save_debt(&env, &user, &updated);
+        credit_total_reserve(&env, reserve_share)?;
         // Track protocol-level total debt
         let total_debt: i128 = env
             .storage()
@@ -530,11 +539,14 @@ impl LendingContract {
         let position = load_debt(&env, &user);
         let prev_principal = position.principal;
         let rate = current_borrow_rate(&env);
-        let updated = repay_amount(position, now, amount, rate).map_err(|e| match e {
-            debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
-            debt::DebtError::Overflow => LendingError::Overflow,
-        })?;
+        let reserve_factor_bps = Self::get_reserve_factor_bps(env.clone());
+        let (updated, reserve_share) =
+            repay_amount(position, now, amount, rate, reserve_factor_bps).map_err(|e| match e {
+                debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
+                debt::DebtError::Overflow => LendingError::Overflow,
+            })?;
         save_debt(&env, &user, &updated);
+        credit_total_reserve(&env, reserve_share)?;
         // Track protocol-level total debt
         let total_debt: i128 = env
             .storage()
@@ -556,6 +568,39 @@ impl LendingContract {
             extend_debt_ttl(&env, &user);
         }
         position
+    }
+
+    /// Set the protocol reserve factor in basis points (admin-only).
+    ///
+    /// The value must be between 0 and 5000 inclusive. On each settled accrual,
+    /// this percentage of borrower interest is credited to TotalReserve and the
+    /// remainder compounds into borrower principal.
+    pub fn set_reserve_factor_bps(env: Env, factor_bps: i128) -> Result<(), LendingError> {
+        let admin = Self::get_admin(env.clone());
+        admin.require_auth();
+        if !(0..=MAX_RESERVE_FACTOR_BPS).contains(&factor_bps) {
+            return Err(LendingError::InvalidFeeBps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ReserveFactorBps, &factor_bps);
+        Ok(())
+    }
+
+    /// Return the configured protocol reserve factor in basis points.
+    pub fn get_reserve_factor_bps(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ReserveFactorBps)
+            .unwrap_or(0)
+    }
+
+    /// Return total interest routed to the protocol reserve.
+    pub fn get_total_reserve(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TotalReserve)
+            .unwrap_or(0)
     }
 
     /// Set the protocol-level debt ceiling (admin-only).
@@ -875,6 +920,27 @@ fn current_borrow_rate(env: &Env) -> i128 {
         }
         None => DEFAULT_APR_BPS,
     }
+}
+
+fn credit_total_reserve(env: &Env, amount: i128) -> Result<(), LendingError> {
+    if amount == 0 {
+        return Ok(());
+    }
+    if amount < 0 {
+        return Err(LendingError::InvalidAmount);
+    }
+    let total_reserve: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::TotalReserve)
+        .unwrap_or(0);
+    let updated = total_reserve
+        .checked_add(amount)
+        .ok_or(LendingError::Overflow)?;
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalReserve, &updated);
+    Ok(())
 }
 
 #[contract]

--- a/stellar-lend/contracts/lending/src/reserve_factor_test.rs
+++ b/stellar-lend/contracts/lending/src/reserve_factor_test.rs
@@ -1,0 +1,114 @@
+use crate::debt::{split_reserve_share, DEFAULT_APR_BPS, MAX_RESERVE_FACTOR_BPS};
+use crate::rounding_strategy::SECONDS_PER_YEAR;
+use crate::{LendingContract, LendingContractClient, LendingError};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin, user)
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    let mut ledger = env.ledger().get();
+    ledger.timestamp = ledger.timestamp.saturating_add(seconds);
+    ledger.sequence_number = ledger.sequence_number.saturating_add(1);
+    env.ledger().set(ledger);
+}
+
+#[test]
+fn reserve_factor_defaults_to_zero() {
+    let (_env, client, _admin, _user) = setup();
+    assert_eq!(client.get_reserve_factor_bps(), 0);
+    assert_eq!(client.get_total_reserve(), 0);
+}
+
+#[test]
+fn reserve_factor_bounds_are_enforced() {
+    let (_env, client, _admin, _user) = setup();
+
+    client.set_reserve_factor_bps(&0);
+    assert_eq!(client.get_reserve_factor_bps(), 0);
+
+    client.set_reserve_factor_bps(&MAX_RESERVE_FACTOR_BPS);
+    assert_eq!(client.get_reserve_factor_bps(), MAX_RESERVE_FACTOR_BPS);
+
+    let too_high = MAX_RESERVE_FACTOR_BPS + 1;
+    let result = client.try_set_reserve_factor_bps(&too_high);
+    assert!(
+        matches!(result, Err(Ok(LendingError::InvalidFeeBps))),
+        "expected InvalidFeeBps, got {:?}",
+        result
+    );
+
+    let result = client.try_set_reserve_factor_bps(&-1);
+    assert!(
+        matches!(result, Err(Ok(LendingError::InvalidFeeBps))),
+        "expected InvalidFeeBps, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn repay_accrual_routes_reserve_share_and_compounds_remainder() {
+    let (env, client, _admin, user) = setup();
+
+    client.set_reserve_factor_bps(&1_000);
+    client.borrow(&user, &100_000);
+    advance_time(&env, SECONDS_PER_YEAR);
+
+    let remaining = client.repay(&user, &1_000);
+
+    assert_eq!(DEFAULT_APR_BPS, 500);
+    assert_eq!(client.get_total_reserve(), 500);
+    assert_eq!(remaining, 103_500);
+
+    let position = client.get_debt_position(&user);
+    assert_eq!(position.principal, 103_500);
+}
+
+#[test]
+fn reserve_accumulates_across_multiple_settlements() {
+    let (env, client, _admin, user) = setup();
+
+    client.set_reserve_factor_bps(&1_000);
+    client.borrow(&user, &100_000);
+
+    advance_time(&env, SECONDS_PER_YEAR);
+    client.repay(&user, &1_000);
+    assert_eq!(client.get_total_reserve(), 500);
+
+    advance_time(&env, SECONDS_PER_YEAR);
+    let remaining = client.borrow(&user, &1_000);
+
+    assert_eq!(client.get_total_reserve(), 1_018);
+    assert_eq!(remaining, 109_157);
+}
+
+#[test]
+fn max_factor_routes_half_of_interest_to_reserve() {
+    let (env, client, _admin, user) = setup();
+
+    client.set_reserve_factor_bps(&MAX_RESERVE_FACTOR_BPS);
+    client.borrow(&user, &100_000);
+    advance_time(&env, SECONDS_PER_YEAR);
+
+    let remaining = client.repay(&user, &1_000);
+
+    assert_eq!(client.get_total_reserve(), 2_500);
+    assert_eq!(remaining, 101_500);
+}
+
+#[test]
+fn tiny_interest_rounds_reserve_share_in_protocol_favor() {
+    assert_eq!(split_reserve_share(1, 1_000).unwrap(), 1);
+    assert_eq!(split_reserve_share(9, 1_000).unwrap(), 1);
+    assert_eq!(split_reserve_share(10, 1_000).unwrap(), 1);
+    assert_eq!(split_reserve_share(0, 1_000).unwrap(), 0);
+}


### PR DESCRIPTION
## Summary

Closes #972.

Adds protocol reserve-factor accounting to the lending contract:

- adds `DataKey::ReserveFactorBps` and `DataKey::TotalReserve`
- adds admin `set_reserve_factor_bps`, `get_reserve_factor_bps`, and `get_total_reserve`
- splits accrued interest during borrow/repay settlement so the reserve share is credited to protocol reserve and the remainder compounds into borrower principal
- rounds positive reserve shares up in the protocol's favor with checked arithmetic
- documents the implemented accounting model and feature status

## Tests

- `cargo fmt -p stellarlend-lending --check`
- `cargo test -p stellarlend-lending --lib reserve_factor -- --nocapture`
- `cargo test -p stellarlend-lending --lib`

Note: I intentionally validated the lending library target. Full-package `cargo test -p stellarlend-lending` has pre-existing unrelated failures in this repo around example/cross-contract test targets, which are outside this issue's lending reserve-factor path.
