### PR TITLE
feat(lending): timelocked multisig WASM upgrade governance

### DIFF
--- a/UPGRADE_MIGRATION_IMPLEMENTATION.md
+++ b/UPGRADE_MIGRATION_IMPLEMENTATION.md
@@ -1,5 +1,30 @@
 # Upgrade and Storage Migration Safety Suite - Implementation Summary
 
+## Lending contract upgrade governance (issue #971)
+
+The canonical lending crate (`stellar-lend/contracts/lending`) now implements timelocked multisig WASM upgrade governance in `src/upgrade.rs`:
+
+| Entrypoint | Role | Description |
+|---|---|---|
+| `upgrade_init` | admin | Bootstrap current WASM hash, version `0`, and approval threshold |
+| `upgrade_propose` | admin | Record pending WASM hash with `MIN_THRESHOLD_DELAY_LEDGERS` ETA |
+| `upgrade_approve` | approver | Collect approvals toward the snapshotted threshold |
+| `upgrade_execute` | approver | `update_current_contract_wasm` after timelock + threshold |
+| `upgrade_add_approver` / `upgrade_remove_approver` | admin | Manage approver set (max 32) |
+| `upgrade_set_required_approvals` | admin | Change live threshold for **future** proposals only |
+
+Tests: `cargo test -p stellarlend-lending --lib upgrade_governance`
+
+Worked example (threshold = 1):
+
+```rust
+client.upgrade_init(&admin, &current_hash, &1);
+let id = client.upgrade_propose(&admin, &new_hash, &1);
+client.upgrade_approve(&admin, &id);
+// advance ledger to proposal.eta_ledger
+client.upgrade_execute(&admin, &id);
+```
+
 ## Overview
 
 Implemented a comprehensive test suite for contract upgrade and storage migration safety in the StellarLend lending protocol. The suite validates that contract upgrades preserve user state, handle failures gracefully, and support safe rollback operations.

--- a/docs/upgrade_playbook.md
+++ b/docs/upgrade_playbook.md
@@ -1,5 +1,9 @@
 # Upgrade Playbook
 
+## Implementation status
+
+The canonical lending contract (`stellar-lend/contracts/lending/src/upgrade.rs`) implements `upgrade_init`, `upgrade_propose`, `upgrade_approve`, and `upgrade_execute` with the same timelock / multisig approval model described below. Governance tests live in `src/upgrade_governance_test.rs`.
+
 ## Overview
 
 This playbook provides a practical guide for safely upgrading StellarLend contracts, including preflight checks, execution procedures, post-upgrade monitoring, and rollback criteria. It aligns with the upgrade authorization model documented in `docs/UPGRADE_AUTHORIZATION.md`.

--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -96,6 +96,13 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 |---|---|---|---|
 | `set_min_borrow` | `(env, min_borrow: i128) → Result<(), LendingError>` | admin | Sets the minimum amount required to open or increase a borrow. |
 | `set_debt_ceiling` | `(env, ceiling: i128) → Result<(), LendingError>` | admin | Sets the maximum total protocol debt. |
+| `upgrade_init` | `(env, caller: Address, current_wasm_hash: BytesN<32>, required_approvals: u32) → Result<(), LendingError>` | admin | One-time upgrade governance bootstrap. |
+| `upgrade_propose` | `(env, caller: Address, new_wasm_hash: BytesN<32>, new_version: u32) → Result<u64, LendingError>` | admin | Timelocked WASM upgrade proposal (`MIN_THRESHOLD_DELAY_LEDGERS` ETA). |
+| `upgrade_approve` | `(env, caller: Address, proposal_id: u64) → Result<u32, LendingError>` | approver | Records an approval toward the snapshotted threshold. |
+| `upgrade_execute` | `(env, caller: Address, proposal_id: u64) → Result<(), LendingError>` | approver | Calls `update_current_contract_wasm` after timelock + threshold checks. |
+| `upgrade_add_approver` / `upgrade_remove_approver` | `(env, caller, approver) → Result<(), LendingError>` | admin | Manage the authorized approver set (max 32). |
+| `upgrade_set_required_approvals` | `(env, caller, required_approvals) → Result<(), LendingError>` | admin | Updates the live threshold for future proposals only. |
+| `upgrade_status` / `current_version` / `current_wasm_hash` | view | — | Query upgrade proposal state and active version/hash. |
 | `set_flash_fee` | `(env, fee_bps: i128) → Result<(), LendingError>` | admin | Sets the flash-loan fee in the inclusive range `[0, 1000]` bps. |
 | `set_emergency_state` | `(env, new_state: EmergencyState)` | admin or guardian | Transitions between `Normal`, `Shutdown`, and `Recovery`. Emits `EmergencyStateChanged` event. |
 
@@ -129,6 +136,17 @@ Normal ──► Shutdown ──► Recovery ──► Normal
 | `LendingError::InvalidOracleSignature` | 5001 | Oracle price update signature is invalid. |
 | `LendingError::StaleOracleTimestamp` | 5002 | Oracle price update is too old. |
 | `LendingError::OraclePubkeyNotSet` | 5003 | Oracle public key is missing from storage. |
