### PR TITLE
feat(lending): enforce health-factor and debt-ceiling checks in borrow

### DIFF
--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -58,7 +58,7 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 |---|---|---|---|---|
 | `deposit` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | New collateral balance | Adds `amount` to the user's collateral. Enforces deposit cap. Blocked during Shutdown. |
 | `withdraw` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | New collateral balance | Removes `amount` from the user's collateral. Only allowed in Normal and Recovery states. |
-| `borrow` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Updated debt principal | Increases user debt; enforces `min_borrow` and protocol debt ceiling. Blocked during Shutdown/Recovery. |
+| `borrow` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Updated debt principal | Increases user debt; enforces `min_borrow`, post-borrow health factor (`>= 1.0`), and protocol debt ceiling. Blocked during Shutdown/Recovery. |
 | `repay` | `(env, user: Address, amount: i128) → Result<i128, LendingError>` | `user` | Remaining debt principal | Reduces user debt with interest accrued up to the current timestamp. Allowed in Normal and Recovery. |
 | `liquidate` | `(env, liquidator: Address, borrower: Address, amount: i128) → Result<i128, LendingError>` | `liquidator` | Actual debt repaid | Repays up to 50% of an undercollateralized borrower's debt and seizes proportional collateral (+ 10% bonus). Reverts if position is healthy (`hf >= 10000`). |
 

--- a/stellar-lend/contracts/lending/borrow.md
+++ b/stellar-lend/contracts/lending/borrow.md
@@ -64,7 +64,7 @@ repay(user, 1_000);
 
 ## Overview
 
-The borrow function allows users to borrow assets from the StellarLend protocol by providing collateral. The system enforces minimum collateral ratios, tracks interest accrual, and respects protocol-level constraints such as debt ceilings and pause states.
+The borrow function allows users to borrow assets from the StellarLend protocol against deposited collateral. The system accrues interest on each borrow, enforces a post-borrow health factor of at least 1.0, and respects protocol-level constraints such as debt ceilings and pause states.
 
 ## Function Signature
 
@@ -72,60 +72,48 @@ The borrow function allows users to borrow assets from the StellarLend protocol 
 pub fn borrow(
     env: Env,
     user: Address,
-    asset: Address,
     amount: i128,
-    collateral_asset: Address,
-    collateral_amount: i128,
-) -> Result<(), BorrowError>
+) -> Result<i128, LendingError>
 ```
 
 ## Parameters
 
 - `env`: The contract environment
 - `user`: The borrower's address (must authorize the transaction)
-- `asset`: The address of the asset to borrow
 - `amount`: The amount to borrow (must be positive and above minimum)
-- `collateral_asset`: The address of the collateral asset
-- `collateral_amount`: The amount of collateral to deposit (must be positive)
 
 ## Returns
 
-- `Ok(())` on successful borrow
-- `Err(BorrowError)` on failure
+- `Ok(principal)` with the updated debt principal on success
+- `Err(LendingError)` on failure
 
 ## Error Types
 
 | Error                    | Description                                           |
 | ------------------------ | ----------------------------------------------------- |
-| `InsufficientCollateral` | Collateral ratio is below the minimum required (150%) |
-| `DebtCeilingReached`     | Protocol's total debt ceiling would be exceeded       |
-| `ProtocolPaused`         | Borrow operations are currently paused                |
-| `InvalidAmount`          | Amount or collateral is zero or negative              |
+| `InsufficientCollateral` | Post-borrow health factor would fall below 1.0        |
+| `DebtCeilingExceeded`    | Protocol's total debt ceiling would be exceeded       |
+| `InvalidAmount`          | Amount is zero or negative                            |
 | `BelowMinimumBorrow`     | Borrow amount is below the minimum threshold          |
 | `Overflow`               | Arithmetic overflow occurred during calculation       |
-| `Unauthorized`           | User did not authorize the transaction                |
-| `AssetNotSupported`      | The specified asset is not supported                  |
+
+Borrow also panics when the protocol or borrow operation is paused, or when emergency state blocks borrows.
 
 ## Security Assumptions
 
-### Collateral Ratio
+### Health Factor (Collateralization)
 
-- **Minimum Ratio**: 150% (15 000 basis points) — configurable by admin via `set_collateral_ratio`
-- Users must have collateral worth at least 1.5× their **total** debt (existing + new borrow)
-- Ratio is evaluated as:
-
-  ```
-  collateral * 10_000 / (existing_debt + amount) >= col_ratio
-  ```
-
-  Equivalently (overflow-safe form used in the contract):
+- **Liquidation threshold**: 80% (`LIQUIDATION_THRESHOLD_BPS = 8000`)
+- **Minimum health factor**: 1.0 (`HEALTH_FACTOR_SCALE = 10000`)
+- Before committing debt, `borrow` loads `DataKey::Collateral`, computes effective debt after accrual via `effective_debt` using `current_borrow_rate`, and requires:
 
   ```
