### PR TITLE
docs: document lending rate model curve

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ This document provides a central, canonical entry point for all project document
 - [Security Assumptions](SECURITY_ASSUMPTIONS.md)
 - [Reentrancy Guarantees](REENTRANCY_GUARANTEES.md)
 
-These documents define the protocol’s core security model, including assumptions, invariants, and protections against reentrancy and malicious interactions.
+These documents define the protocol?? core security model, including assumptions, invariants, and protections against reentrancy and malicious interactions.
 
 
 ### Access Control & Admin
@@ -30,6 +30,7 @@ Single-page reference for frontend integrators: unit scales, entrypoint signatur
 
 ### Lending & Risk
 
+- [Interest Rate Kink Model](../stellar-lend/contracts/lending/RATE_MODEL.md)
 - [Risk Parameters](risk_params.md)
 
 Covers protocol-level parameters such as collateral ratios, liquidation thresholds, and limits enforced by the lending system.
@@ -47,7 +48,7 @@ Provides step-by-step instructions for building, deploying, and initializing con
 - [Interface Quick Reference](interface_quick_reference.md)
 - [Lending Contract README](../stellar-lend/contracts/lending/README.md)
 
-Documents the **shipping** function surface of the lending contract (`src/lib.rs`), including exact signatures, return types, error codes, and emergency state permissions. Functions that are planned but not yet implemented are explicitly marked as 🔮 Planned.
+Documents the **shipping** function surface of the lending contract (`src/lib.rs`), including exact signatures, return types, error codes, and emergency state permissions. Functions that are planned but not yet implemented are explicitly marked as ?? Planned.
 
 
 ## Additional Documentation
