### PR TITLE
feat(lending): add timelocked upgrade governance

### DIFF
--- a/UPGRADE_MIGRATION_IMPLEMENTATION.md
+++ b/UPGRADE_MIGRATION_IMPLEMENTATION.md
@@ -1,5 +1,42 @@
 # Upgrade and Storage Migration Safety Suite - Implementation Summary
 
+## Current Lending Upgrade Governance
+
+The lending contract now ships a native timelocked WASM upgrade governance flow:
+
+- `upgrade_init(approvers, threshold)` stores the approver set and threshold. It is
+  admin-only and rejects empty approver sets, zero thresholds, and thresholds greater
+  than the approver count.
+- `upgrade_propose(new_wasm_hash)` is admin-only. It records an `UpgradeProposal`
+  with a 600,000-ledger ETA, a 1,200,000-ledger expiry, and the admin's approval when
+  the admin is in the approver set.
+- `upgrade_approve(approver, proposal_id)` is approver-only and rejects duplicate
+  approvals, unknown proposals, executed proposals, and expired proposals.
+- `upgrade_execute(executor, proposal_id)` is approver-only and calls
+  `update_current_contract_wasm(new_wasm_hash)` only after the timelock has elapsed
+  and the stored approval threshold has been met.
+- Audit views are available through `get_upgrade_proposal`, `get_upgrade_approvals`,
+  `get_upgrade_approvers`, and `get_upgrade_threshold`.
+
+The focused test suite is `stellar-lend/contracts/lending/src/upgrade_governance_test.rs`.
+Run it with:
+
+```bash
+cd stellar-lend
+cargo test -p stellarlend-lending --lib upgrade_governance -- --nocapture
+```
+
+Full lending library validation:
+
+```bash
+cd stellar-lend
+cargo test -p stellarlend-lending --lib
+```
+
+The older notes below describe a broader versioned rollback/data-store safety suite and
+should be treated as historical design context unless those modules are present in the
+current branch.
+
 ## Overview
 
 Implemented a comprehensive test suite for contract upgrade and storage migration safety in the StellarLend lending protocol. The suite validates that contract upgrades preserve user state, handle failures gracefully, and support safe rollback operations.

--- a/docs/UPGRADE_AUTHORIZATION.md
+++ b/docs/UPGRADE_AUTHORIZATION.md
@@ -2,25 +2,25 @@
 
 ## Scope
 
-This document describes how upgrade authorization works for contracts using
-`stellarlend_common::upgrade::UpgradeManager` and how to safely rotate upgrade keys.
+This document describes how upgrade authorization works for the lending contract's
+native timelocked WASM upgrade flow.
 
 ## Authorization model
 
-- `upgrade_init(admin, current_wasm_hash, required_approvals)` initializes upgrade state.
-- `upgrade_propose(caller, new_wasm_hash, new_version)` is `admin` only.
-- `upgrade_add_approver(caller, approver)` is `admin` only.
-- `upgrade_remove_approver(caller, approver)` is `admin` only.
-- `upgrade_approve(caller, proposal_id)` is restricted to the configured approver set.
-- `upgrade_execute(caller, proposal_id)` is restricted to the configured approver set.
-- `upgrade_rollback(caller, proposal_id)` is `admin` only.
+- `upgrade_init(approvers, threshold)` is `admin` only and stores the approver set.
+- `upgrade_propose(new_wasm_hash)` is `admin` only. It records the WASM hash, ETA
+  ledger, expiry ledger, and the admin's approval when the admin is in the approver set.
+- `upgrade_approve(approver, proposal_id)` is restricted to the configured approver set.
+- `upgrade_execute(executor, proposal_id)` is restricted to the configured approver set.
+  It calls `env.deployer().update_current_contract_wasm(new_wasm_hash)` only after
+  the timelock has elapsed and the approval threshold is met.
 
 All mutating authorization paths call `require_auth()` on the provided caller.
 
 ## Role separation
 