-  collateral * 10_000 >= col_ratio * (existing_debt + amount)
+  collateral * LIQUIDATION_THRESHOLD_BPS >= HEALTH_FACTOR_SCALE * new_debt
   ```
 
-- The ratio is stored under the `"col_ratio"` instance-storage key; if unset the default of 15 000 bps applies
-- Prevents under-collateralised positions that could lead to protocol insolvency
+  Equivalently: `(collateral * 8000) / new_debt >= 10000`.
+
+- **Worked example**: 100 collateral and 80 debt → `100 * 8000 = 800_000 >= 10_000 * 80 = 800_000` (HF exactly 1.0). A borrow to 81 debt would fail because `800_000 < 810_000`.
 
 ### Interest Calculation
 
@@ -142,8 +130,9 @@ pub fn borrow(
 
 ### Debt Ceiling
 
-- Protocol enforces a maximum total debt limit
-- Each borrow checks if new total debt would exceed ceiling
+- Protocol enforces a maximum total debt limit via `DataKey::DebtCeiling` (set by admin through `set_debt_ceiling`)
+- Each borrow checks whether post-borrow `TotalDebt` would exceed the ceiling
+- Returns `LendingError::DebtCeilingExceeded` when `new_total_debt > ceiling`
 - Protects protocol from excessive leverage
 
 ### Minimum Borrow Threshold
@@ -159,17 +148,10 @@ pub fn borrow(
 
 ```rust
 let user = Address::from_string("GUSER...");
-let usdc = Address::from_string("GUSDC...");
-let xlm = Address::from_string("GXLM...");
 
-// Borrow 10,000 USDC with 20,000 XLM collateral (200% ratio)
-contract.borrow(
-    user.clone(),
-    usdc,
-    10_000,
-    xlm,
-    20_000
-)?;
+// Deposit collateral, then borrow up to the health-factor limit.
+contract.deposit(user.clone(), 200)?;
+contract.borrow(user.clone(), 100)?; // HF = (200 * 8000) / 100 = 16000
 ```
 
 ### Check User Position
@@ -267,31 +249,32 @@ The contract uses persistent storage for:
 
 Comprehensive tests cover:
 
-- ✅ Successful borrow with valid collateral
-- ✅ Insufficient collateral rejection
+- ✅ Successful borrow with sufficient collateral
+- ✅ Insufficient collateral / sub-1.0 health factor rejection
 - ✅ Protocol pause enforcement
 - ✅ Invalid amount validation
 - ✅ Below minimum borrow rejection
-- ✅ Debt ceiling enforcement
+- ✅ Debt ceiling enforcement (post-borrow `TotalDebt`)
 - ✅ Multiple borrows accumulation
 - ✅ Interest accrual over time
-- ✅ Collateral ratio validation
+- ✅ Health factor boundary and overflow protection
 - ✅ Pause/unpause functionality
-- ✅ Overflow protection
+
+Dedicated coverage lives in `src/borrow_health_factor_test.rs`.
 
 Run tests with:
 
 ```bash