+| `LendingError::UpgradeNotInitialized` | 3001 | Upgrade governance has not been initialized. |
+| `LendingError::ProposalNotFound` | 3002 | Unknown upgrade proposal id. |
+| `LendingError::ProposalNotReady` | 3003 | Timelock has not elapsed. |
+| `LendingError::ProposalExpired` | 3004 | Proposal expiry ledger has passed. |
+| `LendingError::ProposalAlreadyExecuted` | 3005 | Proposal was already executed. |
+| `LendingError::AlreadyApproved` | 3006 | Duplicate approval from the same signer. |
+| `LendingError::InsufficientUpgradeApprovals` | 3007 | Approval threshold not met. |
+| `LendingError::InvalidUpgradeVersion` | 3008 | Proposed version is not greater than the current version. |
+| `LendingError::ApproverNotFound` | 3009 | Approver is not in the configured set. |
+| `LendingError::MaxApproversReached` | 3010 | Approver set is at capacity. |
+| `LendingError::InvalidUpgradeConfig` | 3011 | Invalid upgrade configuration (e.g. zero threshold). |
 
 ---
 
@@ -147,7 +165,6 @@ The functions listed below appear in older documentation but are **not yet imple
 | `get_max_liquidatable_amount(env, user)` | Convenience helper for liquidators. |
 | `get_emergency_state(env)` | Public view for current lifecycle state (today exposed only via events). |
 | `deposit_collateral(env, user, asset, amount)` | Multi-asset collateral support. |
-| `upgrade_init / upgrade_propose / upgrade_approve / upgrade_execute` | Multisig upgrade governance. |
 | `data_store_init / data_save / data_load / data_backup / data_restore` | Persistent data-store management helpers. |
 
 ---

--- a/stellar-lend/contracts/lending/src/error_codes_test.rs
+++ b/stellar-lend/contracts/lending/src/error_codes_test.rs
@@ -18,6 +18,17 @@ fn test_error_code_stability_and_uniqueness() {
         (LendingError::InvalidOracleSignature, 5001),
         (LendingError::StaleOracleTimestamp, 5002),
         (LendingError::OraclePubkeyNotSet, 5003),
+        (LendingError::UpgradeNotInitialized, 3001),
+        (LendingError::ProposalNotFound, 3002),
+        (LendingError::ProposalNotReady, 3003),
+        (LendingError::ProposalExpired, 3004),
+        (LendingError::ProposalAlreadyExecuted, 3005),
+        (LendingError::AlreadyApproved, 3006),
+        (LendingError::InsufficientUpgradeApprovals, 3007),
+        (LendingError::InvalidUpgradeVersion, 3008),
+        (LendingError::ApproverNotFound, 3009),
+        (LendingError::MaxApproversReached, 3010),
+        (LendingError::InvalidUpgradeConfig, 3011),
     ];
 
     for i in 0..cases.len() {

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -4,8 +4,10 @@ pub mod debt;
 pub mod math;
 pub mod rate_model;
 pub mod rounding_strategy;
+pub mod upgrade;
 
 #[cfg(test)]
+mod upgrade_governance_test;
 mod admin_setters_dedupe_test;
 #[cfg(test)]
 mod deposit_accounting_test;
@@ -29,7 +31,7 @@ use debt::{
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, BytesN,
-    Env, IntoVal, Symbol, Val,
+    Env, IntoVal, Symbol, Val, Vec,
 };
 
 const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
@@ -133,6 +135,17 @@ pub enum LendingError {
     InvalidOracleSignature = 5001,
     StaleOracleTimestamp = 5002,
     OraclePubkeyNotSet = 5003,
+    UpgradeNotInitialized = 3001,
+    ProposalNotFound = 3002,
+    ProposalNotReady = 3003,
+    ProposalExpired = 3004,
+    ProposalAlreadyExecuted = 3005,
+    AlreadyApproved = 3006,
+    InsufficientUpgradeApprovals = 3007,
+    InvalidUpgradeVersion = 3008,
+    ApproverNotFound = 3009,
+    MaxApproversReached = 3010,
+    InvalidUpgradeConfig = 3011,
 }
 
 #[contracttype]
@@ -792,6 +805,98 @@ impl LendingContract {
             ledger: env.ledger().sequence(),
         }
     }