-- The stored `admin` is the governance authority for upgrade configuration: it can propose upgrades,
-  add/remove approvers, and roll back executed upgrades.
+- The stored `admin` is the governance authority for upgrade configuration: it initializes
+  approvers and proposes upgrades.
 - The approver set is the execution authority for upgrades: only current approvers can approve or
   execute a proposal once it exists.
 - Guardian or emergency operators are not part of the upgrade trust boundary and gain no upgrade
@@ -28,16 +28,16 @@ All mutating authorization paths call `require_auth()` on the provided caller.
 
 If you need to rotate the humans or devices behind the admin role, prefer making `admin` a stable
 governance or multisig address and rotating its signers through governance. The lending upgrade
-manager does not expose a separate `set_upgrade_admin(...)` entrypoint.
+flow does not expose a separate `set_upgrade_admin(...)` entrypoint.
 
 ## Key rotation procedure
 
 Safe rotation for an upgrade approver key:
 
-1. Add a replacement key: `upgrade_add_approver(admin, new_key)`.
-2. Verify the new key can approve and execute a proposal.
-3. Revoke the old key: `upgrade_remove_approver(admin, old_key)`.
-4. Confirm old key is rejected for `upgrade_approve` and `upgrade_execute`.
+1. Prepare the replacement approver set off-chain.
+2. Use the contract admin to call `upgrade_init(replacement_approvers, replacement_threshold)`.
+3. Verify the new key can approve and execute a dry-run/testnet proposal.
+4. Confirm old keys are rejected for `upgrade_approve` and `upgrade_execute` on new proposals.
 
 Safe rotation for admin/governance signers:
 
@@ -49,23 +49,22 @@ Safe rotation for admin/governance signers:
 4. Do not revoke old governance or approver signers until the replacement set has successfully
    exercised the exact upgrade path it is expected to control.
 
-`upgrade_remove_approver` enforces threshold safety:
+`upgrade_init` enforces threshold safety:
 
-- It rejects removals that would leave no approvers.
-- It rejects removals that would leave fewer approvers than `required_approvals`.
+- It rejects an empty approver set.
+- It rejects a zero threshold.
+- It rejects a threshold greater than the approver count.
 
 This prevents accidental permanent lockout during rotation.
 
 ## Invalid upgrade attempts covered by tests
 
-- Unauthorized address attempts to add/remove approvers.
 - Unauthorized address attempts to approve or execute upgrades.
-- Removed approvers attempting to approve or execute after rotation.
+- Non-approvers attempting to approve or execute upgrades.
 - Duplicate approvals from the same key.
 - Execute attempts before threshold approval is reached.
-- Invalid version proposals (`new_version <= current_version`).
-- Unsafe key removal that violates threshold constraints.
-- Partial signer updates that have not yet restored full replacement capacity.
+- Execute attempts before the timelock has elapsed.
+- Expired proposals rejecting approval and execution.
 
 Soroban `Address` values are strongly typed, so there is no zero-address sentinel to rotate into.
 The practical "invalid address" risk is rotating to an address you do not control operationally,
@@ -96,26 +95,25 @@ which must be mitigated by live authorization checks before revoking the old sig
 
 | Threat | Mitigation |
 |--------|------------|
-| Old signer keeps upgrade power after rotation | `upgrade_remove_approver` takes effect immediately for future approve/execute calls; tests verify revoked signers are rejected |
-| Rotation bricks upgrade execution | Removal is rejected if it would make `required_approvals` unsatisfiable |
-| Partial rotation silently weakens authorization | Threshold does not auto-drop during staged rotations; tests verify `n - 1` approvals remain insufficient |
+| Old signer keeps upgrade power after rotation | Reinitialize the approver set and verify old signers are no longer included before proposing production upgrades |
+| Rotation bricks upgrade execution | `upgrade_init` rejects thresholds greater than the approver count |
+| Partial rotation silently weakens authorization | Threshold does not auto-drop; tests verify `n - 1` approvals remain insufficient |
 | Governance signer swap changes upgrade authority unexpectedly | Keep stored `admin` stable and rotate underlying multisig/governance signers atomically |
 | Wrong replacement address is staged | Operationally verify the new signer can authenticate the real path before revoking the old one |
 
 ## Trust boundaries and operator powers
 
