### PR TITLE
test: admin handover state-machine coverage with no-pending revert

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -85,10 +85,23 @@ uncontrolled address:
    - Stores `new_admin` under `DataKey::PendingAdmin`.
    - Guarded by `require_admin`, so only the current admin can nominate a
      successor.
+   - Re-proposing replaces any previously pending admin.
 2. **Accept**: `new_admin` calls `accept_admin()`.
-   - `new_admin.require_auth()` is called — the successor must sign the
-     acceptance.
-   - Clears `PendingAdmin` and overwrites `Admin` with `new_admin`.
+   - If no proposal exists, the contract returns `LendingError::PendingAdminNotSet`.
+   - Otherwise `new_admin.require_auth()` is called — the successor must sign
+     the acceptance.
+   - On success, `PendingAdmin` is cleared and `Admin` is overwritten with
+     `new_admin`.
+
+### State machine
+
+| Current state | `propose_admin(new_admin)` | `accept_admin()` |
+|---|---|---|
+| No pending admin | Sets `PendingAdmin = new_admin` | Returns `PendingAdminNotSet` |
+| Pending admin set | Overwrites `PendingAdmin` with `new_admin` | If signed by the pending admin, promotes to `Admin` and clears `PendingAdmin` |
+
+Re-proposing while a handover is in flight is intentional. The latest proposal
+wins, which lets the current admin correct a bad nomination before acceptance.
 
 ---
 
@@ -110,7 +123,7 @@ private key in a hot path.
 initialize          ── no auth (deployer trusted)
 ─── already-initialized guard prevents re-init ───────────────────────────
 propose_admin       ── require_admin()
-accept_admin        ── pending_admin.require_auth()
+accept_admin        ── PendingAdminNotSet if empty, else pending_admin.require_auth()
 set_min_borrow      ── require_admin()
 set_debt_ceiling    ── require_admin()
 set_flash_fee       ── require_admin()

--- a/stellar-lend/contracts/lending/src/admin_handover_test.rs
+++ b/stellar-lend/contracts/lending/src/admin_handover_test.rs
@@ -1,0 +1,151 @@
+#![cfg(test)]
+
+use super::{DataKey, LendingContract, LendingContractClient, LendingError};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+fn setup() -> (
+    Env,
+    Address,
+    LendingContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    let contract_id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let first_pending_admin = Address::generate(&env);
+    let second_pending_admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    (
+        env,
+        contract_id,
+        client,
+        admin,
+        first_pending_admin,
+        second_pending_admin,
+    )
+}
+
+fn mock_propose_admin_auth(
+    env: &Env,
+    contract_id: &Address,
+    caller: &Address,
+    new_admin: &Address,
+) {
+    env.mock_auths(&[MockAuth {
+        address: caller,
+        invoke: &MockAuthInvoke {
+            contract: contract_id,
+            fn_name: "propose_admin",
+            args: (new_admin.clone(),).into_val(env),
+            sub_invokes: &[],
+        },
+    }]);
+}
+
+fn mock_accept_admin_auth(env: &Env, contract_id: &Address, caller: &Address) {
+    env.mock_auths(&[MockAuth {
+        address: caller,
+        invoke: &MockAuthInvoke {
+            contract: contract_id,
+            fn_name: "accept_admin",
+            args: ().into_val(env),
+            sub_invokes: &[],
+        },
+    }]);
+}
+
+#[test]
+fn propose_and_accept_admin_updates_admin_and_clears_pending() {
+    let (env, contract_id, client, admin, pending_admin, _second_pending_admin) = setup();
+
+    mock_propose_admin_auth(&env, &contract_id, &admin, &pending_admin);
+    client.propose_admin(&pending_admin);
+
+    let stored_pending: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::PendingAdmin)
+        .expect("pending admin should be stored");
+    assert_eq!(stored_pending, pending_admin);
+
+    mock_accept_admin_auth(&env, &contract_id, &pending_admin);
+    let res = client.try_accept_admin();
+    assert_eq!(res, Ok(Ok(())));
+    assert_eq!(client.get_admin(), pending_admin);
+    assert!(!env.storage().instance().has(&DataKey::PendingAdmin));
+}
+
+#[test]
+fn accept_admin_without_pending_returns_error() {
+    let (env, _contract_id, client, admin, _pending_admin, _second_pending_admin) = setup();
+
+    let res = client.try_accept_admin();
+    assert_eq!(res, Ok(Err(LendingError::PendingAdminNotSet)));
+    assert_eq!(client.get_admin(), admin);
+    assert!(!env.storage().instance().has(&DataKey::PendingAdmin));
+}
+
+#[test]
+#[should_panic]
+fn accept_admin_rejects_non_pending_signer() {
+    let (env, contract_id, client, admin, pending_admin, _second_pending_admin) = setup();
+    let wrong_acceptor = Address::generate(&env);
+
+    mock_propose_admin_auth(&env, &contract_id, &admin, &pending_admin);
+    client.propose_admin(&pending_admin);
+
+    mock_accept_admin_auth(&env, &contract_id, &wrong_acceptor);
+    client.accept_admin();
+}
+
+#[test]
+fn double_accept_after_success_returns_missing_pending_error() {
+    let (env, contract_id, client, admin, pending_admin, _second_pending_admin) = setup();
+
+    mock_propose_admin_auth(&env, &contract_id, &admin, &pending_admin);
+    client.propose_admin(&pending_admin);
+
+    mock_accept_admin_auth(&env, &contract_id, &pending_admin);
+    assert_eq!(client.try_accept_admin(), Ok(Ok(())));
+    assert_eq!(client.get_admin(), pending_admin);
+    assert!(!env.storage().instance().has(&DataKey::PendingAdmin));
+
+    let res = client.try_accept_admin();
+    assert_eq!(res, Ok(Err(LendingError::PendingAdminNotSet)));
+}
+
+#[test]
+fn re_propose_overwrites_previous_pending_admin() {
+    let (env, contract_id, client, admin, first_pending_admin, second_pending_admin) = setup();
+
+    mock_propose_admin_auth(&env, &contract_id, &admin, &first_pending_admin);
+    client.propose_admin(&first_pending_admin);
+    let stored_pending: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::PendingAdmin)
+        .expect("first pending admin should be stored");
+    assert_eq!(stored_pending, first_pending_admin);
+
+    mock_propose_admin_auth(&env, &contract_id, &admin, &second_pending_admin);
+    client.propose_admin(&second_pending_admin);
+    let overwritten_pending: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::PendingAdmin)
+        .expect("second pending admin should overwrite the first");
+    assert_eq!(overwritten_pending, second_pending_admin);
+
+    mock_accept_admin_auth(&env, &contract_id, &second_pending_admin);
+    assert_eq!(client.try_accept_admin(), Ok(Ok(())));
+    assert_eq!(client.get_admin(), second_pending_admin);
+    assert!(!env.storage().instance().has(&DataKey::PendingAdmin));
+}