+
+    /// Initialize timelocked multisig upgrade governance (admin-only, once).
+    pub fn upgrade_init(
+        env: Env,
+        caller: Address,
+        current_wasm_hash: BytesN<32>,
+        required_approvals: u32,
+    ) -> Result<(), LendingError> {
+        upgrade::upgrade_init(&env, &caller, current_wasm_hash, required_approvals)
+    }
+
+    /// Propose a WASM upgrade with a timelocked ETA ledger (admin-only).
+    pub fn upgrade_propose(
+        env: Env,
+        caller: Address,
+        new_wasm_hash: BytesN<32>,
+        new_version: u32,
+    ) -> Result<u64, LendingError> {
+        upgrade::upgrade_propose(&env, &caller, new_wasm_hash, new_version)
+    }
+
+    /// Record an approval for a pending upgrade proposal (approver-only).
+    pub fn upgrade_approve(
+        env: Env,
+        caller: Address,
+        proposal_id: u64,
+    ) -> Result<u32, LendingError> {
+        upgrade::upgrade_approve(&env, &caller, proposal_id)
+    }
+
+    /// Execute an approved upgrade after the timelock elapses (approver-only).
+    pub fn upgrade_execute(
+        env: Env,
+        caller: Address,
+        proposal_id: u64,
+    ) -> Result<(), LendingError> {
+        upgrade::upgrade_execute(&env, &caller, proposal_id)
+    }
+
+    pub fn upgrade_set_required_approvals(
+        env: Env,
+        caller: Address,
+        required_approvals: u32,
+    ) -> Result<(), LendingError> {
+        upgrade::upgrade_set_required_approvals(&env, &caller, required_approvals)
+    }
+
+    /// Add an upgrade approver (admin-only).
+    pub fn upgrade_add_approver(
+        env: Env,
+        caller: Address,
+        approver: Address,
+    ) -> Result<(), LendingError> {
+        upgrade::upgrade_add_approver(&env, &caller, approver)
+    }
+
+    /// Remove an upgrade approver (admin-only).
+    pub fn upgrade_remove_approver(
+        env: Env,
+        caller: Address,
+        approver: Address,
+    ) -> Result<(), LendingError> {
+        upgrade::upgrade_remove_approver(&env, &caller, approver)
+    }
+
+    pub fn current_version(env: Env) -> Result<u32, LendingError> {
+        upgrade::current_version(&env)
+    }
+
+    pub fn current_wasm_hash(env: Env) -> Result<BytesN<32>, LendingError> {
+        upgrade::current_wasm_hash(&env)
+    }
+
+    pub fn get_required_approvals(env: Env) -> Result<u32, LendingError> {
+        upgrade::get_required_approvals(&env)
+    }
+
+    pub fn get_upgrade_approvers(env: Env) -> Result<Vec<Address>, LendingError> {
+        upgrade::get_upgrade_approvers(&env)
+    }
+
+    pub fn get_proposal_approvals(env: Env, proposal_id: u64) -> Result<Vec<Address>, LendingError> {
+        upgrade::get_proposal_approvals(&env, proposal_id)
+    }
+
+    pub fn upgrade_status(env: Env, proposal_id: u64) -> Result<upgrade::UpgradeStatus, LendingError> {
+        upgrade::upgrade_status(&env, proposal_id)
+    }
+
+    pub fn get_min_upgrade_delay_ledgers(env: Env) -> u32 {
+        upgrade::get_min_upgrade_delay_ledgers(&env)
+    }
 }
 
 #[allow(dead_code)]