-- Upgrade authority boundary: only `admin` can propose upgrades, manage approvers, and roll back
-  executed upgrades.
+- Upgrade authority boundary: only `admin` can initialize approvers and propose upgrades.
 - Execution boundary: only currently configured approvers can execute approved proposals.
 - Guardian boundary: guardian operations (pause or emergency flows) are separate from upgrade
   authority and do not grant upgrade proposal, execution, or rollback rights.
-- Rotation boundary: removing an approver takes effect immediately for future `upgrade_approve`
-  and `upgrade_execute` calls.
+- Rotation boundary: replacing the approver set takes effect immediately for future
+  `upgrade_approve` and `upgrade_execute` calls.
 
 ## External call and token transfer safety
 
-- Upgrade entrypoints (`upgrade_propose`, `upgrade_approve`, `upgrade_execute`,
-  `upgrade_rollback`) do not perform token transfers.
+- Upgrade entrypoints (`upgrade_propose`, `upgrade_approve`, `upgrade_execute`) do not perform
+  token transfers.
 - Token transfer paths remain confined to lending operations such as deposit, withdraw, repay,
   and liquidation modules.
 - Authorization checks (`require_auth()`) are enforced on every mutating upgrade path.
@@ -124,11 +122,8 @@ which must be mitigated by live authorization checks before revoking the old sig
 
 ## Rollback and failure-path coverage checklist
 
-- Rollback rejects proposals that were never executed (`InvalidStatus`).
-- Execute and rollback reject unknown proposal ids (`ProposalNotFound`).
-- Non-monotonic version proposals are rejected after successful execution
-  (`new_version <= current_version`).
-- Execution by a removed approver is rejected even if they approved earlier during proposal
-  lifecycle.
-- Rotation add/remove actions emit audit events (`up_apadd`, `up_aprm`) so signer changes can be
-  monitored off-chain.
+- Execute rejects unknown proposal ids (`UpgradeProposalNotFound`).
+- Execute rejects already executed proposals (`UpgradeAlreadyExecuted`).
+- Approval rejects duplicate signers (`UpgradeDuplicateApproval`).
+- Approval and execute reject expired proposals (`UpgradeProposalExpired`).
+- Upgrade propose/approve/execute emit audit events for off-chain monitoring.

--- a/docs/upgrade_playbook.md
+++ b/docs/upgrade_playbook.md
@@ -4,6 +4,47 @@
 
 This playbook provides a practical guide for safely upgrading StellarLend contracts, including preflight checks, execution procedures, post-upgrade monitoring, and rollback criteria. It aligns with the upgrade authorization model documented in `docs/UPGRADE_AUTHORIZATION.md`.
 
+## Lending WASM Governance Flow
+
+The lending contract uses a timelocked threshold approval flow for WASM upgrades:
+
+1. Configure approvers once or during signer rotation:
+
+   ```rust
+   client.upgrade_init(&approvers, &threshold);
+   ```
+
+2. Admin proposes the reviewed WASM hash:
+
+   ```rust
+   let proposal_id = client.upgrade_propose(&new_wasm_hash);
+   ```
+
+   The proposal records `eta_ledger = current_ledger + 600_000` and
+   `expires_at_ledger = current_ledger + 1_200_000`.
+
+3. Approvers review the artifact and approve:
+
+   ```rust
+   client.upgrade_approve(&approver, &proposal_id);
+   ```
+
+4. After the ETA ledger and once the threshold is met, an approver executes:
+
+   ```rust
+   client.upgrade_execute(&executor, &proposal_id);
+   ```
+
+5. Verify proposal state and approvals:
+
+   ```rust
+   client.get_upgrade_proposal(&proposal_id);
+   client.get_upgrade_approvals(&proposal_id);
+   ```
+
+Execution rejects unknown proposals, expired proposals, duplicate execution, insufficient
+approvals, and execution before the timelock.
+
 ## Pre-Upgrade Checklist
 
 ### 1. Authorization Verification

