### PR TITLE
docs: document cross-asset health factor aggregation

### DIFF
--- a/docs/CROSS_ASSET_RULES.md
+++ b/docs/CROSS_ASSET_RULES.md
@@ -30,18 +30,28 @@ Each user has separate positions for each asset, tracking:
 
 ### Health Factor
 
-The health factor determines whether a position can be liquidated:
+The health factor determines whether a position can be liquidated. For the full
+formula, scales, and worked examples, see
+[Cross-Asset Operations](../stellar-lend/contracts/lending/cross_asset.md#aggregation-formula-and-scales).
 
+```text
+collateral_value_i = collateral_amount_i * price_i / PRICE_SCALE
+weighted_collateral_i = collateral_value_i * liquidation_threshold_i / BPS_SCALE
+debt_value_j = debt_amount_j * price_j / PRICE_SCALE
+
+total_weighted_collateral = sum(weighted_collateral_i)
+total_debt_value = sum(debt_value_j)
+health_factor = total_weighted_collateral * HF_SCALE / total_debt_value
 ```
-Health Factor = (Weighted Collateral Value / Weighted Debt Value) * 10000
-```
 
-- Health Factor >= 10000 (1.0): Position is healthy
-- Health Factor < 10000 (1.0): Position is liquidatable
+- `PRICE_SCALE = 10_000_000` for oracle prices.
+- `BPS_SCALE = 10_000` for risk weights.
+- `HF_SCALE = 10_000_000` in `src/math.rs`, where `10_000_000 = 1.0`.
+- Health factor `>= HF_SCALE`: position is healthy.
+- Health factor `< HF_SCALE`: position is liquidatable.
 
-**Weighted Collateral Value** = Sum of (Collateral Amount × Price × Collateral Factor) for all assets
-
-**Weighted Debt Value** = Sum of (Debt Amount × Price × Borrow Factor) for all assets
+When a UI or view presents health factor on a 10,000 scale, divide the
+`HF_SCALE` result by `1_000` using integer floor semantics.
 
 ## Borrowing Rules
 
@@ -358,8 +368,8 @@ Result:
 
 ## View Guarantees
 
-<<<<<<< HEAD
-The following guarantees hold for `get_cross_position_summary` and all other read-only view functions. These are verified by the invariant test suite in `cross_asset_view_invariants_test.rs`.
+The following guarantees describe the intended cross-asset summary behavior for
+`get_cross_position_summary` and other read-only view functions.
 
 ### G-1 — Read-only (no state mutation)
 
@@ -389,15 +399,17 @@ total_debt_usd = Σ_j  (debt_balances[j] × price_j) / 10_000_000
 
 `health_factor` is computed from the above totals using:
 
-```
+```text
 if total_debt_usd == 0:
-    health_factor = 1_000_000   # HF_NO_DEBT sentinel
+    health_factor = i128::MAX
 else:
-    weighted_collateral = Σ_i (collateral_value_i × ltv_i) / BPS_SCALE
-    health_factor       = weighted_collateral × BPS_SCALE / total_debt_usd
+    weighted_collateral_i = collateral_value_i * liquidation_threshold_i / BPS_SCALE
+    total_weighted_collateral = sum(weighted_collateral_i)
+    health_factor = total_weighted_collateral * HF_SCALE / total_debt_usd
 ```
 
-All divisions use integer floor semantics (truncation toward zero). `BPS_SCALE = 10_000`.
+All divisions use integer floor semantics (truncation toward zero).
+`BPS_SCALE = 10_000` and `HF_SCALE = 10_000_000`.
 
 ### G-6 — Monotonicity in collateral and debt
 
@@ -416,9 +428,9 @@ Depositing assets in any order produces the same `total_collateral_usd` and `hea
 
 ### G-9 — Rounding is conservative (floor division)
 
-All LTV weighting and USD-value conversions use integer floor division. This means:
+All risk weighting and USD-value conversions use integer floor division. This means:
 - `weighted_collateral` can only be less than or equal to the real-valued result.
-- A borrow is only permitted when the floor-divided health factor is **strictly above 1.0** (> `BPS_SCALE`).
+- A borrow is only permitted when the floor-divided health factor is above the configured healthy threshold.
 - Borrowers cannot extract more value than the floor-rounded weighted collateral.
 
 ### G-10 — No view-based exploitation
@@ -437,13 +449,11 @@ Because view functions are read-only and deterministic, there is no mechanism th
 | LTV = 0 | `weighted_collateral = 0`; borrow rejected by health check |
 | Overpayment of debt | Capped at outstanding balance; `total_debt_usd` goes to 0 |
 | Same asset in collateral and debt | Counted independently in both totals (no netting) |
-=======
-Read-only methods that surface position state — `get_user_position`,
-`get_collateral_balance`, `get_debt_balance`, `get_collateral_value`,
-`get_debt_value`, `get_health_factor`, `get_max_liquidatable_amount`, and
-`get_liquidation_incentive_amount` — are pinned by the invariant test suite
-in `stellar-lend/contracts/lending/src/views_test.rs`. The properties below
-hold for every user, asset configuration, and ordering of view calls.
+
+### Current View Helper Guarantees
+
+Read-only methods that surface position state should preserve the properties
+below for every user, asset configuration, and ordering of view calls.
 
 ### Consistency
 
@@ -481,7 +491,6 @@ Views never mutate state, never charge fees, and trigger only the read-only
 oracle lookup. Integrators MUST NOT rely on a view's value beyond the ledger
 height at which it was observed — oracle prices and risk parameters can
 change.
->>>>>>> origin
 
 ## Conclusion
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,8 @@ Single-page reference for frontend integrators: unit scales, entrypoint signatur
 ### Lending & Risk
 
 - [Risk Parameters](risk_params.md)
+- [Cross-Asset Rules](CROSS_ASSET_RULES.md)
+- [Cross-Asset Operations](../stellar-lend/contracts/lending/cross_asset.md)
 
 Covers protocol-level parameters such as collateral ratios, liquidation thresholds, and limits enforced by the lending system.
 

--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -181,6 +181,7 @@ graph LR
 
 ## Documentation
 
+- [Cross-Asset Operations](cross_asset.md) - multi-asset valuation, health-factor aggregation, and worked examples.
 - [Interface Quick Reference](../../../../docs/interface_quick_reference.md) — compact, integrator-focused function table.
 - [Storage Layout](../../../../docs/storage.md) — persistent key schema and TTL policy.
 - [Developer Glossary](../../../../docs/glossary.md) — key protocol terms and numeric scales.

--- a/stellar-lend/contracts/lending/cross_asset.md
+++ b/stellar-lend/contracts/lending/cross_asset.md
@@ -7,7 +7,8 @@ The Cross-Asset implementation in StellarLend allows users to interact with mult
 - **Unified Position Logic**: All collateral assets contribute to a single USD-denominated borrowing capacity.
 - **Risk Management**: Each asset has its own Loan-to-Value (LTV) and Liquidation Threshold (LT).
 - **Asset Specificity**: Supports `set_asset_params` for admin configuration of LTV, LT, and price feeds.
-- **Aggregate Health Factor**: HealthFactor = (Σ CollateralValue_i * LTV_i) / Σ DebtValue_j.
+- **Aggregate Health Factor**: Sum each asset's oracle-priced value into a common
+  unit, apply its risk weight, and divide weighted collateral by total debt.
 
 ## Operations
 
@@ -49,27 +50,113 @@ Returns a summary of the user's position:
 - `total_debt_usd`: Aggregated value of all debt.
 - `health_factor`: Unified risk indicator for the entire position.
 
-## Valuation and Oracle Requirements
+## Aggregation Formula And Scales
 
-### Valuation Examples
+The cross-asset risk calculation starts by normalizing every collateral and debt
+asset into the same oracle-priced value unit. The pure math helpers in
+`src/math.rs` use:
 
-The protocol uses a deterministic valuation model for multi-collateral positions. The total collateral value and health factor are calculated by aggregating per-asset values.
+| Scale | Value | Use |
+|---|---:|---|
+| `PRICE_SCALE` | `10_000_000` | Oracle prices, where `10_000_000 = $1.00`. |
+| `BPS_SCALE` | `10_000` | Risk weights, where `10_000 = 100%`. |
+| `HF_SCALE` | `10_000_000` | `math::SCALE`, where `10_000_000 = 1.0` health factor. |
 
-**Example 1: Multi-Collateral Position**
-- **User Deposits**:
-  - 100 USDC at $1.00 (LTV 90%)
-  - 1 ETH at $2,000.00 (LTV 80%)
-- **Calculations**:
-  - USDC Value: $100.00
-  - ETH Value: $2,000.00
-  - Total Collateral Value: $2,100.00
-  - Weighted Collateral: ($100 * 0.9) + ($2,000 * 0.8) = $90 + $1,600 = $1,690.00
-- **User Borrows**:
-  - 1,000 USDC ($1,000.00)
-- **Health Factor**:
-  - $1,690 / $1,000 = 1.69 (16,900 bps)
+For each collateral asset `i`:
 
-### Oracle Requirements for Multi-Collateral
+```text
+collateral_value_i = collateral_amount_i * price_i / PRICE_SCALE
+weighted_collateral_i = collateral_value_i * liquidation_threshold_i / BPS_SCALE
+```
+
+For each debt asset `j`:
+
+```text
+debt_value_j = debt_amount_j * price_j / PRICE_SCALE
+```
+
+Aggregate across all assets:
+
+```text
+total_collateral_value = sum(collateral_value_i)
+total_weighted_collateral = sum(weighted_collateral_i)
+total_debt_value = sum(debt_value_j)
+```
+
+Then derive the unified health factor:
+
+```text
+if total_debt_value == 0:
+    health_factor = i128::MAX
+else:
+    health_factor = total_weighted_collateral * HF_SCALE / total_debt_value
+```
+
+All divisions use integer floor semantics. A value below `HF_SCALE` is below
+1.0 and therefore liquidatable under the shared `math::is_liquidatable` helper.
+When presenting the same health factor on the 10,000 UI/BPS scale, divide the
+`HF_SCALE` result by `1_000`.
+
+For the rule and invariant view, see
+[Cross-Asset Rules](../../../docs/CROSS_ASSET_RULES.md).
+
+### Worked Example: Two Collaterals, One Debt
+
+Assume:
+
+| Asset | Side | Amount | Oracle price | Threshold | Value | Weighted value |
+|---|---|---:|---:|---:|---:|---:|
+| USDC | Collateral | `1_000` | `10_000_000` | `9_000` BPS | `1_000` | `900` |
+| ETH | Collateral | `2` | `20_000_000_000` | `8_000` BPS | `4_000` | `3_200` |
+| USDC | Debt | `3_000` | `10_000_000` | n/a | `3_000` | n/a |
+
+Step by step:
+
+```text
+usdc_collateral_value = 1_000 * 10_000_000 / 10_000_000
+                      = 1_000
+eth_collateral_value  = 2 * 20_000_000_000 / 10_000_000
+                      = 4_000
+
+usdc_weighted = 1_000 * 9_000 / 10_000
+              = 900
+eth_weighted  = 4_000 * 8_000 / 10_000
+              = 3_200
+
+total_weighted_collateral = 900 + 3_200
+                          = 4_100
+
+debt_value = 3_000 * 10_000_000 / 10_000_000
+           = 3_000
+
+health_factor = 4_100 * 10_000_000 / 3_000
+              = 13_666_666
+```
+
+The position is healthy because `13_666_666 > 10_000_000`. Displayed on the
+10,000 scale, the same result is `13_666` after floor division.
+
+### Worked Example: Single-Asset Degenerate Case
+
+A cross-asset position with one collateral asset and one debt asset collapses to
+the same arithmetic as `compute_health_factor(collateral_value, debt_value,
+liquidation_threshold_bps)`.
+
+```text
+collateral_value = 1_000
+debt_value = 400
+liquidation_threshold = 8_000
+
+weighted_collateral = 1_000 * 8_000 / 10_000
+                    = 800
+
+health_factor = 800 * 10_000_000 / 400
+              = 20_000_000
+```
+
+The health factor is exactly `2.0` on the `HF_SCALE` scale.
+
+## Oracle Requirements For Multi-Asset Positions
 
 To ensure safe and deterministic valuation, the oracle must satisfy the following:
 1. **Freshness**: Prices must be updated within the configured staleness window (default 1 hour). If any asset in a position has a stale price, the entire position's summary query will fail to prevent unsafe operations.

--- a/stellar-lend/contracts/lending/src/math.rs
+++ b/stellar-lend/contracts/lending/src/math.rs
@@ -92,7 +92,10 @@ pub fn compute_compound_interest(
     }
 }
 
-/// Compute health factor for a position
+/// Compute health factor for a position.
+///
+/// Cross-asset callers use the same BPS and fixed-point scales after aggregating
+/// oracle-priced collateral and debt values as described in `../cross_asset.md`.
 ///
 /// Formula: HF = (collateral_value * liquidation_threshold) / debt_value
 ///


### PR DESCRIPTION
## Summary
- expand `stellar-lend/contracts/lending/cross_asset.md` with cross-asset valuation scales, aggregation formulas, and worked examples
- cross-link the cross-asset rules from the lending README and docs index
- align `docs/CROSS_ASSET_RULES.md` with the shared health-factor formula and remove stale conflict markers in the view guarantees section
- add a `compute_health_factor` source comment pointing contributors to the cross-asset aggregation guide

Closes #1059

## Validation
- confirmed `cross_asset.md`, `docs/CROSS_ASSET_RULES.md`, `README.md`, `docs/INDEX.md`, and `src/math.rs` reference the cross-asset guide/formula
- confirmed `docs/CROSS_ASSET_RULES.md` has no leftover merge-conflict markers
- `cargo test --target wasm32v1-none --release` could not be run locally because `cargo` is not installed in this environment.