@@ -902,7 +1007,7 @@ struct RateSnapshot {
 
 /// Assert that the transaction signer is the protocol admin.
 /// Panics with the default auth error if not.
-fn assert_admin(env: &Env) {
+pub(crate) fn assert_admin(env: &Env) {
     let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
     admin.require_auth();
 }

--- a/stellar-lend/contracts/lending/src/upgrade.rs
+++ b/stellar-lend/contracts/lending/src/upgrade.rs
@@ -1,0 +1,537 @@
+//! Timelocked multisig WASM upgrade governance for the lending contract.
+//!
+//! Mirrors the proposal / approval / execution model from `contracts/multisig`,
+//! adapted for `env.deployer().update_current_contract_wasm`.
+
+use soroban_sdk::{contractevent, contracttype, Address, BytesN, Env, Vec};
+
+use crate::{assert_admin, LendingError};
+
+/// Minimum timelock before an approved proposal may execute (~7 days at 5 s/ledger).
+pub const MIN_THRESHOLD_DELAY_LEDGERS: u32 = 600_000;
+/// Default proposal lifetime (~14 days at 5 s/ledger).
+pub const DEFAULT_PROPOSAL_EXPIRY_LEDGERS: u32 = 1_200_000;
+/// Maximum configured upgrade approvers.
+pub const MAX_APPROVERS: u32 = 32;
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UpgradeKey {
+    Initialized,
+    CurrentWasmHash,
+    CurrentVersion,
+    RequiredApprovals,
+    Approvers,
+    ProposalCounter,
+    Proposal(u64),
+    ProposalApprovals(u64),
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpgradeProposalStatus {
+    Pending,
+    Executed,
+    Expired,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeProposal {
+    pub id: u64,
+    pub new_wasm_hash: BytesN<32>,
+    pub new_version: u32,
+    pub eta_ledger: u32,
+    pub expires_at_ledger: u32,
+    pub required_approvals: u32,
+    pub executed: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeStatus {
+    pub proposal: UpgradeProposal,
+    pub approval_count: u32,
+    pub status: UpgradeProposalStatus,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeProposedEvent {
+    pub proposer: Address,
+    pub proposal_id: u64,
+    pub new_wasm_hash: BytesN<32>,
+    pub new_version: u32,
+    pub eta_ledger: u32,
+    pub expires_at_ledger: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeApprovedEvent {
+    pub approver: Address,
+    pub proposal_id: u64,
+    pub approval_count: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeExecutedEvent {
+    pub executor: Address,
+    pub proposal_id: u64,
+    pub new_version: u32,
+    pub new_wasm_hash: BytesN<32>,
+    pub ledger: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeApproverAddedEvent {
+    pub admin: Address,
+    pub approver: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpgradeApproverRemovedEvent {
+    pub admin: Address,
+    pub approver: Address,
+}
+
+fn load_proposal(env: &Env, id: u64) -> Result<UpgradeProposal, LendingError> {
+    env.storage()
+        .instance()
+        .get(&UpgradeKey::Proposal(id))
+        .ok_or(LendingError::ProposalNotFound)
+}
+
+fn load_approvals(env: &Env, id: u64) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&UpgradeKey::ProposalApprovals(id))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn save_approvals(env: &Env, id: u64, approvals: &Vec<Address>) {
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::ProposalApprovals(id), approvals);
+}
+
+fn ensure_upgrade_initialized(env: &Env) -> Result<(), LendingError> {
+    if env
+        .storage()
+        .instance()
+        .get::<UpgradeKey, bool>(&UpgradeKey::Initialized)
+        .unwrap_or(false)
+    {
+        Ok(())
+    } else {
+        Err(LendingError::UpgradeNotInitialized)
+    }
+}
+
+fn is_approver(env: &Env, address: &Address) -> bool {
+    let approvers: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::Approvers)
+        .unwrap_or_else(|| Vec::new(env));
+    approvers.contains(address)
+}
+
+fn require_approver(env: &Env, caller: &Address) -> Result<(), LendingError> {
+    caller.require_auth();
+    if is_approver(env, caller) {
+        Ok(())
+    } else {
+        Err(LendingError::Unauthorized)
+    }
+}
+
+fn proposal_status(env: &Env, proposal: &UpgradeProposal) -> UpgradeProposalStatus {
+    if proposal.executed {
+        UpgradeProposalStatus::Executed
+    } else if env.ledger().sequence() > proposal.expires_at_ledger {
+        UpgradeProposalStatus::Expired
+    } else {
+        UpgradeProposalStatus::Pending
+    }
+}
+
+fn ensure_proposal_active(env: &Env, proposal: &UpgradeProposal) -> Result<(), LendingError> {
+    if proposal.executed {
+        return Err(LendingError::ProposalAlreadyExecuted);
+    }
+    if env.ledger().sequence() > proposal.expires_at_ledger {
+        return Err(LendingError::ProposalExpired);
+    }
+    Ok(())
+}
+
+/// Initialize upgrade governance (admin-only, once).
+///
+/// Records the current WASM hash, version `0`, the approval threshold, and seeds
+/// the approver set with the contract admin.
+pub fn upgrade_init(
+    env: &Env,
+    caller: &Address,
+    current_wasm_hash: BytesN<32>,
+    required_approvals: u32,
+) -> Result<(), LendingError> {
+    assert_admin(env);
+    caller.require_auth();
+
+    if env
+        .storage()
+        .instance()
+        .has(&UpgradeKey::Initialized)
+    {
+        return Err(LendingError::AlreadyInitialized);
+    }
+    if required_approvals == 0 {
+        return Err(LendingError::InvalidUpgradeConfig);
+    }
+
+    let admin = crate::LendingContract::get_admin(env.clone());
+    let mut approvers = Vec::new(env);
+    approvers.push_back(admin.clone());
+
+    env.storage().instance().set(&UpgradeKey::Initialized, &true);
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::CurrentWasmHash, &current_wasm_hash);
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::CurrentVersion, &0u32);
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::RequiredApprovals, &required_approvals);
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::Approvers, &approvers);
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::ProposalCounter, &0u64);
+
+    Ok(())
+}
+
+/// Add an upgrade approver (admin-only).
+pub fn upgrade_add_approver(env: &Env, caller: &Address, approver: Address) -> Result<(), LendingError> {
+    assert_admin(env);
+    caller.require_auth();
+    ensure_upgrade_initialized(env)?;
+
+    let mut approvers: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::Approvers)
+        .unwrap_or_else(|| Vec::new(env));
+
+    if approvers.len() >= MAX_APPROVERS as u32 {
+        return Err(LendingError::MaxApproversReached);
+    }
+    if approvers.contains(&approver) {
+        return Err(LendingError::AlreadyApproved);
+    }
+
+    approvers.push_back(approver.clone());
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::Approvers, &approvers);
+
+    UpgradeApproverAddedEvent {
+        admin: caller.clone(),
+        approver,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Remove an upgrade approver without breaking the configured threshold (admin-only).
+pub fn upgrade_remove_approver(
+    env: &Env,
+    caller: &Address,
+    approver: Address,
+) -> Result<(), LendingError> {
+    assert_admin(env);
+    caller.require_auth();
+    ensure_upgrade_initialized(env)?;
+
+    let required: u32 = env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::RequiredApprovals)
+        .unwrap_or(1);
+    let mut approvers: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::Approvers)
+        .unwrap_or_else(|| Vec::new(env));
+
+    if approvers.len() <= 1 {
+        return Err(LendingError::InvalidUpgradeConfig);
+    }
+    if approvers.len() <= required {
+        return Err(LendingError::InvalidUpgradeConfig);
+    }
+    if !approvers.contains(&approver) {
+        return Err(LendingError::ApproverNotFound);
+    }
+
+    let mut next = Vec::new(env);
+    for existing in approvers.iter() {
+        if existing != approver {
+            next.push_back(existing);
+        }
+    }
+    env.storage().instance().set(&UpgradeKey::Approvers, &next);
+
+    UpgradeApproverRemovedEvent {
+        admin: caller.clone(),
+        approver,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Update the live approval threshold for future proposals (admin-only).
+///
+/// In-flight proposals keep the threshold snapshotted at `upgrade_propose` time.
+pub fn upgrade_set_required_approvals(
+    env: &Env,
+    caller: &Address,
+    required_approvals: u32,
+) -> Result<(), LendingError> {
+    assert_admin(env);
+    caller.require_auth();
+    ensure_upgrade_initialized(env)?;
+
+    if required_approvals == 0 {
+        return Err(LendingError::InvalidUpgradeConfig);
+    }
+
+    let approvers: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::Approvers)
+        .unwrap_or_else(|| Vec::new(env));
+    if required_approvals > approvers.len() {
+        return Err(LendingError::InvalidUpgradeConfig);
+    }
+
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::RequiredApprovals, &required_approvals);
+    Ok(())
+}
+
+/// Propose a WASM upgrade with a timelocked ETA ledger (admin-only).
+///
+/// The proposal snapshots the current `required_approvals` threshold so later
+/// configuration changes cannot retroactively weaken or strengthen an in-flight vote.
+pub fn upgrade_propose(
+    env: &Env,
+    caller: &Address,
+    new_wasm_hash: BytesN<32>,
+    new_version: u32,
+) -> Result<u64, LendingError> {
+    assert_admin(env);
+    caller.require_auth();
+    ensure_upgrade_initialized(env)?;
+
+    let current_version: u32 = env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::CurrentVersion)
+        .unwrap_or(0);
+    if new_version <= current_version {
+        return Err(LendingError::InvalidUpgradeVersion);
+    }
+
+    let current_ledger = env.ledger().sequence();
+    let eta_ledger = current_ledger.saturating_add(MIN_THRESHOLD_DELAY_LEDGERS);
+    let expires_at_ledger = current_ledger.saturating_add(DEFAULT_PROPOSAL_EXPIRY_LEDGERS);
+    if expires_at_ledger < eta_ledger {
+        return Err(LendingError::InvalidUpgradeConfig);
+    }
+
+    let required_approvals: u32 = env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::RequiredApprovals)
+        .unwrap_or(1);
+
+    let next_id = env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::ProposalCounter)
+        .unwrap_or(0u64)
+        .saturating_add(1);
+
+    let proposal = UpgradeProposal {
+        id: next_id,
+        new_wasm_hash: new_wasm_hash.clone(),
+        new_version,
+        eta_ledger,
+        expires_at_ledger,
+        required_approvals,
+        executed: false,
+    };
+
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::ProposalCounter, &next_id);
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::Proposal(next_id), &proposal);
+    save_approvals(env, next_id, &Vec::new(env));
+
+    UpgradeProposedEvent {
+        proposer: caller.clone(),
+        proposal_id: next_id,
+        new_wasm_hash,
+        new_version,
+        eta_ledger,
+        expires_at_ledger,
+    }
+    .publish(env);
+
+    Ok(next_id)
+}
+
+/// Record an approval for a pending upgrade proposal (approver-only).
+pub fn upgrade_approve(env: &Env, caller: &Address, proposal_id: u64) -> Result<u32, LendingError> {
+    require_approver(env, caller)?;
+    ensure_upgrade_initialized(env)?;
+
+    let proposal = load_proposal(env, proposal_id)?;
+    ensure_proposal_active(env, &proposal)?;
+
+    let mut approvals = load_approvals(env, proposal_id);
+    if approvals.contains(caller) {
+        return Err(LendingError::AlreadyApproved);
+    }
+
+    approvals.push_back(caller.clone());
+    let approval_count = approvals.len();
+    save_approvals(env, proposal_id, &approvals);
+
+    UpgradeApprovedEvent {
+        approver: caller.clone(),
+        proposal_id,
+        approval_count,
+    }
+    .publish(env);
+
+    Ok(approval_count)
+}
+
+/// Execute an approved upgrade after the timelock elapses (approver-only).
+///
+/// Calls `env.deployer().update_current_contract_wasm` and updates the stored
+/// version/hash on success. Each proposal may execute at most once.
+pub fn upgrade_execute(env: &Env, caller: &Address, proposal_id: u64) -> Result<(), LendingError> {
+    require_approver(env, caller)?;
+    ensure_upgrade_initialized(env)?;
+
+    let mut proposal = load_proposal(env, proposal_id)?;
+    ensure_proposal_active(env, &proposal)?;
+
+    let current_ledger = env.ledger().sequence();
+    if current_ledger < proposal.eta_ledger {
+        return Err(LendingError::ProposalNotReady);
+    }
+
+    let approvals = load_approvals(env, proposal_id);
+    if approvals.len() < proposal.required_approvals {
+        return Err(LendingError::InsufficientUpgradeApprovals);
+    }
+
+    // Native `env.register` tests cannot load arbitrary WASM blobs; integration
+    // environments with uploaded WASM exercise the deployer path.
+    #[cfg(not(test))]
+    env.deployer()
+        .update_current_contract_wasm(proposal.new_wasm_hash.clone());
+
+    proposal.executed = true;
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::Proposal(proposal_id), &proposal);
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::CurrentVersion, &proposal.new_version);
+    env.storage()
+        .instance()
+        .set(&UpgradeKey::CurrentWasmHash, &proposal.new_wasm_hash);
+
+    UpgradeExecutedEvent {
+        executor: caller.clone(),
+        proposal_id,
+        new_version: proposal.new_version,
+        new_wasm_hash: proposal.new_wasm_hash,
+        ledger: current_ledger,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+pub fn current_version(env: &Env) -> Result<u32, LendingError> {
+    ensure_upgrade_initialized(env)?;
+    Ok(env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::CurrentVersion)
+        .unwrap_or(0))
+}
+
+pub fn current_wasm_hash(env: &Env) -> Result<BytesN<32>, LendingError> {
+    ensure_upgrade_initialized(env)?;
+    env.storage()
+        .instance()
+        .get(&UpgradeKey::CurrentWasmHash)
+        .ok_or(LendingError::UpgradeNotInitialized)
+}
+
+pub fn get_required_approvals(env: &Env) -> Result<u32, LendingError> {
+    ensure_upgrade_initialized(env)?;
+    Ok(env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::RequiredApprovals)
+        .unwrap_or(1))
+}
+
+pub fn get_upgrade_approvers(env: &Env) -> Result<Vec<Address>, LendingError> {
+    ensure_upgrade_initialized(env)?;
+    Ok(env
+        .storage()
+        .instance()
+        .get(&UpgradeKey::Approvers)
+        .unwrap_or_else(|| Vec::new(env)))
+}
+
+pub fn get_proposal_approvals(env: &Env, proposal_id: u64) -> Result<Vec<Address>, LendingError> {
+    ensure_upgrade_initialized(env)?;
+    let _ = load_proposal(env, proposal_id)?;
+    Ok(load_approvals(env, proposal_id))
+}
+
+pub fn upgrade_status(env: &Env, proposal_id: u64) -> Result<UpgradeStatus, LendingError> {
+    ensure_upgrade_initialized(env)?;
+    let proposal = load_proposal(env, proposal_id)?;
+    let approvals = load_approvals(env, proposal_id);
+    Ok(UpgradeStatus {
+        status: proposal_status(env, &proposal),
+        approval_count: approvals.len(),
+        proposal,
+    })
+}
+
+pub fn get_min_upgrade_delay_ledgers(_env: &Env) -> u32 {
+    MIN_THRESHOLD_DELAY_LEDGERS
+}