--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -132,6 +132,20 @@ Normal ──► Shutdown ──► Recovery ──► Normal
 
 ---
 
+## Upgrade Governance
+
+The lending contract exposes a timelocked WASM upgrade flow:
+
+| Function | Notes |
+|---|---|
+| `upgrade_init(approvers, threshold)` | Admin-only setup for the approver set and required approval threshold. |
+| `upgrade_propose(new_wasm_hash)` | Admin-only proposal. Records the WASM hash, ETA ledger, expiry ledger, and admin approval when the admin is an approver. |
+| `upgrade_approve(approver, proposal_id)` | Approver-only approval. Duplicate approvals are rejected. |
+| `upgrade_execute(executor, proposal_id)` | Approver-only execution after the timelock and threshold are satisfied. Calls `update_current_contract_wasm`. |
+| `get_upgrade_proposal / get_upgrade_approvals` | Audit views for proposal state and signer approvals. |
+
+Upgrade proposals use a 600,000-ledger minimum delay and a 1,200,000-ledger expiry window.
+
 ## 🔮 Planned Features
 
 The functions listed below appear in older documentation but are **not yet implemented** in `src/lib.rs`. They are tracked for future milestones.
@@ -147,7 +161,6 @@ The functions listed below appear in older documentation but are **not yet imple
 | `get_max_liquidatable_amount(env, user)` | Convenience helper for liquidators. |
 | `get_emergency_state(env)` | Public view for current lifecycle state (today exposed only via events). |
 | `deposit_collateral(env, user, asset, amount)` | Multi-asset collateral support. |
-| `upgrade_init / upgrade_propose / upgrade_approve / upgrade_execute` | Multisig upgrade governance. |
 | `data_store_init / data_save / data_load / data_backup / data_restore` | Persistent data-store management helpers. |
 
 ---

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -15,6 +15,8 @@ mod health_factor_edge_test;
 mod interest_drift_regression_test;
 #[cfg(test)]
 mod rounding_drift_test;
