### PR TITLE
perf: per-ledger borrow-rate cache in debt.rs with equivalence tests

### DIFF
--- a/stellar-lend/contracts/lending/PERFORMANCE_REGRESSION_TESTING.md
+++ b/stellar-lend/contracts/lending/PERFORMANCE_REGRESSION_TESTING.md
@@ -10,6 +10,10 @@ This bounded range approach replaces the old `* 2` multiplier to tightly bound t
 ## Borrow Rate Storage Reads
 
 `current_borrow_rate` is a hot helper for borrow, repay, liquidation, and health-factor paths. It must load `TotalDebt`, `TotalDeposits`, and `RateParams` once through `load_rate_snapshot`, then perform all utilization and kink-rate math from that snapshot. This keeps storage reads bounded and prevents future edits from scattering duplicate aggregate loads through nested branches.
+
+The borrow rate is cached in temporary storage per ledger sequence through `debt::cached_borrow_rate`. The cache key is `DataKey::BorrowRateCache(env.ledger().sequence())`, so advancing the ledger naturally invalidates the warmed value and forces a fresh snapshot.
+
+Measured read reduction for warm same-ledger calls: the previous path performed three aggregate reads (`TotalDebt`, `TotalDeposits`, `RateParams`) plus utilization/rate math on every call. After the first call in a ledger, warm calls perform only the cache lookup and reuse the stored `rate_bps`, avoiding all three aggregate reads and the recomputation. Tests in `src/rate_cache_test.rs` assert cached/uncached equivalence for a fresh ledger value, same-ledger reuse, ledger-boundary recomputation, and utilization changes between ledgers.
 ## Liquidation Accrual Budget
 `liquidate` settles borrower debt once at the start of the function and reuses
 that settled principal for the health-factor check, close-factor cap, and final

--- a/stellar-lend/contracts/lending/src/debt.rs
+++ b/stellar-lend/contracts/lending/src/debt.rs
@@ -1,7 +1,8 @@
 use soroban_sdk::{contracttype, Address, Env};
 
 use crate::rounding_strategy::{calculate_interest_with_rounding, RoundingError, RoundingMode};
-use crate::DataKey;
+use crate::{rate_model, DataKey};
+use stellar_lend_common::BPS_DENOM;
 
 pub const DEFAULT_APR_BPS: i128 = 500;
 