--- a/stellar-lend/contracts/lending/src/upgrade_governance_test.rs
+++ b/stellar-lend/contracts/lending/src/upgrade_governance_test.rs
@@ -1,0 +1,216 @@
+#![cfg(test)]
+
+use crate::upgrade::{
+    UpgradeProposalStatus, DEFAULT_PROPOSAL_EXPIRY_LEDGERS, MIN_THRESHOLD_DELAY_LEDGERS,
+};
+use crate::{LendingContract, LendingContractClient, LendingError};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, BytesN, Env};
+
+fn wasm_hash(env: &Env, byte: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = byte;
+    BytesN::from_array(env, &bytes)
+}
+
+fn setup_upgrade(
+    required_approvals: u32,
+) -> (
+    Env,
+    LendingContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    client.initialize(&admin);
+    client.upgrade_init(&admin, &wasm_hash(&env, 1), &required_approvals);
+    if required_approvals > 1 {
+        client.upgrade_add_approver(&admin, &approver);
+    }
+    (env, client, admin, approver, stranger)
+}
+
+fn advance_to_eta(env: &Env, eta_ledger: u32) {
+    env.ledger().set_sequence_number(eta_ledger);
+}
+
+#[test]
+fn upgrade_init_records_version_and_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let hash = wasm_hash(&env, 9);
+    client.initialize(&admin);
+    client.upgrade_init(&admin, &hash, &2);
+    assert_eq!(client.current_version(), 0);
+    assert_eq!(client.current_wasm_hash(), hash);
+    assert_eq!(client.get_required_approvals(), 2);
+}
+
+#[test]
+fn propose_approve_execute_happy_path_with_threshold_one() {
+    let (env, client, admin, _, _) = setup_upgrade(1);
+    let new_hash = wasm_hash(&env, 2);
+    let proposal_id = client.upgrade_propose(&admin, &new_hash, &1);
+    assert_eq!(client.upgrade_approve(&admin, &proposal_id), 1);
+
+    let status = client.upgrade_status(&proposal_id);
+    assert_eq!(status.status, UpgradeProposalStatus::Pending);
+    assert_eq!(status.approval_count, 1);
+
+    advance_to_eta(&env, status.proposal.eta_ledger);
+    client.upgrade_execute(&admin, &proposal_id);
+
+    assert_eq!(client.current_version(), 1);
+    assert_eq!(client.current_wasm_hash(), new_hash);
+    assert_eq!(
+        client.upgrade_status(&proposal_id).status,
+        UpgradeProposalStatus::Executed
+    );
+}
+
+#[test]
+fn execute_before_timelock_is_rejected() {
+    let (env, client, admin, _, _) = setup_upgrade(1);
+    let proposal_id = client.upgrade_propose(&admin, &wasm_hash(&env, 3), &1);
+    client.upgrade_approve(&admin, &proposal_id);
+
+    let res = client.try_upgrade_execute(&admin, &proposal_id);
+    assert!(matches!(res, Err(Ok(LendingError::ProposalNotReady))));
+}
+
+#[test]
+fn execute_without_enough_approvals_is_rejected() {
+    let (env, client, admin, approver, _) = setup_upgrade(2);
+    let proposal_id = client.upgrade_propose(&admin, &wasm_hash(&env, 4), &1);
+
+    let eta = client.upgrade_status(&proposal_id).proposal.eta_ledger;
+    advance_to_eta(&env, eta);
+
+    let res = client.try_upgrade_execute(&admin, &proposal_id);
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InsufficientUpgradeApprovals))
+    ));
+
+    client.upgrade_approve(&admin, &proposal_id);
+    let res = client.try_upgrade_execute(&approver, &proposal_id);
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InsufficientUpgradeApprovals))
+    ));
+}
+
+#[test]
+fn expired_proposal_cannot_be_approved_or_executed() {
+    let (env, client, admin, _, _) = setup_upgrade(1);
+    let proposal_id = client.upgrade_propose(&admin, &wasm_hash(&env, 5), &1);
+    let expires = client.upgrade_status(&proposal_id).proposal.expires_at_ledger;
+    env.ledger().set_sequence_number(expires.saturating_add(1));
+
+    let approve = client.try_upgrade_approve(&admin, &proposal_id);
+    assert!(matches!(approve, Err(Ok(LendingError::ProposalExpired))));
+
+    let execute = client.try_upgrade_execute(&admin, &proposal_id);
+    assert!(matches!(execute, Err(Ok(LendingError::ProposalExpired))));
+}
+
+#[test]
+fn duplicate_approval_is_rejected() {
+    let (env, client, admin, _, _) = setup_upgrade(1);
+    let proposal_id = client.upgrade_propose(&admin, &wasm_hash(&env, 6), &1);
+    client.upgrade_approve(&admin, &proposal_id);
+    let res = client.try_upgrade_approve(&admin, &proposal_id);
+    assert!(matches!(res, Err(Ok(LendingError::AlreadyApproved))));
+}
+
+#[test]
+fn double_execute_is_rejected() {
+    let (env, client, admin, _, _) = setup_upgrade(1);
+    let proposal_id = client.upgrade_propose(&admin, &wasm_hash(&env, 3), &1);
+    client.upgrade_approve(&admin, &proposal_id);
+    advance_to_eta(&env, client.upgrade_status(&proposal_id).proposal.eta_ledger);
+    client.upgrade_execute(&admin, &proposal_id);
+
+    let res = client.try_upgrade_execute(&admin, &proposal_id);
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::ProposalAlreadyExecuted))
+    ));
+}
+
+#[test]
+fn unauthorized_caller_cannot_approve_or_execute() {
+    let (env, client, admin, _, stranger) = setup_upgrade(1);
+    let proposal_id = client.upgrade_propose(&admin, &wasm_hash(&env, 7), &1);
+
+    let approve = client.try_upgrade_approve(&stranger, &proposal_id);
+    assert!(matches!(approve, Err(Ok(LendingError::Unauthorized))));
+
+    client.upgrade_approve(&admin, &proposal_id);
+    advance_to_eta(&env, client.upgrade_status(&proposal_id).proposal.eta_ledger);
+
+    let execute = client.try_upgrade_execute(&stranger, &proposal_id);
+    assert!(matches!(execute, Err(Ok(LendingError::Unauthorized))));
+}
+
+#[test]
+fn threshold_snapshot_is_fixed_at_propose_time() {
+    let (env, client, admin, approver, _) = setup_upgrade(1);
+    let new_hash = wasm_hash(&env, 8);
+    let proposal_id = client.upgrade_propose(&admin, &new_hash, &1);
+    assert_eq!(
+        client.upgrade_status(&proposal_id).proposal.required_approvals,
+        1
+    );
+
+    client.upgrade_add_approver(&admin, &approver);
+    client.upgrade_set_required_approvals(&admin, &2);
+
+    client.upgrade_approve(&admin, &proposal_id);
+    advance_to_eta(&env, client.upgrade_status(&proposal_id).proposal.eta_ledger);
+    client.upgrade_execute(&admin, &proposal_id);
+    assert_eq!(client.current_version(), 1);
+}
+
+#[test]
+fn propose_rejects_non_monotonic_version() {
+    let (env, client, admin, _, _) = setup_upgrade(1);
+    let res = client.try_upgrade_propose(&admin, &wasm_hash(&env, 10), &0);
+    assert!(matches!(res, Err(Ok(LendingError::InvalidUpgradeVersion))));
+}
+
+#[test]
+fn proposal_records_expected_timelock_and_expiry() {
+    let (env, client, admin, _, _) = setup_upgrade(1);
+    let start = env.ledger().sequence();
+    let proposal_id = client.upgrade_propose(&admin, &wasm_hash(&env, 11), &1);
+    let proposal = client.upgrade_status(&proposal_id).proposal;
+    assert_eq!(proposal.eta_ledger, start + MIN_THRESHOLD_DELAY_LEDGERS);
+    assert_eq!(
+        proposal.expires_at_ledger,
+        start + DEFAULT_PROPOSAL_EXPIRY_LEDGERS
+    );
+}
+
+#[test]
+fn upgrade_init_is_idempotent_guarded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    client.upgrade_init(&admin, &wasm_hash(&env, 12), &1);
+    let res = client.try_upgrade_init(&admin, &wasm_hash(&env, 13), &1);
+    assert!(matches!(res, Err(Ok(LendingError::AlreadyInitialized))));
+}


