### PR TITLE
feat(lending): enforce borrow solvency checks

### DIFF
--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -58,7 +58,7 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 |---|---|---|---|---|
 | `deposit` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | New collateral balance | Adds `amount` to the user's collateral. Enforces deposit cap. Blocked during Shutdown. |
 | `withdraw` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | New collateral balance | Removes `amount` from the user's collateral. Only allowed in Normal and Recovery states. |
-| `borrow` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Updated debt principal | Increases user debt; enforces `min_borrow` and protocol debt ceiling. Blocked during Shutdown/Recovery. |
+| `borrow` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Updated debt principal | Increases user debt after enforcing `min_borrow`, post-borrow health factor (`>= 10000`), and protocol debt ceiling. Blocked during Shutdown/Recovery. |
 | `repay` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Remaining debt principal | Reduces user debt with interest accrued up to the current timestamp. Allowed in Normal and Recovery. |
 | `liquidate` | `(env, liquidator: Address, borrower: Address, amount: i128) → Result<i128, LendingError>` | `liquidator` | Actual debt repaid | Repays up to 50% of an undercollateralized borrower's debt and seizes proportional collateral (+ 10% bonus). Reverts if position is healthy (`hf >= 10000`). |
 
@@ -95,7 +95,7 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 | Function | Signature | Auth | Description |
 |---|---|---|---|
 | `set_min_borrow` | `(env, min_borrow: i128) → Result<(), LendingError>` | admin | Sets the minimum amount required to open or increase a borrow. |
-| `set_debt_ceiling` | `(env, ceiling: i128) → Result<(), LendingError>` | admin | Sets the maximum total protocol debt. |
+| `set_debt_ceiling` | `(env, ceiling: i128) → Result<(), LendingError>` | admin | Sets the maximum total protocol debt. If unset, borrow checks use the default 1,000,000,000,000 ceiling. |
 | `set_flash_fee` | `(env, fee_bps: i128) → Result<(), LendingError>` | admin | Sets the flash-loan fee in the inclusive range `[0, 1000]` bps. |
 | `set_emergency_state` | `(env, new_state: EmergencyState)` | admin or guardian | Transitions between `Normal`, `Shutdown`, and `Recovery`. Emits `EmergencyStateChanged` event. |
 

--- a/stellar-lend/contracts/lending/borrow.md
+++ b/stellar-lend/contracts/lending/borrow.md
@@ -64,7 +64,7 @@ repay(user, 1_000);
 
 ## Overview
 
-The borrow function allows users to borrow assets from the StellarLend protocol by providing collateral. The system enforces minimum collateral ratios, tracks interest accrual, and respects protocol-level constraints such as debt ceilings and pause states.
+The borrow function allows users to borrow from the StellarLend protocol against previously deposited collateral. The system enforces a minimum borrow amount, post-borrow health factor, accrued-interest settlement, and protocol-level constraints such as debt ceilings and emergency states.
 
 ## Function Signature
 
@@ -72,60 +72,52 @@ The borrow function allows users to borrow assets from the StellarLend protocol 
 pub fn borrow(
     env: Env,
     user: Address,
-    asset: Address,
     amount: i128,
-    collateral_asset: Address,
-    collateral_amount: i128,
-) -> Result<(), BorrowError>
+) -> Result<i128, LendingError>
 ```
 
 ## Parameters
 
 - `env`: The contract environment
 - `user`: The borrower's address (must authorize the transaction)
-- `asset`: The address of the asset to borrow
 - `amount`: The amount to borrow (must be positive and above minimum)
-- `collateral_asset`: The address of the collateral asset
-- `collateral_amount`: The amount of collateral to deposit (must be positive)
 
 ## Returns
 
-- `Ok(())` on successful borrow
-- `Err(BorrowError)` on failure
+- `Ok(updated_principal)` on successful borrow
+- `Err(LendingError)` on failure
 
 ## Error Types
 
-| Error                    | Description                                           |
-| ------------------------ | ----------------------------------------------------- |
-| `InsufficientCollateral` | Collateral ratio is below the minimum required (150%) |
-| `DebtCeilingReached`     | Protocol's total debt ceiling would be exceeded       |
-| `ProtocolPaused`         | Borrow operations are currently paused                |
-| `InvalidAmount`          | Amount or collateral is zero or negative              |
-| `BelowMinimumBorrow`     | Borrow amount is below the minimum threshold          |
-| `Overflow`               | Arithmetic overflow occurred during calculation       |
-| `Unauthorized`           | User did not authorize the transaction                |
-| `AssetNotSupported`      | The specified asset is not supported                  |
+| Error | Description |
+| --- | --- |
+| `InsufficientCollateral` | Post-borrow health factor would fall below `10000` |
+| `DebtCeilingExceeded` | Protocol's total debt ceiling would be exceeded |
+| `InvalidAmount` | Amount is zero or negative |
+| `BelowMinimumBorrow` | Borrow amount is below the minimum threshold |
+| `Overflow` | Arithmetic overflow occurred during calculation |
+| `Unauthorized` | User did not authorize the transaction |
 
 ## Security Assumptions
 
-### Collateral Ratio
+### Health Factor
 
-- **Minimum Ratio**: 150% (15 000 basis points) — configurable by admin via `set_collateral_ratio`
-- Users must have collateral worth at least 1.5× their **total** debt (existing + new borrow)
-- Ratio is evaluated as:
+- **Minimum Health Factor**: `10000` (1.0)
+- Borrow uses the current borrower debt after interest accrual plus the requested amount.
+- Health factor is evaluated as:
 
   ```
