### PR TITLE
feat(lending): add cross-asset positions

### DIFF
--- a/docs/CROSS_ASSET_RULES.md
+++ b/docs/CROSS_ASSET_RULES.md
@@ -4,6 +4,30 @@
 
 The StellarLend protocol supports cross-asset borrowing and repaying, allowing users to deposit multiple types of collateral and borrow different assets. This document outlines the rules, invariants, and edge cases for these operations.
 
+## Current Lending Contract Surface
+
+The lending contract currently implements the following cross-asset entrypoints:
+
+- `set_asset_params(asset, ltv_bps, liquidation_threshold_bps, price_feed, debt_ceiling, can_collateralize, can_borrow)`
+- `deposit_collateral_asset(user, asset, amount)`
+- `borrow_asset(user, asset, amount)`
+- `repay_asset(user, asset, amount)`
+- `withdraw_asset(user, asset, amount)`
+- `get_cross_position_summary(user)`
+- `get_cross_collateral(user, asset)`
+- `get_cross_debt(user, asset)`
+
+Valuation uses stored `PriceRecord` values with 7-decimal precision (`10_000_000 = $1.00`).
+The implemented aggregate health factor is:
+
+```
+health_factor = sum(collateral_amount_i * price_i * liquidation_threshold_i)
+              / sum(debt_amount_j * price_j)
+```
+
+scaled by `10_000`. Missing or stale prices fail closed. Borrow-factor and reserve-factor
+fields described below remain extension points for future per-asset risk accounting.
+
 ## Core Concepts
 
 ### Asset Configuration

--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -62,6 +62,17 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 | `repay` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Remaining debt principal | Reduces user debt with interest accrued up to the current timestamp. Allowed in Normal and Recovery. |
 | `liquidate` | `(env, liquidator: Address, borrower: Address, amount: i128) → Result<i128, LendingError>` | `liquidator` | Actual debt repaid | Repays up to 50% of an undercollateralized borrower's debt and seizes proportional collateral (+ 10% bonus). Reverts if position is healthy (`hf >= 10000`). |
 
+### Cross-Asset Operations
+
+| Function | Signature | Auth | Returns | Description |
+|---|---|---|---|---|
+| `set_asset_params` | `(asset, ltv_bps, liquidation_threshold_bps, price_feed, debt_ceiling, can_collateralize, can_borrow)` | admin | `Result<(), LendingError>` | Configures an asset for cross-asset collateral and/or borrowing. |
+| `deposit_collateral_asset` | `(user, asset, amount)` | `user` | New per-asset collateral balance | Adds supported asset collateral and tracks the user's collateral asset list. |
+| `borrow_asset` | `(user, asset, amount)` | `user` | New per-asset debt | Borrows a supported asset if aggregate health factor remains `>= 10000` and the asset debt ceiling is respected. |
+| `repay_asset` | `(user, asset, amount)` | `user` | Remaining per-asset debt | Repays up to the current debt for that asset. |
+| `withdraw_asset` | `(user, asset, amount)` | `user` | Remaining per-asset collateral | Withdraws collateral only if the remaining aggregate position stays healthy. |
+| `get_cross_position_summary` | `(user)` | `CrossPositionSummary` | Aggregate collateral, weighted collateral, debt, and health factor. |
+
 ### Flash Loans
 
 | Function | Signature | Auth | Description |
@@ -146,7 +157,6 @@ The functions listed below appear in older documentation but are **not yet imple
 | `get_debt_value(env, user)` | USD-denominated debt value (requires oracle). |
 | `get_max_liquidatable_amount(env, user)` | Convenience helper for liquidators. |
 | `get_emergency_state(env)` | Public view for current lifecycle state (today exposed only via events). |
-| `deposit_collateral(env, user, asset, amount)` | Multi-asset collateral support. |
 | `upgrade_init / upgrade_propose / upgrade_approve / upgrade_execute` | Multisig upgrade governance. |
 | `data_store_init / data_save / data_load / data_backup / data_restore` | Persistent data-store management helpers. |
 