### PR DESCRIPTION
## Overview
This PR adds a timelocked, multi-approval WASM upgrade governance flow to the canonical lending contract (`stellar-lend/contracts/lending`). It implements `upgrade_init`, `upgrade_propose`, `upgrade_approve`, and `upgrade_execute`, reusing multisig-style threshold and delay primitives from `contracts/multisig`.

## Related Issue
Closes #971

## Changes

### 🔐 Upgrade Governance Module
- **[ADD]** `stellar-lend/contracts/lending/src/upgrade.rs`
- `upgrade_init` — admin-only bootstrap of current WASM hash, version `0`, approval threshold, and approver set.
- `upgrade_propose` — records pending WASM hash + monotonic version with `MIN_THRESHOLD_DELAY_LEDGERS` ETA and default expiry window.
- `upgrade_approve` — approver-only; rejects duplicate signers (`AlreadyApproved`).
- `upgrade_execute` — approver-only; requires timelock elapsed + snapshotted threshold; calls `env.deployer().update_current_contract_wasm`.
- `upgrade_add_approver` / `upgrade_remove_approver` / `upgrade_set_required_approvals` — admin approver management (max 32 approvers).
- View helpers: `upgrade_status`, `current_version`, `current_wasm_hash`, `get_required_approvals`, `get_upgrade_approvers`, `get_proposal_approvals`.
- Events: `UpgradeProposed`, `UpgradeApproved`, `UpgradeExecuted`, `UpgradeApproverAdded`, `UpgradeApproverRemoved`.

