### PR TITLE
test: flash-loan callback revert and under-repay roll back all state

### DIFF
--- a/stellar-lend/contracts/lending/flash_loan.md
+++ b/stellar-lend/contracts/lending/flash_loan.md
@@ -54,6 +54,50 @@ The flash loan fee is configurable by the protocol admin in basis points (1 bp =
 - **Reentrancy**: Standard Soroban protections apply.
 - **Fee Caps**: fees are capped at 10% to prevent accidental or malicious misconfiguration.
 
+## Callback Failure Rollback Guarantee
+
+When the `on_flash_loan` callback fails — either by panicking (reverting) or by
+returning without calling `repay_flash_loan` — the lending contract guarantees
+complete state rollback.
+
+### What is guaranteed
+
+| Condition | Outcome |
+|-----------|---------|
+| Callback panics / traps | Whole transaction reverts; treasury and receiver balances restored |
+| Callback under-repays | `InsufficientRepayment` panic; full rollback via Soroban atomicity |
+| `FlashActive` flag | Always `false` after any failed loan — never left stuck |
+| Receiver balance | Never retains loaned funds after failure |
+| Treasury balance | Identical to pre-loan value after failure |
+
+### Mechanism
+
+Soroban executes every contract invocation atomically. When the lending
+contract panics (e.g. on `InsufficientRepayment`), or when the
+`invoke_contract` call to the callback returns a trap, the host rolls back
+**all** storage mutations made during that invocation frame. This means:
+
+1. The treasury debit (`Treasury -= amount`) is reversed.
+2. The receiver credit (`Balance[receiver] += amount`) is reversed.
+3. The `FlashActive = true` write is reversed.
+
+Because rollback is a host-level guarantee — not a manual try/catch inside
+the contract — there is no code path that can leave the `FlashActive` flag
+stuck at `true` after a failed flash loan.
+
+### Verified by integration tests
+
+The file `tests/flash_callback_revert_test.rs` covers:
+
+- `test_reverting_callback_returns_err_and_rolls_back` — callback panics;
+  confirms treasury, receiver balance, and `FlashActive` all restored.
+- `test_reverting_callback_panics_on_direct_call` — non-`try_*` variant
+  propagates the panic to the caller.
+- `test_under_repaying_callback_returns_err_and_rolls_back` — callback
+  returns without repaying; confirms full rollback.
+- `test_flash_active_not_stuck_after_consecutive_failures` — two consecutive
+  failed loans; `FlashActive` is `false` after each, confirming no stuck flag.
+
 # Flash Loan Reservation Accounting
 
 ## Overview

--- a/stellar-lend/contracts/lending/tests/flash_callback_revert_test.rs
+++ b/stellar-lend/contracts/lending/tests/flash_callback_revert_test.rs
@@ -1,0 +1,209 @@
+//! Integration tests for flash-loan callback failure rollback.
+//!
+//! Proves that a reverting or under-repaying `on_flash_loan` callback leaves
+//! zero residual state: treasury balance unchanged, receiver balance unchanged,
+//! and the `FlashActive` guard cleared.
+//!
+//! Pattern mirrors `tests/cross_contract_invocation.rs` but registers the
+//! lending contract natively (no pre-built WASM required), following the
+//! same approach used by `src/deposit_accounting_test.rs`.
+
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::Address as _,
+    Address, Bytes, Env, IntoVal, Val,
+};
+
+use stellarlend_lending::{DataKey, LendingContract, LendingContractClient};
+
+// ── Stub: panics inside the callback ─────────────────────────────────────────
+
+/// Stub receiver whose `on_flash_loan` always panics.
+/// Simulates a borrower strategy that reverts mid-execution.
+#[contract]
+pub struct RevertingBorrower;
+
+#[contractimpl]
+impl RevertingBorrower {
+    /// Callback invoked by the lending contract — always panics.
+    #[allow(unused_variables)]
+    pub fn on_flash_loan(
+        _env: Env,
+        _initiator: Address,
+        _asset: Address,
+        _amount: i128,
+        _fee: i128,
+        _params: Bytes,
+    ) -> Val {
+        panic!("BorrowerStrategyFailed");
+    }
+}
+
+// ── Stub: returns without repaying ───────────────────────────────────────────
+
+/// Stub receiver whose `on_flash_loan` returns without calling
+/// `repay_flash_loan`, leaving the treasury balance under-funded.
+#[contract]
+pub struct UnderRepayingBorrower;
+
+#[contractimpl]
+impl UnderRepayingBorrower {
+    /// Callback that acknowledges the loan but never repays it.
+    #[allow(unused_variables)]
+    pub fn on_flash_loan(
+        env: Env,
+        _initiator: Address,
+        _asset: Address,
+        _amount: i128,
+        _fee: i128,
+        _params: Bytes,
+    ) -> Val {
+        // Returns without transferring funds — treasury stays depleted.
+        false.into_val(&env)
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env, treasury_balance: i128) -> (LendingContractClient<'_>, Address, Address) {
+    let contract_id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    let asset = Address::generate(env);
+    // Seed treasury directly so flash_loan has liquidity.
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Treasury(asset.clone()), &treasury_balance);
+    });
+    (client, contract_id, asset)
+}
+
+fn read_treasury(env: &Env, contract_id: &Address, asset: &Address) -> i128 {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, i128>(&DataKey::Treasury(asset.clone()))
+            .unwrap_or(0)
+    })
+}
+
+fn read_balance(env: &Env, contract_id: &Address, asset: &Address, account: &Address) -> i128 {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, i128>(&DataKey::Balance(asset.clone(), account.clone()))
+            .unwrap_or(0)
+    })
+}
+
+fn read_flash_active(env: &Env, contract_id: &Address) -> bool {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .instance()
+            .get::<DataKey, bool>(&DataKey::FlashActive)
+            .unwrap_or(false)
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// `try_flash_loan` returns `Err` when the callback panics, and all storage
+/// mutations made before the panic are rolled back by Soroban's transaction
+/// atomicity guarantee.
+#[test]
+fn test_reverting_callback_returns_err_and_rolls_back() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, contract_id, asset) = setup(&env, 10_000);
+    let receiver = env.register(RevertingBorrower, ());
+    let initiator = Address::generate(&env);
+
+    let result = client.try_flash_loan(
+        &initiator,
+        &receiver,
+        &asset,
+        &1_000_i128,
+        &Bytes::new(&env),
+    );
+
+    assert!(result.is_err(), "reverting callback must return Err");
+
+    // Treasury restored, no funds leaked to receiver, guard cleared.
+    assert_eq!(read_treasury(&env, &contract_id, &asset), 10_000);
+    assert_eq!(read_balance(&env, &contract_id, &asset, &receiver), 0);
+    assert!(!read_flash_active(&env, &contract_id));
+}
+
+/// Calling `flash_loan` (non-try variant) when the callback panics must
+/// itself panic — i.e., the revert propagates to the caller.
+#[test]
+#[should_panic]
+fn test_reverting_callback_panics_on_direct_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _contract_id, asset) = setup(&env, 10_000);
+    let receiver = env.register(RevertingBorrower, ());
+    let initiator = Address::generate(&env);
+
+    client.flash_loan(
+        &initiator,
+        &receiver,
+        &asset,
+        &1_000_i128,
+        &Bytes::new(&env),
+    );
+}
+
+/// An under-repaying callback causes `InsufficientRepayment` panic inside
+/// `flash_loan`; `try_flash_loan` captures it and rolls back all state.
+#[test]
+fn test_under_repaying_callback_returns_err_and_rolls_back() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, contract_id, asset) = setup(&env, 10_000);
+    let receiver = env.register(UnderRepayingBorrower, ());
+    let initiator = Address::generate(&env);
+
+    let result = client.try_flash_loan(
+        &initiator,
+        &receiver,
+        &asset,
+        &1_000_i128,
+        &Bytes::new(&env),
+    );
+
+    assert!(result.is_err(), "under-repaying callback must return Err");
+
+    assert_eq!(read_treasury(&env, &contract_id, &asset), 10_000);
+    assert_eq!(read_balance(&env, &contract_id, &asset, &receiver), 0);
+    assert!(!read_flash_active(&env, &contract_id));
+}
+
+/// After two consecutive failed flash loans the `FlashActive` flag must not
+/// be stuck `true` — i.e., a failed loan does not permanently block future
+/// loan attempts.
+#[test]
+fn test_flash_active_not_stuck_after_consecutive_failures() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, contract_id, asset) = setup(&env, 20_000);
+    let receiver = env.register(UnderRepayingBorrower, ());
+    let initiator = Address::generate(&env);
+
+    // First failure.
+    let _ = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &Bytes::new(&env));
+    assert!(!read_flash_active(&env, &contract_id), "FlashActive stuck after 1st failure");
+
+    // Second failure — must succeed in entering the loan path (not blocked by stuck flag).
+    let _ = client.try_flash_loan(&initiator, &receiver, &asset, &2_000_i128, &Bytes::new(&env));
+    assert!(!read_flash_active(&env, &contract_id), "FlashActive stuck after 2nd failure");
+
+    // Treasury must be fully intact.
+    assert_eq!(read_treasury(&env, &contract_id, &asset), 20_000);
+}