+#[cfg(test)]
+mod upgrade_governance_test;
 
 use debt::{
     borrow_amount, effective_debt, load_debt, repay_amount, save_debt, DebtPosition,
@@ -23,7 +25,7 @@ use debt::{
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, BytesN,
-    Env, IntoVal, Symbol, Val,
+    Env, IntoVal, Symbol, Val, Vec,
 };
 
 const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
@@ -35,6 +37,8 @@ pub const LIQUIDATION_THRESHOLD_BPS: i128 = 8000;
 const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
 const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
+const MIN_UPGRADE_DELAY_LEDGERS: u32 = 600_000;
+const DEFAULT_UPGRADE_EXPIRY_LEDGERS: u32 = 1_200_000;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -58,6 +62,11 @@ pub enum DataKey {
     Guardian,
     PauseState(PauseType),
     RateParams,
+    UpgradeApprovers,
+    UpgradeThreshold,
+    UpgradeProposalCounter,
+    UpgradeProposal(u64),
+    UpgradeApprovals(u64),
 }
 
 #[contractevent]
@@ -120,6 +129,15 @@ pub enum LendingError {
     NotInitialized = 1009,
     AlreadyInitialized = 1010,
     PositionHealthy = 1011,
+    UpgradeNotInitialized = 1012,
+    InvalidUpgradeThreshold = 1013,
+    UpgradeProposalNotFound = 1014,
+    UpgradeProposalNotReady = 1015,
+    UpgradeProposalExpired = 1016,
+    UpgradeAlreadyExecuted = 1017,
+    UpgradeInsufficientApprovals = 1018,
+    UpgradeDuplicateApproval = 1019,
+    InvalidUpgradeProposal = 1020,
     DebtCeilingExceeded = 2001,
     DepositCapExceeded = 2002,
     InvalidFeeBps = 2005,
@@ -151,6 +169,40 @@ pub struct PositionSummary {
     pub collateral: i128,
     pub debt: i128,
     pub health_factor: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeProposal {
+    pub id: u64,
+    pub new_wasm_hash: BytesN<32>,
+    pub eta_ledger: u32,
+    pub expires_at_ledger: u32,
+    pub executed: bool,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeProposedEvent {
+    pub proposal_id: u64,
+    pub new_wasm_hash: BytesN<32>,
+    pub eta_ledger: u32,
+    pub expires_at_ledger: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeApprovedEvent {
+    pub proposal_id: u64,
+    pub approver: Address,
+    pub approvals: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeExecutedEvent {
+    pub proposal_id: u64,
+    pub new_wasm_hash: BytesN<32>,
 }
 
 #[contract]
@@ -584,6 +636,195 @@ impl LendingContract {
         Ok(())
     }
 
+    /// Initialize timelocked upgrade governance with approvers and a threshold.
+    pub fn upgrade_init(
+        env: Env,
+        approvers: Vec<Address>,
+        threshold: u32,
+    ) -> Result<(), LendingError> {
+        let admin = Self::get_admin(env.clone());
+        admin.require_auth();
+        validate_upgrade_threshold(&approvers, threshold)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeApprovers, &approvers);
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeThreshold, &threshold);
+        Ok(())
+    }
+
+    /// Propose a WASM upgrade and record the admin as the first approval if eligible.
+    pub fn upgrade_propose(env: Env, new_wasm_hash: BytesN<32>) -> Result<u64, LendingError> {
+        let admin = Self::get_admin(env.clone());
+        admin.require_auth();
+        let approvers = get_upgrade_approvers(&env)?;
+        let _threshold = get_upgrade_threshold(&env)?;
+        let current_ledger = env.ledger().sequence();
+        let eta_ledger = current_ledger
+            .checked_add(MIN_UPGRADE_DELAY_LEDGERS)
+            .ok_or(LendingError::Overflow)?;
+        let expires_at_ledger = current_ledger
+            .checked_add(DEFAULT_UPGRADE_EXPIRY_LEDGERS)
+            .ok_or(LendingError::Overflow)?;
+        if expires_at_ledger < eta_ledger {
+            return Err(LendingError::InvalidUpgradeProposal);
+        }
+        let proposal_id = env
+            .storage()
+            .instance()
+            .get(&DataKey::UpgradeProposalCounter)
+            .unwrap_or(0u64)
+            .checked_add(1)
+            .ok_or(LendingError::Overflow)?;
+        let proposal = UpgradeProposal {
+            id: proposal_id,
+            new_wasm_hash: new_wasm_hash.clone(),
+            eta_ledger,
+            expires_at_ledger,
+            executed: false,
+        };
+        let mut approvals = Vec::new(&env);
+        if address_in_vec(&approvers, &admin) {
+            approvals.push_back(admin);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeProposalCounter, &proposal_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeProposal(proposal_id), &proposal);
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeApprovals(proposal_id), &approvals);
+
+        UpgradeProposedEvent {
+            proposal_id,
+            new_wasm_hash,
+            eta_ledger,
+            expires_at_ledger,
+        }
+        .publish(&env);
+
+        Ok(proposal_id)
+    }
+
+    /// Approve a pending WASM upgrade proposal.
+    pub fn upgrade_approve(
+        env: Env,
+        approver: Address,
+        proposal_id: u64,
+    ) -> Result<u32, LendingError> {
+        approver.require_auth();
+        let approvers = get_upgrade_approvers(&env)?;
+        if !address_in_vec(&approvers, &approver) {
+            return Err(LendingError::Unauthorized);
+        }
+        let proposal = get_live_upgrade_proposal(&env, proposal_id)?;
+        if proposal.executed {
+            return Err(LendingError::UpgradeAlreadyExecuted);
+        }
+        let mut approvals: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::UpgradeApprovals(proposal_id))
+            .unwrap_or(Vec::new(&env));
+        if address_in_vec(&approvals, &approver) {
+            return Err(LendingError::UpgradeDuplicateApproval);
+        }
+        approvals.push_back(approver.clone());
+        let approval_count = approvals.len();
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeApprovals(proposal_id), &approvals);
+
+        UpgradeApprovedEvent {
+            proposal_id,
+            approver,
+            approvals: approval_count,
+        }
+        .publish(&env);
+
+        Ok(approval_count)
+    }
+
+    /// Execute an approved WASM upgrade after its timelock has elapsed.
+    pub fn upgrade_execute(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+    ) -> Result<(), LendingError> {
+        executor.require_auth();
+        let approvers = get_upgrade_approvers(&env)?;
+        if !address_in_vec(&approvers, &executor) {
+            return Err(LendingError::Unauthorized);
+        }
+        let threshold = get_upgrade_threshold(&env)?;
+        let mut proposal = get_live_upgrade_proposal(&env, proposal_id)?;
+        if proposal.executed {
+            return Err(LendingError::UpgradeAlreadyExecuted);
+        }
+        let current_ledger = env.ledger().sequence();
+        if current_ledger < proposal.eta_ledger {
+            return Err(LendingError::UpgradeProposalNotReady);
+        }
+        let approvals: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::UpgradeApprovals(proposal_id))
+            .unwrap_or(Vec::new(&env));
+        if approvals.len() < threshold {
+            return Err(LendingError::UpgradeInsufficientApprovals);
+        }
+
+        proposal.executed = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeProposal(proposal_id), &proposal);
+        update_current_contract_wasm(&env, proposal.new_wasm_hash.clone());
+
+        UpgradeExecutedEvent {
+            proposal_id,
+            new_wasm_hash: proposal.new_wasm_hash,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Return the configured upgrade approver set.
+    pub fn get_upgrade_approvers(env: Env) -> Option<Vec<Address>> {
+        env.storage().instance().get(&DataKey::UpgradeApprovers)
+    }
+
+    /// Return the configured upgrade approval threshold.
+    pub fn get_upgrade_threshold(env: Env) -> Option<u32> {
+        env.storage().instance().get(&DataKey::UpgradeThreshold)
+    }
+
+    /// Return a stored upgrade proposal.
+    pub fn get_upgrade_proposal(env: Env, proposal_id: u64) -> Option<UpgradeProposal> {
+        env.storage()
+            .instance()
+            .get(&DataKey::UpgradeProposal(proposal_id))
+    }
+
+    /// Return approvals recorded for a stored upgrade proposal.
+    pub fn get_upgrade_approvals(env: Env, proposal_id: u64) -> Option<Vec<Address>> {
+        env.storage()
+            .instance()
+            .get(&DataKey::UpgradeApprovals(proposal_id))
+    }
+
+    pub fn get_upgrade_delay_ledgers(_env: Env) -> u32 {
+        MIN_UPGRADE_DELAY_LEDGERS
+    }
+
+    pub fn get_upgrade_expiry_ledgers(_env: Env) -> u32 {
+        DEFAULT_UPGRADE_EXPIRY_LEDGERS
+    }
+
     /// Repay function used by receiver during callback to return funds to the contract.
     /// Uses checked arithmetic to prevent overflow/underflow.
     pub fn repay_flash_loan(env: Env, payer: Address, asset: Address, amount: i128) {
@@ -876,6 +1117,59 @@ fn current_borrow_rate(env: &Env) -> i128 {
         None => DEFAULT_APR_BPS,
     }
 }
+
+fn validate_upgrade_threshold(
+    approvers: &Vec<Address>,
+    threshold: u32,
+) -> Result<(), LendingError> {
+    if threshold == 0 || approvers.is_empty() || threshold > approvers.len() {
+        return Err(LendingError::InvalidUpgradeThreshold);
+    }
+    Ok(())
+}
+
+fn get_upgrade_approvers(env: &Env) -> Result<Vec<Address>, LendingError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::UpgradeApprovers)
+        .ok_or(LendingError::UpgradeNotInitialized)
+}
+
+fn get_upgrade_threshold(env: &Env) -> Result<u32, LendingError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::UpgradeThreshold)
+        .ok_or(LendingError::UpgradeNotInitialized)
+}
+
+fn get_live_upgrade_proposal(env: &Env, proposal_id: u64) -> Result<UpgradeProposal, LendingError> {
+    let proposal: UpgradeProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::UpgradeProposal(proposal_id))
+        .ok_or(LendingError::UpgradeProposalNotFound)?;
+    if env.ledger().sequence() > proposal.expires_at_ledger {
+        return Err(LendingError::UpgradeProposalExpired);
+    }
+    Ok(proposal)
+}
+
+fn address_in_vec(addresses: &Vec<Address>, needle: &Address) -> bool {
+    for address in addresses.iter() {
+        if address == *needle {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(not(test))]
+fn update_current_contract_wasm(env: &Env, new_wasm_hash: BytesN<32>) {
+    env.deployer().update_current_contract_wasm(new_wasm_hash);
+}
+
+#[cfg(test)]
+fn update_current_contract_wasm(_env: &Env, _new_wasm_hash: BytesN<32>) {}
 
 #[contract]
 pub struct MockAmm;

--- a/stellar-lend/contracts/lending/src/upgrade_governance_test.rs
+++ b/stellar-lend/contracts/lending/src/upgrade_governance_test.rs
@@ -1,0 +1,162 @@
+use crate::{
+    LendingContract, LendingContractClient, LendingError, DEFAULT_UPGRADE_EXPIRY_LEDGERS,
+    MIN_UPGRADE_DELAY_LEDGERS,
+};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, BytesN, Env, Vec};
+
+fn setup() -> (
+    Env,
+    LendingContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let second = Address::generate(&env);
+    let third = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin, second, third)
+}
+
+fn approvers(env: &Env, admin: &Address, second: &Address) -> Vec<Address> {
+    let mut approvers = Vec::new(env);
+    approvers.push_back(admin.clone());
+    approvers.push_back(second.clone());
+    approvers
+}
+
+fn wasm_hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+#[test]
+fn upgrade_init_stores_approvers_and_threshold() {
+    let (env, client, admin, second, _third) = setup();
+    let approvers = approvers(&env, &admin, &second);
+
+    client.upgrade_init(&approvers, &2);
+
+    assert_eq!(client.get_upgrade_threshold().unwrap(), 2);
+    assert_eq!(client.get_upgrade_approvers().unwrap().len(), 2);
+}
+
+#[test]
+fn upgrade_init_rejects_invalid_thresholds() {
+    let (env, client, admin, second, _third) = setup();
+    let approvers = approvers(&env, &admin, &second);
+
+    let zero = client.try_upgrade_init(&approvers, &0);
+    assert!(matches!(
+        zero,
+        Err(Ok(LendingError::InvalidUpgradeThreshold))
+    ));
+
+    let too_high = client.try_upgrade_init(&approvers, &3);
+    assert!(matches!(
+        too_high,
+        Err(Ok(LendingError::InvalidUpgradeThreshold))
+    ));
+}
+
+#[test]
+fn propose_records_timelock_expiry_and_admin_approval() {
+    let (env, client, admin, second, _third) = setup();
+    client.upgrade_init(&approvers(&env, &admin, &second), &2);
+    let current_ledger = env.ledger().sequence();
+    let hash = wasm_hash(&env, 7);
+
+    let proposal_id = client.upgrade_propose(&hash);
+    let proposal = client.get_upgrade_proposal(&proposal_id).unwrap();
+    let approvals = client.get_upgrade_approvals(&proposal_id).unwrap();
+
+    assert_eq!(proposal.id, proposal_id);
+    assert_eq!(proposal.new_wasm_hash, hash);
+    assert_eq!(
+        proposal.eta_ledger,
+        current_ledger + MIN_UPGRADE_DELAY_LEDGERS
+    );
+    assert_eq!(
+        proposal.expires_at_ledger,
+        current_ledger + DEFAULT_UPGRADE_EXPIRY_LEDGERS
+    );
+    assert!(!proposal.executed);
+    assert_eq!(approvals.len(), 1);
+    assert_eq!(approvals.get(0).unwrap(), admin);
+}
+
+#[test]
+fn approve_rejects_non_approver_and_duplicate() {
+    let (env, client, admin, second, third) = setup();
+    client.upgrade_init(&approvers(&env, &admin, &second), &2);
+    let proposal_id = client.upgrade_propose(&wasm_hash(&env, 8));
+
+    let non_approver = client.try_upgrade_approve(&third, &proposal_id);
+    assert!(matches!(non_approver, Err(Ok(LendingError::Unauthorized))));
+
+    let duplicate = client.try_upgrade_approve(&admin, &proposal_id);
+    assert!(matches!(
+        duplicate,
+        Err(Ok(LendingError::UpgradeDuplicateApproval))
+    ));
+
+    assert_eq!(client.upgrade_approve(&second, &proposal_id), 2);
+}
+
+#[test]
+fn execute_requires_timelock_and_threshold() {
+    let (env, client, admin, second, _third) = setup();
+    client.upgrade_init(&approvers(&env, &admin, &second), &2);
+    let proposal_id = client.upgrade_propose(&wasm_hash(&env, 9));
+
+    let early = client.try_upgrade_execute(&admin, &proposal_id);
+    assert!(matches!(
+        early,
+        Err(Ok(LendingError::UpgradeProposalNotReady))
+    ));
+
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + MIN_UPGRADE_DELAY_LEDGERS);
+    let under_approved = client.try_upgrade_execute(&admin, &proposal_id);
+    assert!(matches!(
+        under_approved,
+        Err(Ok(LendingError::UpgradeInsufficientApprovals))
+    ));
+
+    client.upgrade_approve(&second, &proposal_id);
+    client.upgrade_execute(&second, &proposal_id);
+
+    let proposal = client.get_upgrade_proposal(&proposal_id).unwrap();
+    assert!(proposal.executed);
+    let repeated = client.try_upgrade_execute(&second, &proposal_id);
+    assert!(matches!(
+        repeated,
+        Err(Ok(LendingError::UpgradeAlreadyExecuted))
+    ));
+}
+
+#[test]
+fn expired_proposal_cannot_be_approved_or_executed() {
+    let (env, client, admin, second, _third) = setup();
+    client.upgrade_init(&approvers(&env, &admin, &second), &2);
+    let proposal_id = client.upgrade_propose(&wasm_hash(&env, 10));
+
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + DEFAULT_UPGRADE_EXPIRY_LEDGERS + 1);
+
+    let approve = client.try_upgrade_approve(&second, &proposal_id);
+    assert!(matches!(
+        approve,
+        Err(Ok(LendingError::UpgradeProposalExpired))
+    ));
+
+    let execute = client.try_upgrade_execute(&admin, &proposal_id);
+    assert!(matches!(
+        execute,
+        Err(Ok(LendingError::UpgradeProposalExpired))
+    ));
+}


### PR DESCRIPTION
## Summary

Closes #971.

Adds native timelocked WASM upgrade governance to the lending contract:

- `upgrade_init(approvers, threshold)` for admin-controlled approver setup
- `upgrade_propose(new_wasm_hash)` with ETA/expiry ledgers and admin auto-approval when eligible
- `upgrade_approve(approver, proposal_id)` with approver authorization and duplicate-approval rejection
- `upgrade_execute(executor, proposal_id)` with approver authorization, timelock, expiry, threshold, and double-execute guards
- audit views for approvers, threshold, proposals, approvals, delay, and expiry
- proposal/approval/execution events
- docs for authorization and operator playbook

## Tests

- `cargo fmt -p stellarlend-lending --check`
- `cargo test -p stellarlend-lending --lib upgrade_governance -- --nocapture`
- `cargo test -p stellarlend-lending --lib`

Note: I intentionally validated the lending library target. Full-package `cargo test -p stellarlend-lending` has pre-existing unrelated failures in this repo around example/cross-contract test targets, which are outside this upgrade-governance path.
