### PR TITLE
feat: add per-grantee vesting schedule listing and incremental total-…

### DIFF
--- a/stellar-lend/contracts/vesting/README.md
+++ b/stellar-lend/contracts/vesting/README.md
@@ -6,6 +6,12 @@ Key behavior:
 
 - `cliff_seconds` prevents any claims until `now >= start + cliff_seconds`.
 - Linear vesting after the cliff over `duration_seconds`.
-- `revoke(grantee)` callable only by admin; unvested tokens are transferred to the treasury sink.
+- Multiple schedules can be recorded for the same `grantee`.
+- `get_grants(grantee)` returns every schedule currently recorded for that grantee.
+- `total_locked()` returns the aggregate locked supply tracked across all grants.
+- `claim(grantee, now)` advances that grantee's schedules to `now`, decreases `total_locked()` by newly vested amounts, and transfers the newly claimable balance.
+- `revoke(grantee)` callable only by admin; it advances that grantee's schedules to `now`, transfers any still-locked amount to the treasury sink, and removes the revoked schedules from the aggregate locked supply.
 
-See unit tests in `src/lib.rs` for expected behavior and examples.
+`total_locked()` is maintained incrementally during `add_grant`, `claim`, and `revoke`; it is not recomputed by scanning all stored schedules.
+
+See unit tests in `src/lib.rs` and `src/vesting_views_test.rs` for expected behavior and examples.

--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Grant {
     pub grantee: String,
     pub total: u128,
     pub claimed: u128,
+    pub released: u128,
     pub start_seconds: u64,
     pub duration_seconds: u64,
     pub cliff_seconds: u64,
@@ -25,28 +26,31 @@ impl Grant {
             return 0;
         }
         let elapsed = effective - self.start_seconds;
-        // linear vesting proportion: total * elapsed / duration
         (self.total as u128 * elapsed as u128) / self.duration_seconds as u128
     }
 
-    pub fn claimable_at(&self, now: u64) -> u128 {
-        if self.revoked {
-            return 0;
-        }
+    pub fn claimable(&self) -> u128 {
+        self.released.saturating_sub(self.claimed)
+    }
+
+    fn sync(&mut self, now: u64) -> u128 {
         let vested = self.vested_at(now);
-        if vested <= self.claimed {
-            0
-        } else {
-            vested - self.claimed
-        }
+        let newly_released = vested.saturating_sub(self.released);
+        self.released = vested;
+        newly_released
+    }
+
+    fn locked(&self) -> u128 {
+        self.total.saturating_sub(self.released)
     }
 }
 
 pub struct VestingContract {
     pub admin: String,
     pub treasury: String,
-    grants: HashMap<String, Grant>,
+    grants: HashMap<String, Vec<Grant>>,
     pub balances: HashMap<String, u128>,
+    total_locked: u128,
 }
 
 impl VestingContract {
@@ -56,9 +60,11 @@ impl VestingContract {
             treasury: treasury.to_string(),
             grants: HashMap::new(),
             balances: HashMap::new(),
+            total_locked: 0,
         }
     }
 