--- a/stellar-lend/contracts/lending/src/error_codes_test.rs
+++ b/stellar-lend/contracts/lending/src/error_codes_test.rs
@@ -7,6 +7,7 @@ fn test_error_code_stability_and_uniqueness() {
         (LendingError::InvalidAmount, 1001),
         (LendingError::Overflow, 1002),
         (LendingError::Unauthorized, 1003),
+        (LendingError::PendingAdminNotSet, 1004),
         (LendingError::BelowMinimumBorrow, 1008),
         (LendingError::NotInitialized, 1009),
         (LendingError::AlreadyInitialized, 1010),

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -6,6 +6,8 @@ pub mod rate_model;
 pub mod rounding_strategy;
 
 #[cfg(test)]
+mod admin_handover_test;
+#[cfg(test)]
 mod admin_setters_dedupe_test;
 #[cfg(test)]
 mod deposit_accounting_test;
@@ -122,6 +124,7 @@ pub enum LendingError {
     InvalidAmount = 1001,
     Overflow = 1002,
     Unauthorized = 1003,
+    PendingAdminNotSet = 1004,
     BelowMinimumBorrow = 1008,
     NotInitialized = 1009,
     AlreadyInitialized = 1010,
@@ -255,6 +258,8 @@ impl LendingContract {
     }
 
     /// Propose a new admin (current admin only).
+    ///
+    /// Replaces any existing pending admin proposal.
     pub fn propose_admin(env: Env, new_admin: Address) {
         let current_admin = Self::get_admin(env.clone());
         current_admin.require_auth();
@@ -263,17 +268,23 @@ impl LendingContract {
             .set(&DataKey::PendingAdmin, &new_admin);
     }
 
-    pub fn accept_admin(env: Env) {
+    /// Accept the currently pending admin handover.
+    ///
+    /// Returns `PendingAdminNotSet` if no admin has been proposed yet. On
+    /// success, the pending admin must sign the call, the admin address is
+    /// updated, and `PendingAdmin` is cleared.
+    pub fn accept_admin(env: Env) -> Result<(), LendingError> {
         let pending_admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::PendingAdmin)
-            .expect("no pending admin");
+            .ok_or(LendingError::PendingAdminNotSet)?;
         pending_admin.require_auth();
         env.storage()
             .instance()
             .set(&DataKey::Admin, &pending_admin);
         env.storage().instance().remove(&DataKey::PendingAdmin);
+        Ok(())
     }
 
     pub fn set_guardian(env: Env, guardian: Address) {
@@ -1192,23 +1203,6 @@ mod test {
             res
         );
     }
-
-    // -----------------------------------------------------------------------
-    // Admin rotation
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_propose_and_accept_admin() {
-        let (env, client, _admin, _user) = setup();
-        let new_admin = Address::generate(&env);
-        client.propose_admin(&new_admin);
-        client.accept_admin();
-        assert_eq!(client.get_admin(), new_admin);
-    }
-
-    // -----------------------------------------------------------------------
-    // Core operations
-    // -----------------------------------------------------------------------
 
     #[test]
     fn test_set_price_with_valid_signature_succeeds() {


### PR DESCRIPTION
Closes #1041 

**Admin Handover** — `accept_admin()` now returns `LendingError::PendingAdminNotSet` instead of panicking when no pending admin. Added 5 state-machine tests verifying all handover transitions.

---

## Changes

### Admin Handover Error Handling
- **lib.rs**
  - Added `PendingAdminNotSet = 1004` to `LendingError` enum
  - Changed `accept_admin()` return type to `Result<(), LendingError>`
  - Replaced `.expect()` panic with `.ok_or(LendingError::PendingAdminNotSet)?`

- **admin_handover_test.rs** (new)
  - 5 tests: propose/accept flow, error on no pending, auth enforcement, idempotence, re-propose overwrite

- **admin.md**
  - Updated state machine table and error behavior