### PR DESCRIPTION
test: flash-loan callback revert and under-repay roll back all state
  
  Summary
  
  Adds integration tests proving that a failing on_flash_loan callback leaves zero residual state
  — no funds moved, no FlashActive flag stuck — and documents the rollback guarantee.
  
  Changes
  
  tests/flash_callback_revert_test.rs (new)
  
  Two stub borrower contracts:
  
  - RevertingBorrower — callback always panics
  - UnderRepayingBorrower — callback returns without calling repay_flash_loan
  
  Four tests:
  
  ┌────────────────────────────────────────┬─────────────────────────────────────────────────┐
  │ Test                                   │ Covers                                          │
  ├────────────────────────────────────────┼─────────────────────────────────────────────────┤
  │ test_reverting_callback_returns_e      │ Panicking callback → Err,                       │
  │ rr_and_rolls_back                      │ treasury/balance/FlashActive all restored       │
  ├────────────────────────────────────────┼─────────────────────────────────────────────────┤
  │ test_reverting_callback_panics_on      │ Non-try_* call propagates panic to caller       │
  │ _direct_call                           │                                                 │
  ├────────────────────────────────────────┼─────────────────────────────────────────────────┤
  │ test_under_repaying_callback_retu      │ No repayment → InsufficientRepayment, full      │
  │ rns_err_and_rolls_back                 │ rollback                                        │
  ├────────────────────────────────────────┼─────────────────────────────────────────────────┤
  │ test_flash_active_not_stuck_after      │ Two consecutive failures, FlashActive is false  │
  │ _consecutive_failures                  │ after each                                      │
  └────────────────────────────────────────┴─────────────────────────────────────────────────┘
  
  flash_loan.md (updated)
  
  Added Callback Failure Rollback Guarantee section documenting the guarantee table, the Soroban
  host-level atomicity mechanism, and cross-references to the new tests.
  
  How to test
  
  cargo test --test flash_callback_revert_test
  
  Notes
  
  - No changes to contract logic — tests only.
  - Rollback is a Soroban host guarantee, not a manual try/catch, so no contract code was
  modified.
  - No regressions to existing flash-loan snapshots.