+    /// Adds a vesting schedule for `grantee` and increases the aggregate locked supply.
     pub fn add_grant(
         &mut self,
         grantee: &str,
@@ -71,35 +77,53 @@ impl VestingContract {
             grantee: grantee.to_string(),
             total,
             claimed: 0,
+            released: 0,
             start_seconds,
             duration_seconds,
             cliff_seconds,
             revoked: false,
         };
-        self.grants.insert(grantee.to_string(), g);
-        // escrow total in contract balance
+        self.grants.entry(grantee.to_string()).or_default().push(g);
         let bal = self.balances.entry("contract".to_string()).or_default();
         *bal += total;
+        self.total_locked += total;
+    }
+
+    fn sync_grants(&mut self, grantee: &str, now: u64) {
+        if let Some(grants) = self.grants.get_mut(grantee) {
+            for grant in grants.iter_mut() {
+                let newly_released = grant.sync(now);
+                self.total_locked = self.total_locked.saturating_sub(newly_released);
+            }
+        }
     }
 
     pub fn claim(&mut self, grantee: &str, now: u64) -> u128 {
-        let g = match self.grants.get_mut(grantee) {
+        self.sync_grants(grantee, now);
+        let grants = match self.grants.get_mut(grantee) {
             Some(x) => x,
             None => return 0,
         };
-        let amount = g.claimable_at(now);
+
+        let mut amount = 0;
+        for grant in grants.iter_mut() {
+            if grant.revoked {
+                continue;
+            }
+            let claimable = grant.claimable();
+            grant.claimed += claimable;
+            amount += claimable;
+        }
+
         if amount == 0 {
             return 0;
         }
-        g.claimed += amount;
-        // transfer from contract balance to grantee
+
         let cbal = self.balances.entry("contract".to_string()).or_default();
         if *cbal >= amount {
             *cbal -= amount;
-            let gbal = self.balances.entry(g.grantee.clone()).or_default();
+            let gbal = self.balances.entry(grantee.to_string()).or_default();
             *gbal += amount;
-        } else {
-            // insufficient balance; treat as zero transfer
         }
         amount
     }
@@ -108,34 +132,52 @@ impl VestingContract {
         if caller != self.admin {
             return Err("only admin can revoke".to_string());
         }
-        let g = match self.grants.get_mut(grantee) {
+
+        self.sync_grants(grantee, now);
+        let grants = match self.grants.get_mut(grantee) {
             Some(x) => x,
             None => return Err("no such grant".to_string()),
         };
-        if g.revoked {
+
+        let mut transfer = 0;
+        let mut revoked_any = false;
+        for grant in grants.iter_mut() {
+            if grant.revoked {
+                continue;
+            }
+            revoked_any = true;
+            let unvested = grant.locked();
+            transfer += unvested;
+            self.total_locked = self.total_locked.saturating_sub(unvested);
+            grant.total = grant.released;
+            grant.revoked = true;
+        }
+
+        if !revoked_any {
             return Err("already revoked".to_string());
         }
-        let vested = g.vested_at(now);
-        let unvested = if g.total > vested {
-            g.total - vested
-        } else {
-            0
-        };
-        // reduce contract balance and send unvested to treasury
+
         let cbal = self.balances.entry("contract".to_string()).or_default();
-        let transfer = if *cbal >= unvested { unvested } else { *cbal };
-        *cbal = cbal.saturating_sub(transfer);
+        let actual_transfer = if *cbal >= transfer { transfer } else { *cbal };
+        *cbal = cbal.saturating_sub(actual_transfer);
         let tbal = self.balances.entry(self.treasury.clone()).or_default();
-        *tbal += transfer;
-        // mark revoked and reduce grant total to vested amount
-        g.revoked = true;
-        g.total = vested;
-        Ok(transfer)
+        *tbal += actual_transfer;
+        Ok(actual_transfer)
     }
 
-    // helpers for tests
+    /// Returns the current token balance recorded for `who`.
     pub fn balance_of(&self, who: &str) -> u128 {
         *self.balances.get(who).unwrap_or(&0)
+    }
+
+    /// Returns every vesting schedule recorded for `grantee`.
+    pub fn get_grants(&self, grantee: &str) -> Vec<Grant> {
+        self.grants.get(grantee).cloned().unwrap_or_default()
+    }
+
+    /// Returns the aggregate locked supply tracked across all grants.
+    pub fn total_locked(&self) -> u128 {
+        self.total_locked
     }
 }
 
@@ -146,38 +188,34 @@ mod tests {
     #[test]
     fn claim_before_cliff_is_zero() {
         let mut c = VestingContract::new("admin", "treasury");
-        c.add_grant("alice", 1000, 1000, 1000, 200); // start=1000, cliff=200
-                                                     // time before cliff
-        let claimed = c.claim("alice", 1100); // start+100 < start+cliff
+        c.add_grant("alice", 1000, 1000, 1000, 200);
+        let claimed = c.claim("alice", 1100);
         assert_eq!(claimed, 0);
         assert_eq!(c.balance_of("alice"), 0);
+        assert_eq!(c.total_locked(), 1000);
     }
 
     #[test]
     fn claim_after_cliff_partial() {
         let mut c = VestingContract::new("admin", "treasury");
-        c.add_grant("bob", 1000, 1000, 1000, 100); // cliff at 1100
-                                                   // at time 1200, elapsed since start = 200, vested = 1000 * 200/1000 = 200
+        c.add_grant("bob", 1000, 1000, 1000, 100);
         let claimed = c.claim("bob", 1200);
         assert_eq!(claimed, 200);
         assert_eq!(c.balance_of("bob"), 200);
+        assert_eq!(c.total_locked(), 800);
     }
 
     #[test]
     fn revoke_claws_unvested_to_treasury() {
         let mut c = VestingContract::new("admin", "treasury");
         c.add_grant("carol", 1000, 1000, 1000, 100);
-        // at time 1200 vested=200
         let _ = c.claim("carol", 1200);
-        // contract had 1000, after claim it has 800
         assert_eq!(c.balance_of("contract"), 800);
-        // revoke by admin at time 1200
         let transferred = c.revoke("admin", "carol", 1200).expect("revoke failed");
-        // unvested was 800, so treasury should get 800
         assert_eq!(transferred, 800);
         assert_eq!(c.balance_of("treasury"), 800);
-        // grantee should only have vested (200) and further claims are zero
         assert_eq!(c.claim("carol", 1300), 0);
+        assert_eq!(c.total_locked(), 0);
     }
 
     #[test]
@@ -186,5 +224,9 @@ mod tests {
         c.add_grant("dan", 500, 0, 100, 0);
         let res = c.revoke("not-admin", "dan", 10);
         assert!(res.is_err());
+        assert_eq!(c.total_locked(), 500);
     }
 }
+
+#[cfg(test)]
+mod vesting_views_test;

--- a/stellar-lend/contracts/vesting/src/vesting_views_test.rs
+++ b/stellar-lend/contracts/vesting/src/vesting_views_test.rs
@@ -1,0 +1,88 @@
+use super::{Grant, VestingContract};
+
+#[test]
+fn get_grants_lists_multiple_schedules_for_one_grantee() {
+    let mut contract = VestingContract::new("admin", "treasury");
+    contract.add_grant("alice", 1000, 100, 1000, 100);
+    contract.add_grant("alice", 500, 200, 500, 0);
+
+    let grants = contract.get_grants("alice");
+    assert_eq!(grants.len(), 2);
+    assert_eq!(
+        grants[0],
+        Grant {
+            grantee: "alice".to_string(),
+            total: 1000,
+            claimed: 0,
+            released: 0,
+            start_seconds: 100,
+            duration_seconds: 1000,
+            cliff_seconds: 100,
+            revoked: false,
+        }
+    );
+    assert_eq!(
+        grants[1],
+        Grant {
+            grantee: "alice".to_string(),
+            total: 500,
+            claimed: 0,
+            released: 0,
+            start_seconds: 200,
+            duration_seconds: 500,
+            cliff_seconds: 0,
+            revoked: false,
+        }
+    );
+}
+
+#[test]
+fn get_grants_for_empty_grantee_returns_empty_list() {
+    let contract = VestingContract::new("admin", "treasury");
+    assert!(contract.get_grants("missing").is_empty());
+    assert_eq!(contract.total_locked(), 0);
+}
+
+#[test]
+fn total_locked_tracks_multiple_grants_after_claim() {
+    let mut contract = VestingContract::new("admin", "treasury");
+    contract.add_grant("alice", 1000, 1000, 1000, 0);
+    contract.add_grant("alice", 500, 1000, 500, 0);
+    contract.add_grant("bob", 800, 1000, 800, 0);
+
+    assert_eq!(contract.total_locked(), 2300);
+
+    let claimed = contract.claim("alice", 1500);
+    assert_eq!(claimed, 1000);
+    assert_eq!(contract.balance_of("alice"), 1000);
+    assert_eq!(contract.total_locked(), 1300);
+
+    let alice_grants = contract.get_grants("alice");
+    assert_eq!(alice_grants[0].released, 500);
+    assert_eq!(alice_grants[0].claimed, 500);
+    assert_eq!(alice_grants[1].released, 500);
+    assert_eq!(alice_grants[1].claimed, 500);
+}
+
+#[test]
+fn total_locked_tracks_revoke_without_scanning_other_grantees() {
+    let mut contract = VestingContract::new("admin", "treasury");
+    contract.add_grant("alice", 1000, 1000, 1000, 0);
+    contract.add_grant("alice", 500, 1000, 500, 0);
+    contract.add_grant("bob", 800, 1000, 800, 0);
+
+    let transferred = contract
+        .revoke("admin", "alice", 1250)
+        .expect("revoke should succeed");
+
+    assert_eq!(transferred, 1000);
+    assert_eq!(contract.balance_of("treasury"), 1000);
+    assert_eq!(contract.total_locked(), 800);
+
+    let alice_grants = contract.get_grants("alice");
+    assert!(alice_grants.iter().all(|grant| grant.revoked));
+    assert_eq!(alice_grants[0].total, 250);
+    assert_eq!(alice_grants[0].released, 250);
+    assert_eq!(alice_grants[1].total, 250);
+    assert_eq!(alice_grants[1].released, 250);
+}


### PR DESCRIPTION
## Summary

- Adds `get_grants(grantee)` to enumerate all vesting schedules for a grantee by updating the contract storage model from one grant per grantee to a per-grantee grant list.
- Adds `total_locked()` as a read-only aggregate locked-supply view, maintained incrementally during `add_grant`, `claim`, and `revoke` instead of by scanning storage.
- Adds lifecycle and edge-case tests for multi-grant listing, empty grantees, claim/read behavior, and revoke/read behavior, and documents the new view semantics in the vesting README.

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [x] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [x] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [x] Zero/negative/boundary values tested for numeric inputs
- [x] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

Notes:
`get_grants(grantee)` and `total_locked()` are read-only views and do not introduce new error codes. Boundary coverage includes empty grantees, pre-cliff claims, and partial/full vesting progression across multiple schedules.

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

Notes:
Not applicable. This PR only touches the vesting contract and does not affect `cross_asset`, repay semantics, or interest calculations.

### Upgrade safety _(skip if no storage / signature changes)_
- [x] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [x] `initialize` still idempotent (second call → `AlreadyInitialized`)

Notes:
This crate does not expose an `initialize` entrypoint in its current form. Storage shape changes are limited to the vesting contract internals. Repository-wide `docs/storage.md` was not updated because this simplified crate does not currently participate in that storage documentation structure.

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

Notes:
Not applicable. The current vesting crate does not emit events, and this PR does not add or rename any event topics.

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

Notes:
Not applicable in Soroban terms for this crate version. Access control behavior remains unchanged: only `revoke` is admin-gated, and the new functions are read-only views.

**Arithmetic**
- [x] No unchecked arithmetic on untrusted values
- [x] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

Notes:
Not applicable. This contract does not perform cross-contract calls.

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

Notes:
Not applicable. This PR does not change lending math; vesting math remains unchanged.

### Docs
- [x] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

Notes:
Updated `stellar-lend/contracts/vesting/README.md` for view semantics and incremental locked-supply tracking. The listed docs are not relevant to this vesting-only change.

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [x] No secrets or key material committed

Notes:
Validated with `cargo +stable test` and `cargo +stable test --release` in `stellar-lend/contracts/vesting`. The issue’s requested pinned-toolchain command could not be completed in this environment because `rustup` timed out while fetching Rust `1.91.0` from `stellar-lend/rust-toolchain.toml`.

## Test Output

```text
$ cargo +stable test
running 8 tests
test tests::claim_after_cliff_partial ... ok
test vesting_views_test::get_grants_for_empty_grantee_returns_empty_list ... ok
test tests::claim_before_cliff_is_zero ... ok
test tests::revoke_claws_unvested_to_treasury ... ok
test tests::revoke_only_admin ... ok
test vesting_views_test::total_locked_tracks_multiple_grants_after_claim ... ok
test vesting_views_test::total_locked_tracks_revoke_without_scanning_other_grantees ... ok
test vesting_views_test::get_grants_lists_multiple_schedules_for_one_grantee ... ok

test result: ok. 8 passed; 0 failed
```

```text
$ cargo +stable test --release
running 8 tests
test tests::claim_after_cliff_partial ... ok
test tests::claim_before_cliff_is_zero ... ok
test tests::revoke_claws_unvested_to_treasury ... ok
test vesting_views_test::get_grants_for_empty_grantee_returns_empty_list ... ok
test vesting_views_test::get_grants_lists_multiple_schedules_for_one_grantee ... ok
test tests::revoke_only_admin ... ok
test vesting_views_test::total_locked_tracks_multiple_grants_after_claim ... ok
test vesting_views_test::total_locked_tracks_revoke_without_scanning_other_grantees ... ok

test result: ok. 8 passed; 0 failed
```

fixes #1033 