- **[MODIFY]** `stellar-lend/contracts/lending/src/lib.rs`
- Wired upgrade entrypoints into `LendingContract`.
- Added upgrade-specific `LendingError` variants (3001–3011).
- Exported `assert_admin` as `pub(crate)` for reuse in the upgrade module.

### 🧪 Tests
- **[ADD]** `stellar-lend/contracts/lending/src/upgrade_governance_test.rs`
- Happy path: propose → approve → execute.
- Execute before timelock (`ProposalNotReady`).
- Insufficient approvals at execute time.
- Expired proposal rejection on approve/execute.
- Duplicate approval rejection.
- Double-execute prevention.
- Unauthorized caller rejection.
- Threshold snapshotted at propose time (live threshold raised afterward).
- Non-monotonic version rejection.
- Timelock/expiry ledger math.
- `upgrade_init` idempotency guard.

- **[MODIFY]** `stellar-lend/contracts/lending/src/error_codes_test.rs`
- Stable error code coverage for new upgrade variants.

### 📚 Documentation
- **[MODIFY]** `UPGRADE_MIGRATION_IMPLEMENTATION.md` — documents implemented upgrade governance API and worked example.
- **[MODIFY]** `docs/upgrade_playbook.md` — implementation status note pointing to `src/upgrade.rs`.
- **[MODIFY]** `stellar-lend/contracts/lending/README.md` — upgrade API table, error reference, removed from planned features.

## Verification Results

```
cargo test -p stellarlend-lending --lib ✅ passed (163/163)
```

| Acceptance Criteria | Status |
|---|---|
| `upgrade_propose` records pending hash with ETA ledger delay | ✅ |
| `upgrade_approve` collects approvals until threshold met | ✅ |
| `upgrade_execute` calls `update_current_contract_wasm` after timelock + threshold | ✅ |
| Upgrade events emitted on propose/approve/execute | ✅ |
| Reject expired proposals | ✅ |
| Reject under-approved proposals | ✅ |
| Reject execute before timelock | ✅ |
| Reject duplicate approval from same signer | ✅ |
| Reject double-execute | ✅ |
| Threshold snapshotted at propose time | ✅ |
| Only authorized approvers may approve/execute | ✅ |
| Documentation aligned with implementation | ✅ |