--- a/stellar-lend/contracts/lending/cross_asset.md
+++ b/stellar-lend/contracts/lending/cross_asset.md
@@ -7,7 +7,7 @@ The Cross-Asset implementation in StellarLend allows users to interact with mult
 - **Unified Position Logic**: All collateral assets contribute to a single USD-denominated borrowing capacity.
 - **Risk Management**: Each asset has its own Loan-to-Value (LTV) and Liquidation Threshold (LT).
 - **Asset Specificity**: Supports `set_asset_params` for admin configuration of LTV, LT, and price feeds.
-- **Aggregate Health Factor**: HealthFactor = (Σ CollateralValue_i * LTV_i) / Σ DebtValue_j.
+- **Aggregate Health Factor**: HealthFactor = (Σ CollateralValue_i * liquidation_threshold_i) / Σ DebtValue_j.
 
 ## Operations
 
@@ -17,35 +17,38 @@ Admin only function to configure an asset's parameters.
 - `liquidation_threshold`: Point at which the asset becomes eligible for liquidation (basis points).
 - `price_feed`: The oracle address providing the asset's price.
 - `debt_ceiling`: Total system-wide debt allowed for this asset.
+- `can_collateralize`: Whether this asset can be deposited as collateral.
+- `can_borrow`: Whether this asset can be borrowed.
 - **Event**: Emits `AssetParamsSetEvent`.
 
 ### `deposit_collateral_asset`
 Users can deposit any supported asset as collateral. This increases their total borrowing power based on the asset's USD value and its specific LTV.
 - **Pause Check**: Blocked if `PauseType::Deposit` or `PauseType::All` is set.
-- **Token Transfer**: Automatically transfers tokens from user to the contract.
+- **Accounting**: Updates per-user/per-asset collateral storage.
 - **Event**: Emits `CrossDepositEvent`.
 
 ### `borrow_asset`
 Users can borrow any supported asset as long as their aggregate Health Factor remains above 1.0 (10000 basis points).
 - **Pause Check**: Blocked if `PauseType::Borrow` or `PauseType::All` is set.
-- **Token Transfer**: Automatically transfers tokens from the contract to the user.
+- **Accounting**: Updates per-user/per-asset debt storage and per-asset total debt.
 - **Event**: Emits `CrossBorrowEvent`.
 
 ### `repay_asset`
 Users repay borrowed assets to reduce their total debt and improve their position's Health Factor.
 - **Pause Check**: Blocked if `PauseType::Repay` or `PauseType::All` is set.
-- **Token Transfer**: Automatically transfers tokens from user to the contract.
+- **Accounting**: Reduces per-user/per-asset debt and per-asset total debt.
 - **Event**: Emits `CrossRepayEvent`.
 
 ### `withdraw_asset`
 Collateral withdrawal is allowed only if the remaining position stays healthy (Health Factor > 1.0).
 - **Pause Check**: Blocked if `PauseType::Withdraw` or `PauseType::All` is set.
-- **Token Transfer**: Automatically transfers tokens from the contract to the user.
+- **Accounting**: Reduces per-user/per-asset collateral storage.
 - **Event**: Emits `CrossWithdrawEvent`.
 
 ### `get_cross_position_summary`
 Returns a summary of the user's position:
 - `total_collateral_usd`: Aggregated value of all collateral.
+- `weighted_collateral_usd`: Aggregated collateral value after liquidation thresholds.
 - `total_debt_usd`: Aggregated value of all debt.
 - `health_factor`: Unified risk indicator for the entire position.
 
@@ -74,8 +77,29 @@ The protocol uses a deterministic valuation model for multi-collateral positions
 To ensure safe and deterministic valuation, the oracle must satisfy the following:
 1. **Freshness**: Prices must be updated within the configured staleness window (default 1 hour). If any asset in a position has a stale price, the entire position's summary query will fail to prevent unsafe operations.
 2. **Precision**: All prices are scaled to 7 decimals (`10,000,000 = $1.00`) within the cross-asset module to maintain consistency.
-3. **Availability**: Both primary and fallback feeds are supported. Fallback is automatically used if the primary is stale or missing.
+3. **Availability**: Each asset must have a stored `PriceRecord`; missing prices fail closed.
 4. **Monotonicity**: Valuation must remain monotonic with respect to price changes. A price increase in collateral must never decrease the health factor.
