### PR TITLE
fix(lending): enforce granular pause checks

### DIFF
--- a/stellar-lend/contracts/lending/pause.md
+++ b/stellar-lend/contracts/lending/pause.md
@@ -224,6 +224,10 @@ mode act as master overrides.
 Emergency lifecycle states (`Shutdown`, `Recovery`) provide a secondary layer of protection for
 high-risk entry points.
 
+Core user entry points evaluate granular/global pause flags first, then emergency lifecycle state.
+This keeps the `All` flag and operation-specific flags available as immediate circuit breakers,
+including for `Recovery` unwind paths that would otherwise be allowed.
+
 | Emergency State | Granular Pause | High-Risk Op (e.g. `Borrow`) | Unwind Op (e.g. `Repay`) |
 | --------------- | -------------- | ---------------------------- | ------------------------ |
 | `Normal`        | `False`        | Allowed                      | Allowed                  |
@@ -243,8 +247,8 @@ Normal ──(emergency_shutdown)──► Shutdown ──(start_recovery)──
                                      └──────────────(complete_recovery, fast-exit)────────────────►
 ```
 
-During **Recovery**, the pause check for repay / withdraw explicitly allows these paths so users can
-fully unwind positions. All other entry points remain blocked.
+During **Recovery**, repay / withdraw remain available only when their granular pause flag and the
+global `All` flag are inactive. Deposit, borrow, and liquidation remain blocked by emergency state.
 
 ## Events
 
@@ -289,10 +293,11 @@ fully unwind positions. All other entry points remain blocked.
 
 ```rust
 // Pause borrowing in an emergency
-client.set_pause(&admin, &PauseType::Borrow, &true);
+let expires_at_ledger = env.ledger().sequence() + 100;
+client.set_pause(&admin, &PauseType::Borrow, &true, &expires_at_ledger);
 
 // Re-enable borrowing
-client.set_pause(&admin, &PauseType::Borrow, &false);
+client.set_pause(&admin, &PauseType::Borrow, &false, &expires_at_ledger);
 
 // Query pause state before presenting UI options
 let borrow_paused = client.get_pause_state(&PauseType::Borrow);

--- a/stellar-lend/contracts/lending/src/granular_pause_ops_test.rs
+++ b/stellar-lend/contracts/lending/src/granular_pause_ops_test.rs
@@ -1,0 +1,98 @@
+use crate::{LendingContract, LendingContractClient, PauseType};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin, user)
+}
+
+fn pause(
+    env: &Env,
+    client: &LendingContractClient<'static>,
+    admin: &Address,
+    operation: PauseType,
+) {
+    let expires_at = env.ledger().sequence().saturating_add(5);
+    client.set_pause(admin, &operation, &true, &expires_at);
+}
+
+fn advance_past_pause_expiry(env: &Env) {
+    let mut ledger = env.ledger().get();
+    ledger.sequence_number = ledger.sequence_number.saturating_add(10);
+    env.ledger().set(ledger);
+}
+
+#[test]
+#[should_panic(expected = "OperationPaused")]
+fn deposit_specific_pause_blocks_deposit() {
+    let (env, client, admin, user) = setup();
+    pause(&env, &client, &admin, PauseType::Deposit);
+
+    client.deposit(&user, &100);
+}
+
+#[test]
+#[should_panic(expected = "OperationPaused")]
+fn deposit_all_pause_blocks_deposit() {
+    let (env, client, admin, user) = setup();
+    pause(&env, &client, &admin, PauseType::All);
+
+    client.deposit(&user, &100);
+}
+
+#[test]
+#[should_panic(expected = "OperationPaused")]
+fn withdraw_specific_pause_blocks_withdraw() {
+    let (env, client, admin, user) = setup();
+    client.deposit(&user, &100);
+    pause(&env, &client, &admin, PauseType::Withdraw);
+
+    client.withdraw(&user, &25);
+}
+
+#[test]
+#[should_panic(expected = "OperationPaused")]
+fn withdraw_all_pause_blocks_withdraw() {
+    let (env, client, admin, user) = setup();
+    client.deposit(&user, &100);
+    pause(&env, &client, &admin, PauseType::All);
+
+    client.withdraw(&user, &25);
+}
+
+#[test]
+#[should_panic(expected = "OperationPaused")]
+fn borrow_specific_pause_blocks_borrow() {
+    let (env, client, admin, user) = setup();
+    pause(&env, &client, &admin, PauseType::Borrow);
+
+    client.borrow(&user, &50);
+}
+
+#[test]
+#[should_panic(expected = "OperationPaused")]
+fn borrow_all_pause_blocks_borrow() {
+    let (env, client, admin, user) = setup();
+    pause(&env, &client, &admin, PauseType::All);
+
+    client.borrow(&user, &50);
+}
+
+#[test]
+fn expired_pause_allows_operation_again() {
+    let (env, client, admin, user) = setup();
+    pause(&env, &client, &admin, PauseType::Deposit);
+    advance_past_pause_expiry(&env);
+
+    assert_eq!(client.deposit(&user, &100), 100);
+    assert!(!client.get_pause_state(&PauseType::Deposit));
+}

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -10,6 +10,8 @@ mod deposit_accounting_test;
 #[cfg(test)]
 mod error_codes_test;
 #[cfg(test)]