-cargo test
+cargo test -p stellarlend-lending
 ```
 
 ## Security Considerations
 
 1. **Authorization**: User must authorize the transaction via `require_auth()`
-2. **Collateral Validation**: Strict enforcement of 150% minimum ratio
-3. **Overflow Protection**: All arithmetic uses checked operations
-4. **Debt Ceiling**: Prevents protocol over-leverage
-5. **Pause Mechanism**: Emergency stop functionality
+2. **Health factor validation**: Post-borrow HF must be `>= 1.0` using effective debt and liquidation threshold
+3. **Overflow protection**: All arithmetic uses checked operations
+4. **Debt ceiling**: Post-borrow `TotalDebt` cannot exceed `DataKey::DebtCeiling`
+5. **Pause mechanism**: Emergency stop functionality
 6. **Interest Calculation**: Uses saturating arithmetic to prevent overflow
 7. **Storage Isolation**: User positions stored separately to prevent cross-contamination
 

--- a/stellar-lend/contracts/lending/src/borrow_health_factor_test.rs
+++ b/stellar-lend/contracts/lending/src/borrow_health_factor_test.rs
@@ -1,0 +1,153 @@
+#![cfg(test)]
+
+use crate::{
+    LendingContract, LendingContractClient, LendingError, DataKey, HEALTH_FACTOR_SCALE,
+    LIQUIDATION_THRESHOLD_BPS,
+};
+use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, id, user)
+}
+
+/// Minimum collateral so effective debt `debt` keeps HF >= 1.0.
+fn min_collateral_for_debt(debt: i128) -> i128 {
+    (debt.saturating_mul(HEALTH_FACTOR_SCALE) + LIQUIDATION_THRESHOLD_BPS - 1)
+        / LIQUIDATION_THRESHOLD_BPS
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    let mut info: LedgerInfo = env.ledger().get();
+    info.timestamp = info.timestamp.saturating_add(seconds);
+    info.sequence_number = info.sequence_number.saturating_add(1);
+    env.ledger().set(info);
+}
+
+#[test]
+fn borrow_zero_collateral_rejected() {
+    let (_env, client, _admin, user) = setup();
+    let res = client.try_borrow(&user, &100);
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InsufficientCollateral))
+    ));
+    assert_eq!(client.get_position(&user).debt, 0);
+}
+
+#[test]
+fn borrow_at_exact_health_factor_threshold_succeeds() {
+    let (_env, client, _admin, user) = setup();
+    let debt = 80i128;
+    client.deposit(&user, &100);
+    let res = client.borrow(&user, &debt);
+    assert_eq!(res, debt);
+    assert_eq!(client.get_health_factor(&user), HEALTH_FACTOR_SCALE);
+}
+
+#[test]
+fn borrow_one_unit_past_health_factor_threshold_rejected() {
+    let (_env, client, _admin, user) = setup();
+    client.deposit(&user, &100);
+    let res = client.try_borrow(&user, &81);
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InsufficientCollateral))
+    ));
+    assert_eq!(client.get_position(&user).debt, 0);
+}
+
+#[test]
+fn borrow_rejects_when_weighted_collateral_multiplication_overflows() {
+    let (env, client, id, user) = setup();
+    let overflowing_collateral = i128::MAX / LIQUIDATION_THRESHOLD_BPS + 1;
+
+    env.as_contract(&id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user.clone()), &overflowing_collateral);
+    });
+
+    let res = client.try_borrow(&user, &1);
+    assert!(matches!(res, Err(Ok(LendingError::Overflow))));
+    assert_eq!(client.get_position(&user).debt, 0);
+}
+
+#[test]
+fn borrow_rejects_when_post_borrow_total_debt_exceeds_ceiling_by_one() {
+    let (_env, client, _id, user) = setup();
+    client.set_debt_ceiling(&1_000);
+    client.deposit(&user, &min_collateral_for_debt(1_001));
+
+    let first = client.borrow(&user, &1_000);
+    assert_eq!(first, 1_000);
+
+    let res = client.try_borrow(&user, &1);
+    assert!(matches!(res, Err(Ok(LendingError::DebtCeilingExceeded))));
+    assert_eq!(client.get_position(&user).debt, 1_000);
+}
+
+#[test]
+fn borrow_at_exact_debt_ceiling_succeeds() {
+    let (_env, client, _admin, user) = setup();
+    client.set_debt_ceiling(&500);
+    client.deposit(&user, &min_collateral_for_debt(500));
+
+    let res = client.borrow(&user, &500);
+    assert_eq!(res, 500);
+}
+
+#[test]
+fn second_borrow_with_accrued_interest_requires_extra_collateral() {
+    let (env, client, _admin, user) = setup();
+    client.deposit(&user, &125);
+    client.borrow(&user, &100);
+
+    advance_time(&env, SECONDS_PER_YEAR);
+    let position = client.get_position(&user);
+    assert!(position.debt > 100, "interest should have accrued");
+
+    let res = client.try_borrow(&user, &1);
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InsufficientCollateral))
+    ));
+
+    client.deposit(&user, &25);
+    let res = client.try_borrow(&user, &1);
+    assert!(matches!(res, Ok(Ok(_))));
+}
+
+#[test]
+fn healthy_borrow_succeeds_with_sufficient_collateral() {
+    let (_env, client, _admin, user) = setup();
+    client.deposit(&user, &200);
+    let res = client.borrow(&user, &100);
+    assert_eq!(res, 100);
+    assert!(client.get_health_factor(&user) > HEALTH_FACTOR_SCALE);
+}
+
+#[test]
+fn rejected_borrow_does_not_mutate_debt_or_total_debt() {
+    let (_env, client, _admin, user) = setup();
+    client.set_debt_ceiling(&10_000);
+    client.deposit(&user, &100);
+
+    let metrics_before = client.get_protocol_metrics();
+    let _ = client.try_borrow(&user, &200);
+
+    assert_eq!(client.get_position(&user).debt, 0);
+    assert_eq!(
+        client.get_protocol_metrics().total_borrow,
+        metrics_before.total_borrow
+    );
+}
+
+const SECONDS_PER_YEAR: u64 = 31_536_000;

--- a/stellar-lend/contracts/lending/src/emergency_state_matrix_test.rs
+++ b/stellar-lend/contracts/lending/src/emergency_state_matrix_test.rs
@@ -231,6 +231,7 @@ fn shutdown_blocks_borrow() {
 #[should_panic(expected = "OperationDisabledDuringShutdown")]
 fn shutdown_blocks_repay() {
     let (_env, client, _cid, _admin, _guardian, user) = setup_with_guardian();
+    client.deposit(&user, &250);
     client.borrow(&user, &100);
     client.set_emergency_state(&EmergencyState::Shutdown);
     client.repay(&user, &10);
@@ -244,8 +245,9 @@ fn shutdown_blocks_repay() {
 #[test]
 fn shutdown_does_not_block_liquidation() {
     let (env, client, _cid, _admin, _guardian, user) = setup_with_guardian();
-    client.deposit(&user, &100);
-    client.borrow(&user, &200);
+    client.deposit(&user, &125);
+    client.borrow(&user, &100);
+    client.withdraw(&user, &25);
     client.set_emergency_state(&EmergencyState::Shutdown);
     let liquidator = Address::generate(&env);
     let result = client.try_liquidate(&liquidator, &user, &100);
@@ -281,6 +283,7 @@ fn recovery_blocks_borrow() {
 #[test]
 fn recovery_allows_repay() {
     let (_env, client, _cid, _admin, _guardian, user) = setup_with_guardian();
+    client.deposit(&user, &250);
     client.borrow(&user, &100);
     client.set_emergency_state(&EmergencyState::Recovery);
     let remaining = client.repay(&user, &40);

--- a/stellar-lend/contracts/lending/src/health_factor_edge_test.rs
+++ b/stellar-lend/contracts/lending/src/health_factor_edge_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::debt::{save_debt, DebtPosition};
 use soroban_sdk::testutils::Address as _;
 
 fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
@@ -39,17 +40,15 @@ fn health_factor_no_debt_uses_healthy_sentinel() {
     assert_health_factor_consistency(&client, &user, HEALTH_FACTOR_NO_DEBT);
 }
 
-/// Zero collateral with non-zero debt must be liquidatable at an exact zero
-/// health factor, not the no-debt sentinel.
+/// Zero collateral cannot open debt through `borrow`; the entrypoint rejects
+/// before storage is mutated.
 #[test]
 fn health_factor_zero_collateral_nonzero_debt_is_zero() {
     let (_env, client, _id, user) = setup();
-    client.borrow(&user, &125);
-
-    let position = client.get_position(&user);
-    assert_eq!(position.collateral, 0);
-    assert_eq!(position.debt, 125);
-    assert_health_factor_consistency(&client, &user, 0);
+    let res = client.try_borrow(&user, &125);
+    assert!(matches!(res, Err(Ok(LendingError::InsufficientCollateral))));
+    assert_eq!(client.get_position(&user).debt, 0);
+    assert_health_factor_consistency(&client, &user, HEALTH_FACTOR_NO_DEBT);
 }
 
 /// The liquidation threshold boundary is exact: 100 collateral and 80 debt
@@ -63,8 +62,8 @@ fn health_factor_at_liquidation_threshold_is_exactly_scaled_one() {
     assert_health_factor_consistency(&client, &user, HEALTH_FACTOR_SCALE);
 }
 
-/// A collateral amount just past the checked-multiply boundary must not wrap;
-/// both view paths intentionally return i128::MAX as the overflow sentinel.
+/// Collateral large enough to overflow `collateral * LIQUIDATION_THRESHOLD_BPS`
+/// must be rejected at borrow time with `Overflow`.
 #[test]
 fn health_factor_overflow_returns_i128_max_sentinel() {
     let (env, client, id, user) = setup();
@@ -75,10 +74,21 @@ fn health_factor_overflow_returns_i128_max_sentinel() {
             .persistent()
             .set(&DataKey::Collateral(user.clone()), &overflowing_collateral);
     });
-    client.borrow(&user, &1);
 
-    let position = client.get_position(&user);
-    assert_eq!(position.collateral, overflowing_collateral);
-    assert_eq!(position.debt, 1);
+    let res = client.try_borrow(&user, &1);
+    assert!(matches!(res, Err(Ok(LendingError::Overflow))));
+    assert_eq!(client.get_position(&user).debt, 0);
+
+    env.as_contract(&id, || {
+        save_debt(
+            &env,
+            &user,
+            &DebtPosition {
+                principal: 1,
+                last_update: env.ledger().timestamp(),
+            },
+        );
+    });
+
     assert_health_factor_consistency(&client, &user, i128::MAX);
 }

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -20,6 +20,8 @@ mod health_factor_edge_test;
 #[cfg(test)]
 mod interest_drift_regression_test;
 #[cfg(test)]
+mod borrow_health_factor_test;
+#[cfg(test)]
 mod rounding_drift_test;
 
 use debt::{
@@ -35,7 +37,7 @@ use soroban_sdk::{
 const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
 const DEFAULT_DEPOSIT_CAP: i128 = 1_000_000_000_000;
 #[allow(dead_code)]
-const HEALTH_FACTOR_SCALE: i128 = 10_000;
+pub(crate) const HEALTH_FACTOR_SCALE: i128 = 10_000;
 const HEALTH_FACTOR_NO_DEBT: i128 = 100_000_000;
 pub const LIQUIDATION_THRESHOLD_BPS: i128 = 8000;
 const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
@@ -444,6 +446,11 @@ impl LendingContract {
     }
 
     /// Borrow assets after pause and emergency gates pass.
+    ///
+    /// Accrues interest on the existing position, increases principal by `amount`,
+    /// and rejects the borrow when the post-borrow health factor would fall below
+    /// 1.0 (`HEALTH_FACTOR_SCALE`) or when protocol `TotalDebt` would exceed
+    /// `DataKey::DebtCeiling`.
     pub fn borrow(env: Env, user: Address, amount: i128) -> Result<i128, LendingError> {
         check_pause_status(&env, ProtocolAction::Borrow);
         check_emergency_status(&env, ProtocolAction::Borrow);
@@ -464,8 +471,7 @@ impl LendingContract {
             debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
             debt::DebtError::Overflow => LendingError::Overflow,
         })?;
-        save_debt(&env, &user, &updated);
-        // Track protocol-level total debt
+
         let total_debt: i128 = env
             .storage()
             .persistent()
@@ -474,10 +480,14 @@ impl LendingContract {
         let delta = updated
             .principal
             .checked_sub(prev_principal)
-            .expect("borrow: delta overflow");
+            .ok_or(LendingError::Overflow)?;
         let new_total_debt = total_debt
             .checked_add(delta)
-            .expect("borrow: total_debt overflow");
+            .ok_or(LendingError::Overflow)?;
+
+        assert_borrow_solvent(&env, &user, &updated, new_total_debt)?;
+
+        save_debt(&env, &user, &updated);
         env.storage()
             .persistent()
             .set(&DataKey::TotalDebt, &new_total_debt);
@@ -936,6 +946,57 @@ fn load_rate_snapshot(env: &Env) -> RateSnapshot {
     }
 }
 
+/// Reject a prospective borrow that would leave the user undercollateralized or
+/// push protocol `TotalDebt` past the configured ceiling.
+///
+/// Health factor uses effective debt after accrual:
+/// `(collateral * LIQUIDATION_THRESHOLD_BPS) / new_debt >= HEALTH_FACTOR_SCALE`.
+/// The overflow-safe equivalent is
+/// `collateral * LIQUIDATION_THRESHOLD_BPS >= HEALTH_FACTOR_SCALE * new_debt`.
+///
+/// # Worked example
+/// With 100 collateral, 80% liquidation threshold, and 80 debt:
+/// `100 * 8000 = 800_000 >= 10_000 * 80 = 800_000` — exactly at HF 1.0.
+/// A borrow to 81 debt would fail because `800_000 < 810_000`.
+fn assert_borrow_solvent(
+    env: &Env,
+    user: &Address,
+    updated_position: &DebtPosition,
+    new_total_debt: i128,
+) -> Result<(), LendingError> {
+    let col_key = DataKey::Collateral(user.clone());
+    let collateral: i128 = env.storage().persistent().get(&col_key).unwrap_or(0);
+
+    let now = env.ledger().timestamp();
+    let rate = current_borrow_rate(env);
+    let new_debt = effective_debt(updated_position, now, rate).map_err(|_| LendingError::Overflow)?;
+
+    if new_debt > 0 {
+        let weighted_collateral = collateral
+            .checked_mul(LIQUIDATION_THRESHOLD_BPS)
+            .ok_or(LendingError::Overflow)?;
+        let required_collateral = HEALTH_FACTOR_SCALE
+            .checked_mul(new_debt)
+            .ok_or(LendingError::Overflow)?;
+
+        if weighted_collateral < required_collateral {
+            return Err(LendingError::InsufficientCollateral);
+        }
+    }
+
+    if let Some(ceiling) = env
+        .storage()
+        .instance()
+        .get::<DataKey, i128>(&DataKey::DebtCeiling)
+    {
+        if new_total_debt > ceiling {
+            return Err(LendingError::DebtCeilingExceeded);
+        }
+    }
+
+    Ok(())
+}
+
 fn current_borrow_rate(env: &Env) -> i128 {
     let snapshot = load_rate_snapshot(env);
 
@@ -1305,12 +1366,14 @@ mod test {
     #[test]
     fn test_borrow_increases_debt() {
         let (_env, client, _admin, user) = setup();
+        client.deposit(&user, &125);
         assert_eq!(client.borrow(&user, &50), 50);
     }
 
     #[test]
     fn test_repay_decreases_debt() {
         let (_env, client, _admin, user) = setup();
+        client.deposit(&user, &250);
         client.borrow(&user, &100);
         assert_eq!(client.repay(&user, &30), 70);
     }
@@ -1345,6 +1408,7 @@ mod test {
     #[test]
     fn test_get_debt_position_extends_debt_ttl() {
         let (env, client, _admin, user) = setup();
+        client.deposit(&user, &250);
         client.borrow(&user, &100);
 
         advance_time(&env, (PERSISTENT_TTL_LEDGERS / 2) as u64);
@@ -1376,6 +1440,7 @@ mod test {
     fn test_borrow_exactly_minimum_accepted() {
         let (_env, client, _admin, user) = setup();
         client.set_min_borrow(&50);
+        client.deposit(&user, &125);
         let res = client.borrow(&user, &50);
         assert_eq!(res, 50);
     }
@@ -1410,12 +1475,12 @@ mod test {
     }
 
     #[test]
-    fn test_health_factor_unhealthy() {
+    fn test_health_factor_unhealthy_borrow_rejected() {
         let (_env, client, _admin, user) = setup();
         client.deposit(&user, &100);
-        client.borrow(&user, &200);
-        let hf = client.get_health_factor(&user);
-        assert!(hf < HEALTH_FACTOR_SCALE);
+        let res = client.try_borrow(&user, &200);
+        assert!(matches!(res, Err(Ok(LendingError::InsufficientCollateral))));
+        assert_eq!(client.get_health_factor(&user), HEALTH_FACTOR_NO_DEBT);
     }
 
     #[test]
@@ -1506,6 +1571,7 @@ mod test {
     #[should_panic(expected = "OperationDisabledDuringShutdown")]
     fn test_shutdown_blocks_repay() {
         let (_env, client, _admin, user) = setup();
+        client.deposit(&user, &250);
         client.borrow(&user, &100);
         client.set_emergency_state(&EmergencyState::Shutdown);
         client.repay(&user, &10);


### PR DESCRIPTION
## Overview
This PR enforces collateral health-factor and protocol debt-ceiling checks in `LendingContract::borrow` before user debt or `TotalDebt` is committed. Borrows that would push the borrower's health factor below 1.0 (`10000` BPS) or exceed `DataKey::DebtCeiling` are now rejected with `LendingError::InsufficientCollateral` and `LendingError::DebtCeilingExceeded` respectively.

## Related Issue
Closes #961

## Changes

### 🔒 Borrow Solvency Guard
- **[MODIFY]** `stellar-lend/contracts/lending/src/lib.rs`
- Added `assert_borrow_solvent()` to validate post-borrow health factor and debt ceiling prospectively.
- Loads `DataKey::Collateral`, computes effective debt via `effective_debt()` using `current_borrow_rate()`, and requires `collateral * LIQUIDATION_THRESHOLD_BPS >= HEALTH_FACTOR_SCALE * new_debt`.
- Rejects when post-borrow `TotalDebt` exceeds `DataKey::DebtCeiling`.
- Uses checked arithmetic throughout; returns `LendingError::Overflow` instead of panicking.
- Wired the guard into `borrow()` before `save_debt` / `TotalDebt` updates.

### 🧪 Tests
- **[ADD]** `stellar-lend/contracts/lending/src/borrow_health_factor_test.rs`
- Zero collateral rejection.
- Exact health-factor threshold boundary (100 collateral / 80 debt).
- One-unit past threshold rejection.
- Collateral multiply overflow handling.
- Debt ceiling exact match and exceed-by-one rejection.
- Second borrow with accrued interest requiring extra collateral.
- No state mutation on rejected borrow.

- **[MODIFY]** `stellar-lend/contracts/lending/src/health_factor_edge_test.rs`
- Updated edge-case tests to reflect borrow-time enforcement.

- **[MODIFY]** `stellar-lend/contracts/lending/src/emergency_state_matrix_test.rs`
- Added collateral setup for borrow-dependent lifecycle tests.

- **[MODIFY]** `stellar-lend/contracts/lending/src/lib.rs` (inline tests)
- Updated existing borrow tests to deposit sufficient collateral before borrowing.

### 📚 Documentation
- **[MODIFY]** `stellar-lend/contracts/lending/borrow.md`
- Documented real health-factor and debt-ceiling enforcement with a worked numeric example.

- **[MODIFY]** `stellar-lend/contracts/lending/README.md`
- Updated the `borrow` interface table to reflect collateral and ceiling enforcement.

## Verification Results

```
cargo test -p stellarlend-lending --lib ✅ passed (160/160)
```

| Acceptance Criteria | Status |
|---|---|
| Load borrower `DataKey::Collateral` before committing debt | ✅ |
| Compute effective debt via `effective_debt` + `current_borrow_rate` | ✅ |
| Reject when post-borrow HF < 1.0 (`10000` BPS) | ✅ |
| Reject when post-borrow `TotalDebt` > `DataKey::DebtCeiling` | ✅ |
| Use checked arithmetic; return `Overflow` on overflow | ✅ |
| Reuse `LendingError::InsufficientCollateral` and `DebtCeilingExceeded` | ✅ |
| No regression for healthy borrows in existing tests | ✅ |
| Dedicated edge-case test coverage added | ✅ |
| Documentation updated with worked example | ✅ |