+
+## Storage Model
+
+- `DataKey::AssetParams(asset)` stores per-asset risk and enablement flags.
+- `DataKey::CrossCollateral(user, asset)` stores per-user collateral balances.
+- `DataKey::CrossDebt(user, asset)` stores per-user debt balances.
+- `DataKey::CrossCollateralAssets(user)` and `DataKey::CrossDebtAssets(user)` store the asset lists used for aggregation.
+- `DataKey::CrossTotalDebt(asset)` stores per-asset total debt for debt-ceiling checks.
+
+## Validation
+
+Covered by `src/cross_asset_test.rs`:
+
+- multi-collateral aggregate borrow
+- exact aggregate health-factor boundary
+- insufficient-collateral rejection without mutation
+- repay capping at current debt
+- withdraw health-factor guard
+- per-asset debt ceiling
+- stale-price fail-safe
+- disabled asset rejection
 
 ## Security Considerations
 

--- a/stellar-lend/contracts/lending/src/cross_asset_test.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_test.rs
@@ -1,0 +1,180 @@
+use crate::{
+    AssetParams, DataKey, LendingContract, LendingContractClient, LendingError, PriceRecord,
+    HEALTH_FACTOR_NO_DEBT, HEALTH_FACTOR_SCALE, PRICE_SCALE,
+};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (
+    Env,
+    LendingContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let usdc = Address::generate(&env);
+    let eth = Address::generate(&env);
+    client.initialize(&admin);
+    seed_price(&env, &client.address, &usdc, PRICE_SCALE);
+    seed_price(&env, &client.address, &eth, 2_000 * PRICE_SCALE);
+    client.set_asset_params(&usdc, &9_000, &9_000, &usdc, &1_000_000, &true, &true);
+    client.set_asset_params(&eth, &8_000, &8_000, &eth, &1_000_000, &true, &true);
+    (env, client, admin, user, usdc, eth)
+}
+
+fn seed_price(env: &Env, contract: &Address, asset: &Address, price: i128) {
+    env.as_contract(contract, || {
+        env.storage().persistent().set(
+            &DataKey::OraclePrice(asset.clone()),
+            &PriceRecord {
+                price,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+    });
+}
+
+#[test]
+fn cross_asset_deposit_and_borrow_aggregate_collateral() {
+    let (_env, client, _admin, user, usdc, eth) = setup();
+
+    client.deposit_collateral_asset(&user, &usdc, &100);
+    client.deposit_collateral_asset(&user, &eth, &1);
+    let debt = client.borrow_asset(&user, &usdc, &1_000);
+
+    assert_eq!(debt, 1_000);
+    assert_eq!(client.get_cross_collateral(&user, &usdc), 100);
+    assert_eq!(client.get_cross_collateral(&user, &eth), 1);
+    assert_eq!(client.get_cross_debt(&user, &usdc), 1_000);
+
+    let summary = client.get_cross_position_summary(&user);
+    assert_eq!(summary.total_collateral_usd, 2_100);
+    assert_eq!(summary.weighted_collateral_usd, 1_690);
+    assert_eq!(summary.total_debt_usd, 1_000);
+    assert_eq!(summary.health_factor, 16_900);
+}
+
+#[test]
+fn borrow_rejects_when_aggregate_health_factor_would_break() {
+    let (_env, client, _admin, user, usdc, eth) = setup();
+    client.deposit_collateral_asset(&user, &usdc, &100);
+    client.deposit_collateral_asset(&user, &eth, &1);
+
+    let result = client.try_borrow_asset(&user, &usdc, &1_691);
+
+    assert!(
+        matches!(result, Err(Ok(LendingError::InsufficientCollateral))),
+        "expected InsufficientCollateral, got {:?}",
+        result
+    );
+    assert_eq!(client.get_cross_debt(&user, &usdc), 0);
+}
+
+#[test]
+fn borrow_exactly_at_aggregate_health_boundary_is_allowed() {
+    let (_env, client, _admin, user, usdc, eth) = setup();
+    client.deposit_collateral_asset(&user, &usdc, &100);
+    client.deposit_collateral_asset(&user, &eth, &1);
+
+    client.borrow_asset(&user, &usdc, &1_690);
+    let summary = client.get_cross_position_summary(&user);
+
+    assert_eq!(summary.health_factor, HEALTH_FACTOR_SCALE);
+}
+
+#[test]
+fn repay_asset_caps_at_current_debt() {
+    let (_env, client, _admin, user, usdc, eth) = setup();
+    client.deposit_collateral_asset(&user, &eth, &1);
+    client.borrow_asset(&user, &usdc, &500);
+
+    let remaining = client.repay_asset(&user, &usdc, &700);
+
+    assert_eq!(remaining, 0);
+    let summary = client.get_cross_position_summary(&user);
+    assert_eq!(summary.total_debt_usd, 0);
+    assert_eq!(summary.health_factor, HEALTH_FACTOR_NO_DEBT);
+}
+
+#[test]
+fn withdraw_asset_rejects_if_health_factor_would_break() {
+    let (_env, client, _admin, user, usdc, eth) = setup();
+    client.deposit_collateral_asset(&user, &eth, &1);
+    client.borrow_asset(&user, &usdc, &1_600);
+
+    let result = client.try_withdraw_asset(&user, &eth, &1);
+    assert!(
+        matches!(result, Err(Ok(LendingError::InsufficientCollateral))),
+        "expected InsufficientCollateral, got {:?}",
+        result
+    );
+    assert_eq!(client.get_cross_collateral(&user, &eth), 1);
+
+    client.repay_asset(&user, &usdc, &1_600);
+    assert_eq!(client.withdraw_asset(&user, &eth, &1), 0);
+}
+
+#[test]
+fn per_asset_debt_ceiling_is_enforced() {
+    let (_env, client, _admin, user, usdc, eth) = setup();
+    client.set_asset_params(&usdc, &9_000, &9_000, &usdc, &100, &true, &true);
+    client.deposit_collateral_asset(&user, &eth, &1);
+
+    let result = client.try_borrow_asset(&user, &usdc, &101);
+    assert!(
+        matches!(result, Err(Ok(LendingError::DebtCeilingExceeded))),
+        "expected DebtCeilingExceeded, got {:?}",
+        result
+    );
+    assert_eq!(client.borrow_asset(&user, &usdc, &100), 100);
+}
+
+#[test]
+fn stale_price_blocks_cross_asset_valuation() {
+    let (env, client, _admin, user, usdc, eth) = setup();
+    client.deposit_collateral_asset(&user, &eth, &1);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 3_601);
+    seed_price(&env, &client.address, &usdc, PRICE_SCALE);
+
+    let result = client.try_borrow_asset(&user, &usdc, &100);
+    assert!(
+        matches!(result, Err(Ok(LendingError::StaleOracleTimestamp))),
+        "expected StaleOracleTimestamp, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn unsupported_asset_operations_are_rejected() {
+    let (env, client, _admin, user, usdc, _eth) = setup();
+    let disabled = Address::generate(&env);
+    seed_price(&env, &client.address, &disabled, PRICE_SCALE);
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::AssetParams(disabled.clone()),
+            &AssetParams {
+                ltv_bps: 0,
+                liquidation_threshold_bps: 8_000,
+                price_feed: disabled.clone(),
+                debt_ceiling: 0,
+                can_collateralize: false,
+                can_borrow: false,
+            },
+        );
+    });
+
+    let deposit = client.try_deposit_collateral_asset(&user, &disabled, &1);
+    assert!(matches!(deposit, Err(Ok(LendingError::InvalidAmount))));
+
+    client.deposit_collateral_asset(&user, &usdc, &100);
+    let borrow = client.try_borrow_asset(&user, &disabled, &1);
+    assert!(matches!(borrow, Err(Ok(LendingError::InvalidAmount))));
+}

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -6,6 +6,8 @@ pub mod rate_model;
 pub mod rounding_strategy;
 
 #[cfg(test)]