@@ -10,6 +11,21 @@ pub const DEFAULT_APR_BPS: i128 = 500;
 pub struct DebtPosition {
     pub principal: i128,
     pub last_update: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RateSnapshot {
+    pub total_debt: i128,
+    pub total_supply: i128,
+    pub params: Option<rate_model::RateParams>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BorrowRateCache {
+    pub ledger_sequence: u32,
+    pub rate_bps: i128,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -44,6 +60,64 @@ pub fn load_debt(env: &Env, user: &Address) -> DebtPosition {
 pub fn save_debt(env: &Env, user: &Address, position: &DebtPosition) {
     let key = DataKey::Debt(user.clone());
     env.storage().persistent().set(&key, position);
+}
+
+/// Loads the aggregate values needed to compute the global borrow rate once.
+pub fn load_rate_snapshot(env: &Env) -> RateSnapshot {
+    let storage = env.storage();
+    let persistent = storage.persistent();
+    let instance = storage.instance();
+
+    RateSnapshot {
+        total_debt: persistent.get(&DataKey::TotalDebt).unwrap_or(0),
+        total_supply: persistent.get(&DataKey::TotalDeposits).unwrap_or(0),
+        params: instance.get(&DataKey::RateParams),
+    }
+}
+
+/// Computes the global borrow rate directly from current aggregate storage.
+pub fn uncached_borrow_rate(env: &Env) -> i128 {
+    let snapshot = load_rate_snapshot(env);
+
+    match snapshot.params {
+        Some(p) => {
+            let utilization_bps = if snapshot.total_supply > 0 {
+                snapshot.total_debt.saturating_mul(BPS_DENOM) / snapshot.total_supply
+            } else {
+                0
+            };
+            rate_model::compute_borrow_rate(utilization_bps, &p)
+        }
+        None => DEFAULT_APR_BPS,
+    }
+}
+
+/// Returns the global borrow rate, computing it at most once per ledger.
+///
+/// The temporary-storage key includes `env.ledger().sequence()`, so advancing
+/// the ledger naturally misses the previous cache entry and recomputes from a
+/// fresh `RateSnapshot`.
+pub fn cached_borrow_rate(env: &Env) -> i128 {
+    let ledger_sequence = env.ledger().sequence();
+    let key = DataKey::BorrowRateCache(ledger_sequence);
+
+    if let Some(cache) = env
+        .storage()
+        .temporary()
+        .get::<DataKey, BorrowRateCache>(&key)
+    {
+        if cache.ledger_sequence == ledger_sequence {
+            return cache.rate_bps;
+        }
+    }
+
+    let rate_bps = uncached_borrow_rate(env);
+    let cache = BorrowRateCache {
+        ledger_sequence,
+        rate_bps,
+    };
+    env.storage().temporary().set(&key, &cache);
+    rate_bps
 }
 
 pub fn elapsed_seconds(now: u64, last_update: u64) -> u64 {

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -21,10 +21,12 @@ mod health_factor_edge_test;
 mod interest_drift_regression_test;
 #[cfg(test)]
 mod rounding_drift_test;
+#[cfg(test)]
+mod rate_cache_test;
 
 use debt::{
-    borrow_amount, effective_debt, load_debt, repay_amount, save_debt, settle_accrual,
-    DebtPosition, DEFAULT_APR_BPS,
+    borrow_amount, cached_borrow_rate, effective_debt, load_debt, repay_amount, save_debt,
+    settle_accrual, DebtPosition, DEFAULT_APR_BPS,
 };
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
@@ -53,6 +55,7 @@ pub enum DataKey {
     TotalDeposits,
     DebtCeiling,
     DepositCap,
+    BorrowRateCache(u32),
     FlashActive,
     FlashFeeBps,
     BorrowMinAmount,
@@ -893,13 +896,6 @@ fn check_emergency_status(env: &Env, action: ProtocolAction) {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct RateSnapshot {
-    total_debt: i128,
-    total_supply: i128,
-    params: Option<rate_model::RateParams>,
-}
-
 /// Assert that the transaction signer is the protocol admin.
 /// Panics with the default auth error if not.
 fn assert_admin(env: &Env) {
@@ -924,32 +920,13 @@ fn assert_admin_or_guardian(env: &Env, state: &EmergencyState) {
     }
 }
 
-fn load_rate_snapshot(env: &Env) -> RateSnapshot {
-    let storage = env.storage();
-    let persistent = storage.persistent();
-    let instance = storage.instance();
-
-    RateSnapshot {
-        total_debt: persistent.get(&DataKey::TotalDebt).unwrap_or(0),
-        total_supply: persistent.get(&DataKey::TotalDeposits).unwrap_or(0),
-        params: instance.get(&DataKey::RateParams),
-    }
+#[cfg(test)]
+fn load_rate_snapshot(env: &Env) -> debt::RateSnapshot {
+    debt::load_rate_snapshot(env)
 }
 
 fn current_borrow_rate(env: &Env) -> i128 {
-    let snapshot = load_rate_snapshot(env);
-
-    match snapshot.params {
-        Some(p) => {
-            let utilization_bps = if snapshot.total_supply > 0 {
-                snapshot.total_debt.saturating_mul(10_000) / snapshot.total_supply
-            } else {
-                0
-            };
-            rate_model::compute_borrow_rate(utilization_bps, &p)
-        }
-        None => DEFAULT_APR_BPS,
-    }
+    cached_borrow_rate(env)
 }
 
 #[cfg(test)]

--- a/stellar-lend/contracts/lending/src/rate_cache_test.rs
+++ b/stellar-lend/contracts/lending/src/rate_cache_test.rs
@@ -1,0 +1,121 @@
+use crate::{
+    debt::{cached_borrow_rate, load_rate_snapshot, uncached_borrow_rate, BorrowRateCache},
+    rate_model::RateParams,
+    DataKey, LendingContract,
+};
+use soroban_sdk::{testutils::Ledger, Address, Env};
+
+/// Registers the lending contract and runs storage setup inside its context.
+fn with_contract<R>(env: &Env, f: impl FnOnce(Address) -> R) -> R {
+    let contract_id = env.register(LendingContract, ());
+    env.as_contract(&contract_id, || f(contract_id))
+}
+
+/// Writes the aggregate inputs used by the borrow-rate model.
+fn set_rate_inputs(env: &Env, total_debt: i128, total_deposits: i128, params: Option<RateParams>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalDebt, &total_debt);
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalDeposits, &total_deposits);
+
+    if let Some(params) = params {
+        env.storage().instance().set(&DataKey::RateParams, &params);
+    }
+}
+
+/// Reads the cached rate entry for a specific ledger sequence.
+fn read_cache(env: &Env, ledger_sequence: u32) -> Option<BorrowRateCache> {
+    env.storage()
+        .temporary()
+        .get(&DataKey::BorrowRateCache(ledger_sequence))
+}
+
+#[test]
+fn cached_rate_matches_uncached_rate_and_reuses_same_ledger_entry() {
+    let env = Env::default();
+    with_contract(&env, |_contract_id| {
+        env.ledger().set_sequence(1061);
+        set_rate_inputs(&env, 4_000, 10_000, Some(RateParams::default()));
+
+        let uncached = uncached_borrow_rate(&env);
+        let first_cached = cached_borrow_rate(&env);
+        let second_cached = cached_borrow_rate(&env);
+
+        assert_eq!(uncached, 900);
+        assert_eq!(first_cached, uncached);
+        assert_eq!(second_cached, uncached);
+
+        let cache = read_cache(&env, 1061).expect("cache entry should be stored");
+        assert_eq!(cache.ledger_sequence, 1061);
+        assert_eq!(cache.rate_bps, uncached);
+
+        let snapshot = load_rate_snapshot(&env);
+        assert_eq!(snapshot.total_debt, 4_000);
+        assert_eq!(snapshot.total_supply, 10_000);
+    });
+}
+
+#[test]
+fn ledger_advance_recomputes_from_fresh_inputs() {
+    let env = Env::default();
+    with_contract(&env, |_contract_id| {
+        env.ledger().set_sequence(200);
+        set_rate_inputs(&env, 4_000, 10_000, Some(RateParams::default()));
+        assert_eq!(cached_borrow_rate(&env), 900);
+
+        env.ledger().set_sequence(201);
+        set_rate_inputs(&env, 8_000, 10_000, Some(RateParams::default()));
+
+        let uncached_after_advance = uncached_borrow_rate(&env);
+        let cached_after_advance = cached_borrow_rate(&env);
+
+        assert_eq!(uncached_after_advance, 1_700);
+        assert_eq!(cached_after_advance, uncached_after_advance);
+        assert_eq!(
+            read_cache(&env, 200)
+                .expect("old cache remains keyed")
+                .rate_bps,
+            900
+        );
+        assert_eq!(
+            read_cache(&env, 201)
+                .expect("new cache should be stored")
+                .rate_bps,
+            1_700
+        );
+    });
+}
+
+#[test]
+fn utilization_change_between_ledgers_updates_cached_rate() {
+    let env = Env::default();
+    with_contract(&env, |_contract_id| {
+        env.ledger().set_sequence(300);
+        set_rate_inputs(&env, 0, 10_000, Some(RateParams::default()));
+        assert_eq!(cached_borrow_rate(&env), 100);
+
+        env.ledger().set_sequence(301);
+        set_rate_inputs(&env, 10_000, 10_000, Some(RateParams::default()));
+
+        assert_eq!(uncached_borrow_rate(&env), 3_700);
+        assert_eq!(cached_borrow_rate(&env), 3_700);
+    });
+}
+
+#[test]
+fn missing_rate_params_uses_legacy_default_and_is_cached() {
+    let env = Env::default();
+    with_contract(&env, |_contract_id| {
+        env.ledger().set_sequence(400);
+        set_rate_inputs(&env, 8_000, 10_000, None);
+
+        assert_eq!(uncached_borrow_rate(&env), crate::debt::DEFAULT_APR_BPS);
+        assert_eq!(cached_borrow_rate(&env), crate::debt::DEFAULT_APR_BPS);
+        assert_eq!(
+            read_cache(&env, 400).expect("default rate should be cached").rate_bps,
+            crate::debt::DEFAULT_APR_BPS
+        );
+    });
+}


### PR DESCRIPTION
closes #1061 