▸ Credits: 0.15 • Time: 8s
─────────────────────────────────────────────────────────────────────────────────────────────────
  allow commit
   
  Not sure what you mean — the commit was already made and pushed in the previous step:
  
  [feature/flash-callback-revert-tests d1d148b] test: flash-loan callback revert and under-repay
  roll back all state
   2 files changed, 253 insertions(+)
  
  Could you clarify? For example:
  
  - Do you want to open the PR on GitHub?
  - Did a pre-commit hook block something?
  - Do you want to amend the commit?

▸ Credits: 0.12 • Time: 3s
─────────────────────────────────────────────────────────────────────────────────────────────────
  yes
   
  Which one did you mean?
  
  1. Open the PR on GitHub
  2. A pre-commit hook blocked something
  3. Amend the commit

▸ Credits: 0.11 • Time: 2s
─────────────────────────────────────────────────────────────────────────────────────────────────
  1
   
  Open this URL to create the PR:
  
  https://github.com/sadiqabubakar826-del/stellarlend-contracts/pull/new/feature/flash-callback-r
  evert-tests
  (https://github.com/sadiqabubakar826-del/stellarlend-contracts/pull/new/feature/flash-callback-
  revert-tests)
  
  Use the description I gave you above. Set base branch to main.
close #1047 