+mod cross_asset_test;
+#[cfg(test)]
 mod deposit_accounting_test;
 #[cfg(test)]
 mod error_codes_test;
@@ -23,7 +25,7 @@ use debt::{
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, BytesN,
-    Env, IntoVal, Symbol, Val,
+    Env, IntoVal, Symbol, Val, Vec,
 };
 
 const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
@@ -35,6 +37,7 @@ pub const LIQUIDATION_THRESHOLD_BPS: i128 = 8000;
 const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
 const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
+const PRICE_SCALE: i128 = 10_000_000;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -58,6 +61,12 @@ pub enum DataKey {
     Guardian,
     PauseState(PauseType),
     RateParams,
+    AssetParams(Address),
+    CrossCollateral(Address, Address),
+    CrossDebt(Address, Address),
+    CrossCollateralAssets(Address),
+    CrossDebtAssets(Address),
+    CrossTotalDebt(Address),
 }
 
 #[contractevent]
@@ -134,6 +143,71 @@ pub enum LendingError {
 pub struct PriceRecord {
     pub price: i128,
     pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssetParams {
+    pub ltv_bps: i128,
+    pub liquidation_threshold_bps: i128,
+    pub price_feed: Address,
+    pub debt_ceiling: i128,
+    pub can_collateralize: bool,
+    pub can_borrow: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrossPositionSummary {
+    pub total_collateral_usd: i128,
+    pub weighted_collateral_usd: i128,
+    pub total_debt_usd: i128,
+    pub health_factor: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssetParamsSetEvent {
+    pub asset: Address,
+    pub ltv_bps: i128,
+    pub liquidation_threshold_bps: i128,
+    pub debt_ceiling: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrossDepositEvent {
+    pub user: Address,
+    pub asset: Address,
+    pub amount: i128,
+    pub balance: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrossBorrowEvent {
+    pub user: Address,
+    pub asset: Address,
+    pub amount: i128,
+    pub debt: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrossRepayEvent {
+    pub user: Address,
+    pub asset: Address,
+    pub amount: i128,
+    pub debt: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrossWithdrawEvent {
+    pub user: Address,
+    pub asset: Address,
+    pub amount: i128,
+    pub balance: i128,
 }
 
 #[contracttype]
@@ -226,6 +300,244 @@ impl LendingContract {
 
     pub fn get_price_record(env: Env, asset: Address) -> Option<PriceRecord> {
         env.storage().persistent().get(&DataKey::OraclePrice(asset))
+    }
+
+    /// Configure cross-asset risk parameters for an asset.
+    pub fn set_asset_params(
+        env: Env,
+        asset: Address,
+        ltv_bps: i128,
+        liquidation_threshold_bps: i128,
+        price_feed: Address,
+        debt_ceiling: i128,
+        can_collateralize: bool,
+        can_borrow: bool,
+    ) -> Result<(), LendingError> {
+        let admin = Self::get_admin(env.clone());
+        admin.require_auth();
+        if ltv_bps < 0
+            || liquidation_threshold_bps <= 0
+            || ltv_bps > liquidation_threshold_bps
+            || liquidation_threshold_bps > BPS_DENOM
+            || debt_ceiling < 0
+        {
+            return Err(LendingError::InvalidAmount);
+        }
+
+        let params = AssetParams {
+            ltv_bps,
+            liquidation_threshold_bps,
+            price_feed,
+            debt_ceiling,
+            can_collateralize,
+            can_borrow,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::AssetParams(asset.clone()), &params);
+
+        AssetParamsSetEvent {
+            asset,
+            ltv_bps,
+            liquidation_threshold_bps,
+            debt_ceiling,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_asset_params(env: Env, asset: Address) -> Option<AssetParams> {
+        env.storage().instance().get(&DataKey::AssetParams(asset))
+    }
+
+    /// Deposit a configured asset as cross-asset collateral.
+    pub fn deposit_collateral_asset(
+        env: Env,
+        user: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<i128, LendingError> {
+        check_pause_status(&env, ProtocolAction::Deposit);
+        check_emergency_status(&env, ProtocolAction::Deposit);
+        if amount <= 0 {
+            return Err(LendingError::InvalidAmount);
+        }
+        user.require_auth();
+        let params = get_asset_params_or_err(&env, &asset)?;
+        if !params.can_collateralize {
+            return Err(LendingError::InvalidAmount);
+        }
+        ensure_fresh_price(&env, &asset)?;
+
+        let key = DataKey::CrossCollateral(user.clone(), asset.clone());
+        let current = cross_collateral_balance(&env, &user, &asset);
+        let updated = current.checked_add(amount).ok_or(LendingError::Overflow)?;
+        env.storage().persistent().set(&key, &updated);
+        add_user_asset(&env, &DataKey::CrossCollateralAssets(user.clone()), &asset);
+
+        CrossDepositEvent {
+            user,
+            asset,
+            amount,
+            balance: updated,
+        }
+        .publish(&env);
+
+        Ok(updated)
+    }
+
+    /// Borrow a configured asset against aggregate cross-asset collateral.
+    pub fn borrow_asset(
+        env: Env,
+        user: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<i128, LendingError> {
+        check_pause_status(&env, ProtocolAction::Borrow);
+        check_emergency_status(&env, ProtocolAction::Borrow);
+        if amount <= 0 {
+            return Err(LendingError::InvalidAmount);
+        }
+        user.require_auth();
+        let params = get_asset_params_or_err(&env, &asset)?;
+        if !params.can_borrow {
+            return Err(LendingError::InvalidAmount);
+        }
+        ensure_fresh_price(&env, &asset)?;
+
+        let current_debt = cross_debt_balance(&env, &user, &asset);
+        let updated_debt = current_debt
+            .checked_add(amount)
+            .ok_or(LendingError::Overflow)?;
+        let current_total_debt = cross_total_debt(&env, &asset);
+        let updated_total_debt = current_total_debt
+            .checked_add(amount)
+            .ok_or(LendingError::Overflow)?;
+        if params.debt_ceiling > 0 && updated_total_debt > params.debt_ceiling {
+            return Err(LendingError::DebtCeilingExceeded);
+        }
+
+        let summary =
+            compute_cross_position(&env, &user, Some((asset.clone(), updated_debt)), None)?;
+        if summary.health_factor < HEALTH_FACTOR_SCALE {
+            return Err(LendingError::InsufficientCollateral);
+        }
+
+        env.storage().persistent().set(
+            &DataKey::CrossDebt(user.clone(), asset.clone()),
+            &updated_debt,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::CrossTotalDebt(asset.clone()), &updated_total_debt);
+        add_user_asset(&env, &DataKey::CrossDebtAssets(user.clone()), &asset);
+
+        CrossBorrowEvent {
+            user,
+            asset,
+            amount,
+            debt: updated_debt,
+        }
+        .publish(&env);
+
+        Ok(updated_debt)
+    }
+
+    /// Repay a configured borrowed asset.
+    pub fn repay_asset(
+        env: Env,
+        user: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<i128, LendingError> {
+        check_pause_status(&env, ProtocolAction::Repay);
+        check_emergency_status(&env, ProtocolAction::Repay);
+        if amount <= 0 {
+            return Err(LendingError::InvalidAmount);
+        }
+        user.require_auth();
+        let current_debt = cross_debt_balance(&env, &user, &asset);
+        let actual_repay = if amount > current_debt {
+            current_debt
+        } else {
+            amount
+        };
+        let updated_debt = current_debt.saturating_sub(actual_repay);
+        let updated_total_debt = cross_total_debt(&env, &asset).saturating_sub(actual_repay);
+
+        env.storage().persistent().set(
+            &DataKey::CrossDebt(user.clone(), asset.clone()),
+            &updated_debt,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::CrossTotalDebt(asset.clone()), &updated_total_debt);
+
+        CrossRepayEvent {
+            user,
+            asset,
+            amount: actual_repay,
+            debt: updated_debt,
+        }
+        .publish(&env);
+
+        Ok(updated_debt)
+    }
+
+    /// Withdraw cross-asset collateral if the remaining aggregate position is healthy.
+    pub fn withdraw_asset(
+        env: Env,
+        user: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<i128, LendingError> {
+        check_pause_status(&env, ProtocolAction::Withdraw);
+        check_emergency_status(&env, ProtocolAction::Withdraw);
+        if amount <= 0 {
+            return Err(LendingError::InvalidAmount);
+        }
+        user.require_auth();
+        let current = cross_collateral_balance(&env, &user, &asset);
+        if amount > current {
+            return Err(LendingError::InvalidAmount);
+        }
+        let updated = current.checked_sub(amount).ok_or(LendingError::Overflow)?;
+
+        let summary = compute_cross_position(&env, &user, None, Some((asset.clone(), updated)))?;
+        if summary.total_debt_usd > 0 && summary.health_factor < HEALTH_FACTOR_SCALE {
+            return Err(LendingError::InsufficientCollateral);
+        }
+
+        env.storage().persistent().set(
+            &DataKey::CrossCollateral(user.clone(), asset.clone()),
+            &updated,
+        );
+
+        CrossWithdrawEvent {
+            user,
+            asset,
+            amount,
+            balance: updated,
+        }
+        .publish(&env);
+
+        Ok(updated)
+    }
+
+    pub fn get_cross_position_summary(
+        env: Env,
+        user: Address,
+    ) -> Result<CrossPositionSummary, LendingError> {
+        compute_cross_position(&env, &user, None, None)
+    }
+
+    pub fn get_cross_collateral(env: Env, user: Address, asset: Address) -> i128 {
+        cross_collateral_balance(&env, &user, &asset)
+    }
+
+    pub fn get_cross_debt(env: Env, user: Address, asset: Address) -> i128 {
+        cross_debt_balance(&env, &user, &asset)
     }
 
     fn oracle_price_signature_payload(
@@ -875,6 +1187,163 @@ fn current_borrow_rate(env: &Env) -> i128 {
         }
         None => DEFAULT_APR_BPS,
     }
+}
+
+fn get_asset_params_or_err(env: &Env, asset: &Address) -> Result<AssetParams, LendingError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::AssetParams(asset.clone()))
+        .ok_or(LendingError::NotInitialized)
+}
+
+fn ensure_fresh_price(env: &Env, asset: &Address) -> Result<PriceRecord, LendingError> {
+    let record: PriceRecord = env
+        .storage()
+        .persistent()
+        .get(&DataKey::OraclePrice(asset.clone()))
+        .ok_or(LendingError::OraclePubkeyNotSet)?;
+    let now = env.ledger().timestamp();
+    if record.price <= 0 || now > record.timestamp.saturating_add(DEFAULT_ORACLE_MAX_AGE_SECS) {
+        return Err(LendingError::StaleOracleTimestamp);
+    }
+    Ok(record)
+}
+
+fn cross_collateral_balance(env: &Env, user: &Address, asset: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CrossCollateral(user.clone(), asset.clone()))
+        .unwrap_or(0)
+}
+
+fn cross_debt_balance(env: &Env, user: &Address, asset: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CrossDebt(user.clone(), asset.clone()))
+        .unwrap_or(0)
+}
+
+fn cross_total_debt(env: &Env, asset: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CrossTotalDebt(asset.clone()))
+        .unwrap_or(0)
+}
+
+fn add_user_asset(env: &Env, key: &DataKey, asset: &Address) {
+    let mut assets: Vec<Address> = env.storage().persistent().get(key).unwrap_or(Vec::new(env));
+    if !address_in_vec(&assets, asset) {
+        assets.push_back(asset.clone());
+        env.storage().persistent().set(key, &assets);
+    }
+}
+
+fn address_in_vec(addresses: &Vec<Address>, needle: &Address) -> bool {
+    for address in addresses.iter() {
+        if address == *needle {
+            return true;
+        }
+    }
+    false
+}
+
+fn asset_value_usd(amount: i128, price: i128) -> Result<i128, LendingError> {
+    amount
+        .checked_mul(price)
+        .and_then(|v| v.checked_div(PRICE_SCALE))
+        .ok_or(LendingError::Overflow)
+}
+
+fn weighted_value_usd(value: i128, bps: i128) -> Result<i128, LendingError> {
+    value
+        .checked_mul(bps)
+        .and_then(|v| v.checked_div(BPS_DENOM))
+        .ok_or(LendingError::Overflow)
+}
+
+fn compute_cross_position(
+    env: &Env,
+    user: &Address,
+    debt_override: Option<(Address, i128)>,
+    collateral_override: Option<(Address, i128)>,
+) -> Result<CrossPositionSummary, LendingError> {
+    let collateral_assets: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CrossCollateralAssets(user.clone()))
+        .unwrap_or(Vec::new(env));
+    let debt_assets: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CrossDebtAssets(user.clone()))
+        .unwrap_or(Vec::new(env));
+
+    let mut total_collateral_usd = 0i128;
+    let mut weighted_collateral_usd = 0i128;
+    for asset in collateral_assets.iter() {
+        let amount = match &collateral_override {
+            Some((override_asset, override_amount)) if *override_asset == asset => *override_amount,
+            _ => cross_collateral_balance(env, user, &asset),
+        };
+        if amount == 0 {
+            continue;
+        }
+        let params = get_asset_params_or_err(env, &asset)?;
+        let price = ensure_fresh_price(env, &asset)?;
+        let value = asset_value_usd(amount, price.price)?;
+        total_collateral_usd = total_collateral_usd
+            .checked_add(value)
+            .ok_or(LendingError::Overflow)?;
+        let weighted = weighted_value_usd(value, params.liquidation_threshold_bps)?;
+        weighted_collateral_usd = weighted_collateral_usd
+            .checked_add(weighted)
+            .ok_or(LendingError::Overflow)?;
+    }
+
+    let mut total_debt_usd = 0i128;
+    let mut saw_override_debt_asset = false;
+    for asset in debt_assets.iter() {
+        let amount = match &debt_override {
+            Some((override_asset, override_amount)) if *override_asset == asset => {
+                saw_override_debt_asset = true;
+                *override_amount
+            }
+            _ => cross_debt_balance(env, user, &asset),
+        };
+        if amount == 0 {
+            continue;
+        }
+        let price = ensure_fresh_price(env, &asset)?;
+        let value = asset_value_usd(amount, price.price)?;
+        total_debt_usd = total_debt_usd
+            .checked_add(value)
+            .ok_or(LendingError::Overflow)?;
+    }
+    if let Some((override_asset, override_amount)) = debt_override {
+        if !saw_override_debt_asset && override_amount > 0 {
+            let price = ensure_fresh_price(env, &override_asset)?;
+            let value = asset_value_usd(override_amount, price.price)?;
+            total_debt_usd = total_debt_usd
+                .checked_add(value)
+                .ok_or(LendingError::Overflow)?;
+        }
+    }
+
+    let health_factor = if total_debt_usd > 0 {
+        weighted_collateral_usd
+            .checked_mul(HEALTH_FACTOR_SCALE)
+            .and_then(|v| v.checked_div(total_debt_usd))
+            .ok_or(LendingError::Overflow)?
+    } else {
+        HEALTH_FACTOR_NO_DEBT
+    };
+
+    Ok(CrossPositionSummary {
+        total_collateral_usd,
+        weighted_collateral_usd,
+        total_debt_usd,
+        health_factor,
+    })
 }
 
 #[contract]


### PR DESCRIPTION
## Summary

Closes #970.

Implements cross-asset collateral/debt support in the lending contract:

- adds per-asset `AssetParams` with LTV, liquidation threshold, price feed, debt ceiling, and enablement flags
- adds per-user/per-asset collateral and debt storage
- tracks user collateral/debt asset lists so aggregate valuation can be computed on-chain
- implements `deposit_collateral_asset`, `borrow_asset`, `repay_asset`, `withdraw_asset`
- implements `get_cross_position_summary`, `get_cross_collateral`, and `get_cross_debt`
- enforces aggregate health factor, per-asset debt ceilings, stale-price fail-closed behavior, and unsupported asset rejection
- emits asset params and cross-asset operation events
- updates cross-asset docs and README shipped surface

## Tests

- `cargo fmt -p stellarlend-lending --check`
- `cargo test -p stellarlend-lending --lib cross_asset -- --nocapture`
- `cargo test -p stellarlend-lending --lib`

Note: I intentionally validated the lending library target. Full-package `cargo test -p stellarlend-lending` has pre-existing unrelated failures in this repo around example/cross-contract test targets, which are outside this cross-asset path.