@@ -58,7 +59,7 @@ Documents the **shipping** function surface of the lending contract (`src/lib.rs
 
 ## Historical Documents
 
-⚠️ The following documents are retained for reference but may be outdated or superseded:
+??? The following documents are retained for reference but may be outdated or superseded:
 
 - PR summaries
 - Temporary notes

--- a/stellar-lend/contracts/lending/RATE_MODEL.md
+++ b/stellar-lend/contracts/lending/RATE_MODEL.md
@@ -1,0 +1,107 @@
+# Interest Rate Kink Model
+
+This document is the contributor reference for the lending contract borrow-rate
+curve implemented in [`src/rate_model.rs`](src/rate_model.rs). The model prices
+borrow demand from protocol utilization, expressed in basis points (bps):
+
+```text
+utilization_bps = total_debt * 10_000 / total_supply
+```
+
+When `total_supply` is zero, `current_borrow_rate` treats utilization as `0`.
+If `DataKey::RateParams` is not configured, the lending contract preserves the
+legacy fixed rate by returning `DEFAULT_APR_BPS = 500` from `debt.rs`.
+
+## Parameters
+
+All values are annualized bps unless otherwise noted.
+
+| Field | Default | Meaning |
+| --- | ---: | --- |
+| `base_rate_bps` | `100` | 1.00% APR at zero utilization before floor/ceiling clamps. |
+| `kink_utilization_bps` | `8_000` | 80% utilization point where the slope changes. |
+| `multiplier_bps` | `2_000` | Below-kink slope. Each full 100% of utilization adds 20.00% APR. |
+| `jump_multiplier_bps` | `10_000` | Above-kink slope. Each full 100% above the kink adds 100.00% APR. |
+| `rate_floor_bps` | `50` | Minimum returned borrow APR, 0.50%. |
+| `rate_ceiling_bps` | `10_000` | Maximum returned borrow APR, 100.00%. |
+
+## Formula
+
+`compute_borrow_rate(utilization_bps, params)` first calculates the below-kink
+portion:
+
+```text
+pre_kink_rate =
+  base_rate_bps
+  + min(utilization_bps, kink_utilization_bps) * multiplier_bps / 10_000
+```
+
+If utilization is above the kink, it adds the jump-rate portion:
+
+```text
+raw_rate =
+  pre_kink_rate
+  + (utilization_bps - kink_utilization_bps) * jump_multiplier_bps / 10_000
+```
+
+If utilization is at or below the kink:
+
+```text
+raw_rate = pre_kink_rate
+```
+
+The final borrow APR is clamped:
+
+```text
+borrow_rate_bps = min(max(raw_rate, rate_floor_bps), rate_ceiling_bps)
+```
+
+All arithmetic is integer bps arithmetic. Intermediate multiplication, addition,
+subtraction, and division use checked operations in `rate_model.rs`.
+
+## Default Curve Examples
+
+Using `RateParams::default()`:
+
+| Utilization | Input bps | Calculation | Borrow APR |
+| --- | ---: | --- | ---: |
+| 0% | `0` | `100` | `100` bps (1.00%) |
+| 50% | `5_000` | `100 + 5_000 * 2_000 / 10_000` | `1_100` bps (11.00%) |
+| 80% kink | `8_000` | `100 + 8_000 * 2_000 / 10_000` | `1_700` bps (17.00%) |
+| 100% | `10_000` | `1_700 + (10_000 - 8_000) * 10_000 / 10_000` | `3_700` bps (37.00%) |
+
+```text
+borrow_rate_bps
+10_000 |                              ceiling
+ 3_700 |                         *
+ 1_700 |                   *
+ 1_100 |             *
+   100 | *
+       +---0%-----50%-----80%----100%---- utilization
+```
+
+## Edge Behavior
+
+- Utilization can exceed 100% if `total_debt > total_supply`; the jump slope
+  continues to apply until `rate_ceiling_bps` clamps the result.
+- Low custom configurations can never return below `rate_floor_bps`.
+- High custom configurations can never return above `rate_ceiling_bps`.
+- The configured curve is monotonic non-decreasing for the default parameters.
+- `current_borrow_rate` reads `TotalDebt`, `TotalDeposits`, and `RateParams`
+  once through `load_rate_snapshot`, then computes the rate from that snapshot.
+
+## Tests
+
+The source-level tests in `src/rate_model.rs` cover the main curve checkpoints:
+
+- zero utilization returns the default base rate;
+- below-kink utilization is linear;
+- the 80% kink returns `1_700` bps;
+- 100% utilization returns `3_700` bps;
+- floor and ceiling clamps apply;
+- property tests assert monotonicity, deterministic output, non-negative rates,
+  and floor/ceiling bounds over broad utilization ranges.
+
+The integration-style tests near `current_borrow_rate` in `src/lib.rs` cover
+the storage snapshot behavior and the legacy `DEFAULT_APR_BPS` fallback when
+`RateParams` is absent.

--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -14,9 +14,9 @@ A secure, efficient lending protocol built on Soroban that allows users to depos
 
 - **Collateralized Borrowing**: Users deposit collateral and borrow up to the configured ceiling.
 - **Interest Accrual**: Debt grows continuously based on a fixed APR expressed in basis points.
-- **Risk Management**: Protocol-level debt ceilings, deposit caps, and a health-factor–based liquidation mechanism.
+- **Risk Management**: Protocol-level debt ceilings, deposit caps, and a health-factor??ased liquidation mechanism.
 - **Flash Loans**: Single-transaction loans with configurable fees; callers must implement an `on_flash_loan` callback.
-- **Emergency Lifecycle**: `Normal → Shutdown → Recovery → Normal` state machine controlled by the admin or guardian.
+- **Emergency Lifecycle**: `Normal ??Shutdown ??Recovery ??Normal` state machine controlled by the admin or guardian.
 - **Two-Step Admin Transfer**: Admin handoff requires both `propose_admin` and `accept_admin` to prevent lockouts.
 - **Arithmetic Safety**: All mutations use `checked_*` arithmetic; overflows return `LendingError::Overflow`.
 - **Persistent TTL Management**: Collateral and debt entries have their TTL extended on every read or write to prevent archival.
@@ -39,28 +39,28 @@ cargo test -p stellarlend-lending
 
 ## Contract Interface
 
-The table below reflects the **shipping** surface of `src/lib.rs` as of this branch. Functions marked **🔮 Planned** do not exist yet.
+The table below reflects the **shipping** surface of `src/lib.rs` as of this branch. Functions marked **?? Planned** do not exist yet.
 
 ### Initialization
 
 | Function | Signature | Auth | Description |
 |---|---|---|---|
-| `initialize` | `(env, admin: Address)` | — | One-time setup; sets admin and initial `EmergencyState::Normal`. Reverts if already initialized. |
-| `get_admin` | `(env) → Address` | — | Returns the current admin address. |
+| `initialize` | `(env, admin: Address)` | ??| One-time setup; sets admin and initial `EmergencyState::Normal`. Reverts if already initialized. |
+| `get_admin` | `(env) ??Address` | ??| Returns the current admin address. |
 | `propose_admin` | `(env, new_admin: Address)` | current admin | Step 1 of two-step admin transfer. Stores the proposed address. |
 | `accept_admin` | `(env)` | proposed admin | Step 2: accepts the role committed by `propose_admin`. |
 | `set_guardian` | `(env, guardian: Address)` | admin | Stores the guardian address allowed to enter `Shutdown`. |
-| `get_guardian` | `(env) → Option<Address>` | — | Returns the configured guardian address, if any. |
+| `get_guardian` | `(env) ??Option<Address>` | ??| Returns the configured guardian address, if any. |
 
 ### User Operations
 
 | Function | Signature | Auth | Returns | Description |
 |---|---|---|---|---|
-| `deposit` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | New collateral balance | Adds `amount` to the user's collateral. Enforces deposit cap. Blocked during Shutdown. |
-| `withdraw` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | New collateral balance | Removes `amount` from the user's collateral. Only allowed in Normal and Recovery states. |
-| `borrow` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Updated debt principal | Increases user debt; enforces `min_borrow` and protocol debt ceiling. Blocked during Shutdown/Recovery. |
-| `repay` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Remaining debt principal | Reduces user debt with interest accrued up to the current timestamp. Allowed in Normal and Recovery. |
-| `liquidate` | `(env, liquidator: Address, borrower: Address, amount: i128) → Result<i128, LendingError>` | `liquidator` | Actual debt repaid | Repays up to 50% of an undercollateralized borrower's debt and seizes proportional collateral (+ 10% bonus). Reverts if position is healthy (`hf >= 10000`). |
+| `deposit` | `(env, user: Address, amount: i128) ??Result<i128, LendingError>` | `user` | New collateral balance | Adds `amount` to the user's collateral. Enforces deposit cap. Blocked during Shutdown. |
+| `withdraw` | `(env, user: Address, amount: i128) ??Result<i128, LendingError>` | `user` | New collateral balance | Removes `amount` from the user's collateral. Only allowed in Normal and Recovery states. |
+| `borrow` | `(env, user: Address, amount: i128) ??Result<i128, LendingError>` | `user` | Updated debt principal | Increases user debt; enforces `min_borrow` and protocol debt ceiling. Blocked during Shutdown/Recovery. |
+| `repay` | `(env, user: Address, amount: i128) ??Result<i128, LendingError>` | `user` | Remaining debt principal | Reduces user debt with interest accrued up to the current timestamp. Allowed in Normal and Recovery. |
+| `liquidate` | `(env, liquidator: Address, borrower: Address, amount: i128) ??Result<i128, LendingError>` | `liquidator` | Actual debt repaid | Repays up to 50% of an undercollateralized borrower's debt and seizes proportional collateral (+ 10% bonus). Reverts if position is healthy (`hf >= 10000`). |
 
 ### Flash Loans
 
@@ -75,41 +75,41 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 
 | Function | Signature | Returns | Description |
 |---|---|---|---|
-| `get_position` | `(env, user: Address) → PositionSummary` | `{ collateral: i128, debt: i128, health_factor: i128 }` | Returns collateral balance, effective debt (principal + accrued interest), and health factor (`col * 8000 / debt`; `100_000_000` when debt is zero). Extends TTL on read. |
-| `get_debt_position` | `(env, user: Address) → DebtPosition` | `{ principal: i128, last_update: u64 }` | Raw debt state; useful for debugging or off-chain interest simulation. Extends TTL on read. |
-| `get_min_borrow` | `(env) → i128` | `i128` | Returns the current minimum borrow amount (default `0`). |
-| `get_health_factor` | `(env, user: Address) → i128` | `i128` | Convenience health-factor view using the same liquidation threshold scale; returns the no-debt sentinel when debt is zero. |
-| `get_protocol_metrics` | `(env) → ProtocolMetrics` | `{ total_borrow: i128, total_supply: i128, utilization_bps: i128, ledger: u32 }` | Returns aggregate borrow/supply utilization and the current ledger sequence. |
+| `get_position` | `(env, user: Address) ??PositionSummary` | `{ collateral: i128, debt: i128, health_factor: i128 }` | Returns collateral balance, effective debt (principal + accrued interest), and health factor (`col * 8000 / debt`; `100_000_000` when debt is zero). Extends TTL on read. |
+| `get_debt_position` | `(env, user: Address) ??DebtPosition` | `{ principal: i128, last_update: u64 }` | Raw debt state; useful for debugging or off-chain interest simulation. Extends TTL on read. |
+| `get_min_borrow` | `(env) ??i128` | `i128` | Returns the current minimum borrow amount (default `0`). |
+| `get_health_factor` | `(env, user: Address) ??i128` | `i128` | Convenience health-factor view using the same liquidation threshold scale; returns the no-debt sentinel when debt is zero. |
+| `get_protocol_metrics` | `(env) ??ProtocolMetrics` | `{ total_borrow: i128, total_supply: i128, utilization_bps: i128, ledger: u32 }` | Returns aggregate borrow/supply utilization and the current ledger sequence. |
 
 ### Oracle Price Controls
 
 | Function | Signature | Auth | Description |
 |---|---|---|---|
 | `set_oracle_pubkey` | `(env, pubkey: BytesN<32>)` | admin | Stores the Ed25519 public key used to verify signed price updates. |
-| `get_oracle_pubkey` | `(env) → Option<BytesN<32>>` | — | Returns the configured oracle public key, if any. |
-| `set_price` | `(env, caller: Address, asset: Address, price: i128, timestamp: u64, signature: BytesN<64>) → Result<(), LendingError>` | `caller` must be admin | Verifies a signed price payload and stores a fresh `PriceRecord` for `asset`. |
-| `get_price_record` | `(env, asset: Address) → Option<PriceRecord>` | — | Returns the stored oracle price and timestamp for `asset`, if present. |
+| `get_oracle_pubkey` | `(env) ??Option<BytesN<32>>` | ??| Returns the configured oracle public key, if any. |
+| `set_price` | `(env, caller: Address, asset: Address, price: i128, timestamp: u64, signature: BytesN<64>) ??Result<(), LendingError>` | `caller` must be admin | Verifies a signed price payload and stores a fresh `PriceRecord` for `asset`. |
+| `get_price_record` | `(env, asset: Address) ??Option<PriceRecord>` | ??| Returns the stored oracle price and timestamp for `asset`, if present. |
 
 ### Admin & Risk Controls
 
 | Function | Signature | Auth | Description |
 |---|---|---|---|
-| `set_min_borrow` | `(env, min_borrow: i128) → Result<(), LendingError>` | admin | Sets the minimum amount required to open or increase a borrow. |
-| `set_debt_ceiling` | `(env, ceiling: i128) → Result<(), LendingError>` | admin | Sets the maximum total protocol debt. |
-| `set_flash_fee` | `(env, fee_bps: i128) → Result<(), LendingError>` | admin | Sets the flash-loan fee in the inclusive range `[0, 1000]` bps. |
+| `set_min_borrow` | `(env, min_borrow: i128) ??Result<(), LendingError>` | admin | Sets the minimum amount required to open or increase a borrow. |
+| `set_debt_ceiling` | `(env, ceiling: i128) ??Result<(), LendingError>` | admin | Sets the maximum total protocol debt. |
+| `set_flash_fee` | `(env, fee_bps: i128) ??Result<(), LendingError>` | admin | Sets the flash-loan fee in the inclusive range `[0, 1000]` bps. |
 | `set_emergency_state` | `(env, new_state: EmergencyState)` | admin or guardian | Transitions between `Normal`, `Shutdown`, and `Recovery`. Emits `EmergencyStateChanged` event. |
 
 ### Emergency State Machine
 
 ```
-Normal ──► Shutdown ──► Recovery ──► Normal
+Normal ??????Shutdown ??????Recovery ??????Normal
 ```
 
 | State | Deposit | Borrow | Repay | Withdraw |
 |---|---|---|---|---|
-| `Normal` | ✅ | ✅ | ✅ | ✅ |
-| `Shutdown` | ❌ | ❌ | ❌ | ❌ |
-| `Recovery` | ❌ | ❌ | ✅ | ✅ |
+| `Normal` | ??| ??| ??| ??|
+| `Shutdown` | ??| ??| ??| ??|
+| `Recovery` | ??| ??| ??| ??|
 
 ### Error Reference
 
@@ -121,7 +121,7 @@ Normal ──► Shutdown ──► Recovery ──► Normal
 | `LendingError::BelowMinimumBorrow` | 1008 | Borrow amount is below the protocol minimum. |
 | `LendingError::NotInitialized` | 1009 | Contract has not been initialized. |
 | `LendingError::AlreadyInitialized` | 1010 | `initialize` called on an already-live contract. |
-| `LendingError::PositionHealthy` | 1011 | Liquidation rejected — health factor is sufficient. |
+| `LendingError::PositionHealthy` | 1011 | Liquidation rejected ??health factor is sufficient. |
 | `LendingError::DebtCeilingExceeded` | 2001 | Borrow would exceed the global debt ceiling. |
 | `LendingError::DepositCapExceeded` | 2002 | Deposit would exceed the total deposit cap. |
 | `LendingError::InvalidFeeBps` | 2005 | Flash loan fee is outside the permitted range. |
@@ -132,7 +132,7 @@ Normal ──► Shutdown ──► Recovery ──► Normal
 
 ---
 
-## 🔮 Planned Features
+## ?? Planned Features
 
 The functions listed below appear in older documentation but are **not yet implemented** in `src/lib.rs`. They are tracked for future milestones.
 
@@ -175,15 +175,16 @@ graph LR
 ### Execution Safety
 - **Reentrancy**: Flash loans set `DataKey::FlashActive = true` before the external call and clear it after. `deposit`, `withdraw`, and `repay` panic if the guard is active.
 - **Arithmetic Integrity**: All storage mutations use `checked_add` / `checked_sub`; overflows return `LendingError::Overflow` or panic with an informative message.
-- **Multi-User Isolation**: Storage keys include the user `Address` (e.g., `DataKey::Collateral(user)`), guaranteeing strict per-address namespacing — verified by `test_multi_user_isolation` in `src/lib.rs`.
+- **Multi-User Isolation**: Storage keys include the user `Address` (e.g., `DataKey::Collateral(user)`), guaranteeing strict per-address namespacing ??verified by `test_multi_user_isolation` in `src/lib.rs`.
 
 ---
 
 ## Documentation
 
-- [Interface Quick Reference](../../../../docs/interface_quick_reference.md) — compact, integrator-focused function table.
-- [Storage Layout](../../../../docs/storage.md) — persistent key schema and TTL policy.
-- [Developer Glossary](../../../../docs/glossary.md) — key protocol terms and numeric scales.
+- [Interface Quick Reference](../../../../docs/interface_quick_reference.md) ??compact, integrator-focused function table.
+- [Interest Rate Kink Model](RATE_MODEL.md) - borrow-rate parameters, formulas, and worked examples.
+- [Storage Layout](../../../../docs/storage.md) ??persistent key schema and TTL policy.
+- [Developer Glossary](../../../../docs/glossary.md) ??key protocol terms and numeric scales.
 
 ## License
 

--- a/stellar-lend/contracts/lending/src/rate_model.rs
+++ b/stellar-lend/contracts/lending/src/rate_model.rs
@@ -28,6 +28,15 @@ impl Default for RateParams {
     }
 }
 
+/// Compute the annualized borrow APR in basis points from utilization.
+///
+/// The kink curve and worked examples are documented in
+/// `stellar-lend/contracts/lending/RATE_MODEL.md`.
+///
+/// Formula:
+/// `base + min(utilization, kink) * multiplier / 10_000`, plus
+/// `(utilization - kink) * jump_multiplier / 10_000` above the kink, then
+/// clamped between `rate_floor_bps` and `rate_ceiling_bps`.
 pub fn compute_borrow_rate(utilization_bps: i128, params: &RateParams) -> i128 {
     let pre_kink_rate = params
         .base_rate_bps


### PR DESCRIPTION
## Summary
- add `stellar-lend/contracts/lending/RATE_MODEL.md` documenting the borrow-rate kink curve, default parameters, formulas, edge behavior, and worked examples
- cross-link the guide from the lending README and the top-level docs index
- add a source comment on `compute_borrow_rate` pointing contributors back to the guide

Closes #1057

## Validation
- confirmed `RATE_MODEL.md` exists and cross-links resolve locally
- confirmed `README.md`, `docs/INDEX.md`, and `rate_model.rs` reference the new guide

## Notes
- `cargo test -p stellarlend-lending rate_model --manifest-path stellar-lend/Cargo.toml` could not be run locally because `cargo` is not installed in this environment.