+mod granular_pause_ops_test;
+#[cfg(test)]
 mod health_factor_edge_test;
 #[cfg(test)]
 mod interest_drift_regression_test;
@@ -306,6 +308,52 @@ impl LendingContract {
         .publish(&env);
     }
 
+    /// Set or clear a granular pause flag.
+    ///
+    /// Core user operations check granular/global pause state before emergency
+    /// state so an active pause can also stop recovery-allowed unwind paths.
+    pub fn set_pause(
+        env: Env,
+        admin: Address,
+        operation: PauseType,
+        paused: bool,
+        expires_at_ledger: u32,
+    ) -> Result<(), LendingError> {
+        admin.require_auth();
+        if admin != Self::get_admin(env.clone()) {
+            return Err(LendingError::Unauthorized);
+        }
+
+        let key = DataKey::PauseState(operation);
+        let old_state = env.storage().instance().get(&key).unwrap_or(PauseState {
+            paused: false,
+            expires_at_ledger: 0,
+        });
+        let new_state = PauseState {
+            paused,
+            expires_at_ledger,
+        };
+        env.storage().instance().set(&key, &new_state);
+        PauseStateChangedEvent {
+            operation,
+            old_state,
+            new_state,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Return true if a specific operation is currently paused.
+    ///
+    /// `PauseType::All` acts as a global override for every operation-specific
+    /// query. Expired pauses are treated as inactive.
+    pub fn get_pause_state(env: Env, pause_type: PauseType) -> bool {
+        if pause_is_active(&env, PauseType::All) {
+            return true;
+        }
+        pause_is_active(&env, pause_type)
+    }
+
     pub fn set_min_borrow(env: Env, min_borrow: i128) -> Result<(), LendingError> {
         let admin = Self::get_admin(env.clone());
         admin.require_auth();
@@ -324,6 +372,7 @@ impl LendingContract {
 
     /// Deposit collateral for a user.
     pub fn deposit(env: Env, user: Address, amount: i128) -> Result<i128, LendingError> {
+        check_pause_status(&env, ProtocolAction::Deposit);
         check_emergency_status(&env, ProtocolAction::Deposit);
         if amount <= 0 {
             return Err(LendingError::InvalidAmount);
@@ -367,7 +416,9 @@ impl LendingContract {
         Ok(new_balance)
     }
 
+    /// Withdraw collateral after pause and emergency gates pass.
     pub fn withdraw(env: Env, user: Address, amount: i128) -> Result<i128, LendingError> {
+        check_pause_status(&env, ProtocolAction::Withdraw);
         check_emergency_status(&env, ProtocolAction::Withdraw);
         if amount <= 0 {
             return Err(LendingError::InvalidAmount);
@@ -404,7 +455,9 @@ impl LendingContract {
         Ok(new_balance)
     }
 
+    /// Borrow assets after pause and emergency gates pass.
     pub fn borrow(env: Env, user: Address, amount: i128) -> Result<i128, LendingError> {
+        check_pause_status(&env, ProtocolAction::Borrow);
         check_emergency_status(&env, ProtocolAction::Borrow);
         if amount <= 0 {
             return Err(LendingError::InvalidAmount);


### PR DESCRIPTION
Closes #969.

## Summary
- add the public `set_pause` and `get_pause_state` entrypoints backed by the existing `PauseState(PauseType)` storage and `PauseStateChangedEvent`
- enforce granular/global pause checks on `deposit`, `withdraw`, and `borrow` before the emergency-state gate, matching the existing `repay` ordering
- add focused lending tests for `PauseType::All`, operation-specific `Deposit`/`Withdraw`/`Borrow` pauses, and ledger-expired pause release
- update `pause.md` to document the pause-before-emergency ordering and the expiry-bearing `set_pause` call shape

## Validation
- `cargo test -p stellarlend-lending --lib` (104 tests passed)
- `cargo build -p stellarlend-lending`
- `cargo fmt --manifest-path contracts/lending/Cargo.toml -- --check`
- `rustfmt --edition 2021 --check stellar-lend/contracts/lending/src/lib.rs stellar-lend/contracts/lending/src/granular_pause_ops_test.rs`
- `git diff --check`

## Existing full-test caveat
- `cargo test -p stellarlend-lending` still fails outside this change because the existing `examples/scaling_demo.rs` has no `main` function and `tests/cross_contract_invocation.rs` expects a missing `target/wasm32-unknown-unknown/release/stellar_lend.wasm` plus older SDK auth/event APIs. The lending lib tests and package build pass.