-  collateral * 10_000 / (existing_debt + amount) >= col_ratio
+  collateral * LIQUIDATION_THRESHOLD_BPS / new_debt >= 10_000
   ```
 
   Equivalently (overflow-safe form used in the contract):
 
   ```
-  collateral * 10_000 >= col_ratio * (existing_debt + amount)
+  collateral * LIQUIDATION_THRESHOLD_BPS >= new_debt * 10_000
   ```
 
-- The ratio is stored under the `"col_ratio"` instance-storage key; if unset the default of 15 000 bps applies
-- Prevents under-collateralised positions that could lead to protocol insolvency
+- With the current `LIQUIDATION_THRESHOLD_BPS = 8000`, a borrower must have at least 125% collateralization after the borrow.
+- Prevents under-collateralized positions that could lead to protocol insolvency.
 
 ### Interest Calculation
 
@@ -143,7 +135,8 @@ pub fn borrow(
 ### Debt Ceiling
 
 - Protocol enforces a maximum total debt limit
-- Each borrow checks if new total debt would exceed ceiling
+- Each borrow checks whether post-borrow `TotalDebt` would exceed `DataKey::DebtCeiling`
+- If unset, the default ceiling is 1,000,000,000,000
 - Protects protocol from excessive leverage
 
 ### Minimum Borrow Threshold
@@ -257,7 +250,7 @@ The contract uses persistent storage for:
 
 ## Best Practices
 
-1. **Always check collateral ratio**: Ensure collateral is at least 150% of borrow amount
+1. **Always check health factor**: Ensure collateral supports the full post-borrow debt including accrued interest
 2. **Monitor interest accrual**: Interest compounds over time, check positions regularly
 3. **Respect debt ceiling**: Large borrows may fail if they exceed protocol limits
 4. **Handle pause state**: Implement retry logic for paused protocol scenarios

--- a/stellar-lend/contracts/lending/src/borrow_health_factor_test.rs
+++ b/stellar-lend/contracts/lending/src/borrow_health_factor_test.rs
@@ -1,0 +1,101 @@
+use crate::rounding_strategy::SECONDS_PER_YEAR;
+use crate::{LendingContract, LendingContractClient, LendingError, HEALTH_FACTOR_SCALE};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin, user)
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    let mut ledger = env.ledger().get();
+    ledger.timestamp = ledger.timestamp.saturating_add(seconds);
+    ledger.sequence_number = ledger.sequence_number.saturating_add(1);
+    env.ledger().set(ledger);
+}
+
+#[test]
+fn borrow_with_zero_collateral_is_rejected() {
+    let (_env, client, _admin, user) = setup();
+
+    let result = client.try_borrow(&user, &1);
+
+    assert!(
+        matches!(result, Err(Ok(LendingError::InsufficientCollateral))),
+        "expected InsufficientCollateral, got {:?}",
+        result
+    );
+    assert_eq!(client.get_debt_position(&user).principal, 0);
+    assert_eq!(client.get_protocol_metrics().total_borrow, 0);
+}
+
+#[test]
+fn borrow_exactly_at_health_factor_threshold_is_allowed() {
+    let (_env, client, _admin, user) = setup();
+    client.deposit(&user, &125);
+
+    let debt = client.borrow(&user, &100);
+
+    assert_eq!(debt, 100);
+    assert_eq!(client.get_health_factor(&user), HEALTH_FACTOR_SCALE);
+}
+
+#[test]
+fn borrow_below_health_factor_threshold_is_rejected_without_mutation() {
+    let (_env, client, _admin, user) = setup();
+    client.deposit(&user, &124);
+
+    let result = client.try_borrow(&user, &100);
+
+    assert!(
+        matches!(result, Err(Ok(LendingError::InsufficientCollateral))),
+        "expected InsufficientCollateral, got {:?}",
+        result
+    );
+    assert_eq!(client.get_debt_position(&user).principal, 0);
+    assert_eq!(client.get_protocol_metrics().total_borrow, 0);
+}
+
+#[test]
+fn borrow_that_crosses_debt_ceiling_by_one_is_rejected() {
+    let (_env, client, _admin, user) = setup();
+    client.deposit(&user, &1_000);
+    client.set_debt_ceiling(&99);
+
+    let result = client.try_borrow(&user, &100);
+
+    assert!(
+        matches!(result, Err(Ok(LendingError::DebtCeilingExceeded))),
+        "expected DebtCeilingExceeded, got {:?}",
+        result
+    );
+    assert_eq!(client.get_debt_position(&user).principal, 0);
+    assert_eq!(client.get_protocol_metrics().total_borrow, 0);
+}
+
+#[test]
+fn second_borrow_uses_accrued_debt_for_health_factor() {
+    let (env, client, _admin, user) = setup();
+    client.deposit(&user, &137_500);
+    client.borrow(&user, &100_000);
+
+    advance_time(&env, SECONDS_PER_YEAR);
+
+    let result = client.try_borrow(&user, &5_001);
+    assert!(
+        matches!(result, Err(Ok(LendingError::InsufficientCollateral))),
+        "expected InsufficientCollateral, got {:?}",
+        result
+    );
+
+    let debt = client.borrow(&user, &5_000);
+    assert_eq!(debt, 110_000);
+    assert_eq!(client.get_protocol_metrics().total_borrow, 110_000);
+}

--- a/stellar-lend/contracts/lending/src/health_factor_edge_test.rs
+++ b/stellar-lend/contracts/lending/src/health_factor_edge_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::debt::{save_debt, DebtPosition};
 use soroban_sdk::testutils::Address as _;
 
 fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
@@ -43,8 +44,17 @@ fn health_factor_no_debt_uses_healthy_sentinel() {
 /// health factor, not the no-debt sentinel.
 #[test]
 fn health_factor_zero_collateral_nonzero_debt_is_zero() {
-    let (_env, client, _id, user) = setup();
-    client.borrow(&user, &125);
+    let (env, client, id, user) = setup();
+    env.as_contract(&id, || {
+        save_debt(
+            &env,
+            &user,
+            &DebtPosition {
+                principal: 125,
+                last_update: env.ledger().timestamp(),
+            },
+        );
+    });
 
     let position = client.get_position(&user);
     assert_eq!(position.collateral, 0);
@@ -74,8 +84,15 @@ fn health_factor_overflow_returns_i128_max_sentinel() {
         env.storage()
             .persistent()
             .set(&DataKey::Collateral(user.clone()), &overflowing_collateral);
+        save_debt(
+            &env,
+            &user,
+            &DebtPosition {
+                principal: 1,
+                last_update: env.ledger().timestamp(),
+            },
+        );
     });
-    client.borrow(&user, &1);
 
     let position = client.get_position(&user);
     assert_eq!(position.collateral, overflowing_collateral);

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -6,6 +6,8 @@ pub mod rate_model;
 pub mod rounding_strategy;
 
 #[cfg(test)]
+mod borrow_health_factor_test;
+#[cfg(test)]
 mod deposit_accounting_test;
 #[cfg(test)]
 mod error_codes_test;
@@ -28,6 +30,7 @@ use soroban_sdk::{
 
 const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
 const DEFAULT_DEPOSIT_CAP: i128 = 1_000_000_000_000;
+const DEFAULT_DEBT_CEILING: i128 = 1_000_000_000_000;
 #[allow(dead_code)]
 const HEALTH_FACTOR_SCALE: i128 = 10_000;
 const HEALTH_FACTOR_NO_DEBT: i128 = 100_000_000;
@@ -404,6 +407,8 @@ impl LendingContract {
         Ok(new_balance)
     }
 
+    /// Increase a user's debt after enforcing minimum borrow, health factor,
+    /// and global debt-ceiling checks.
     pub fn borrow(env: Env, user: Address, amount: i128) -> Result<i128, LendingError> {
         check_emergency_status(&env, ProtocolAction::Borrow);
         if amount <= 0 {
@@ -423,8 +428,6 @@ impl LendingContract {
             debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
             debt::DebtError::Overflow => LendingError::Overflow,
         })?;
-        save_debt(&env, &user, &updated);
-        // Track protocol-level total debt
         let total_debt: i128 = env
             .storage()
             .persistent()
@@ -433,10 +436,15 @@ impl LendingContract {
         let delta = updated
             .principal
             .checked_sub(prev_principal)
-            .expect("borrow: delta overflow");
+            .ok_or(LendingError::Overflow)?;
         let new_total_debt = total_debt
             .checked_add(delta)
-            .expect("borrow: total_debt overflow");
+            .ok_or(LendingError::Overflow)?;
+
+        assert_borrow_solvent(&env, &user, updated.principal)?;
+        assert_debt_ceiling(&env, new_total_debt)?;
+
+        save_debt(&env, &user, &updated);
         env.storage()
             .persistent()
             .set(&DataKey::TotalDebt, &new_total_debt);
@@ -877,6 +885,43 @@ fn current_borrow_rate(env: &Env) -> i128 {
     }
 }
 
+/// Require the borrower's post-borrow health factor to remain at or above 1.0.
+fn assert_borrow_solvent(env: &Env, user: &Address, new_debt: i128) -> Result<(), LendingError> {
+    if new_debt <= 0 {
+        return Err(LendingError::InvalidAmount);
+    }
+    let collateral: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Collateral(user.clone()))
+        .unwrap_or(0);
+    if collateral <= 0 {
+        return Err(LendingError::InsufficientCollateral);
+    }
+    let numerator = collateral
+        .checked_mul(LIQUIDATION_THRESHOLD_BPS)
+        .ok_or(LendingError::Overflow)?;
+    let required = new_debt
+        .checked_mul(HEALTH_FACTOR_SCALE)
+        .ok_or(LendingError::Overflow)?;
+    if numerator < required {
+        return Err(LendingError::InsufficientCollateral);
+    }
+    Ok(())
+}
+
+fn assert_debt_ceiling(env: &Env, new_total_debt: i128) -> Result<(), LendingError> {
+    let ceiling: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::DebtCeiling)
+        .unwrap_or(DEFAULT_DEBT_CEILING);
+    if new_total_debt > ceiling {
+        return Err(LendingError::DebtCeilingExceeded);
+    }
+    Ok(())
+}
+
 #[contract]
 pub struct MockAmm;
 #[contractimpl]
@@ -1168,12 +1213,14 @@ mod test {
     #[test]
     fn test_borrow_increases_debt() {
         let (_env, client, _admin, user) = setup();
+        client.deposit(&user, &100);
         assert_eq!(client.borrow(&user, &50), 50);
     }
 
     #[test]
     fn test_repay_decreases_debt() {
         let (_env, client, _admin, user) = setup();
+        client.deposit(&user, &200);
         client.borrow(&user, &100);
         assert_eq!(client.repay(&user, &30), 70);
     }
@@ -1208,6 +1255,7 @@ mod test {
     #[test]
     fn test_get_debt_position_extends_debt_ttl() {
         let (env, client, _admin, user) = setup();
+        client.deposit(&user, &200);
         client.borrow(&user, &100);
 
         advance_time(&env, (PERSISTENT_TTL_LEDGERS / 2) as u64);
@@ -1239,6 +1287,7 @@ mod test {
     fn test_borrow_exactly_minimum_accepted() {
         let (_env, client, _admin, user) = setup();
         client.set_min_borrow(&50);
+        client.deposit(&user, &100);
         let res = client.borrow(&user, &50);
         assert_eq!(res, 50);
     }
@@ -1274,9 +1323,18 @@ mod test {
 
     #[test]
     fn test_health_factor_unhealthy() {
-        let (_env, client, _admin, user) = setup();
+        let (env, client, _admin, user) = setup();
         client.deposit(&user, &100);
-        client.borrow(&user, &200);
+        env.as_contract(&client.address, || {
+            save_debt(
+                &env,
+                &user,
+                &DebtPosition {
+                    principal: 200,
+                    last_update: env.ledger().timestamp(),
+                },
+            );
+        });
         let hf = client.get_health_factor(&user);
         assert!(hf < HEALTH_FACTOR_SCALE);
     }
@@ -1369,6 +1427,7 @@ mod test {
     #[should_panic(expected = "OperationDisabledDuringShutdown")]
     fn test_shutdown_blocks_repay() {
         let (_env, client, _admin, user) = setup();
+        client.deposit(&user, &200);
         client.borrow(&user, &100);
         client.set_emergency_state(&EmergencyState::Shutdown);
         client.repay(&user, &10);


### PR DESCRIPTION
## Summary

Closes #961.

Adds borrow-time solvency enforcement to the lending contract:

- computes the prospective post-borrow debt before committing state
- rejects borrows whose post-borrow health factor would fall below `10000`
- enforces `DataKey::DebtCeiling` with a default 1,000,000,000,000 ceiling when unset
- replaces borrow-path arithmetic panics with `LendingError::Overflow` returns
- keeps state unmodified on health-factor or debt-ceiling rejection
- updates existing tests that intentionally inspect unhealthy debt to seed those states directly
- updates borrow docs and README behavior notes

## Tests

- `cargo fmt -p stellarlend-lending --check`
- `cargo test -p stellarlend-lending --lib borrow_health_factor -- --nocapture`
- `cargo test -p stellarlend-lending --lib`

Note: I intentionally validated the lending library target. Full-package `cargo test -p stellarlend-lending` has pre-existing unrelated failures in this repo around example/cross-contract test targets, which are outside this borrow solvency path.
