### PR TITLE
feat: reject self-liquidation in lending

### DIFF
--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -126,6 +126,7 @@ Normal ──► Shutdown ──► Recovery ──► Normal
 | `LendingError::DepositCapExceeded` | 2002 | Deposit would exceed the total deposit cap. |
 | `LendingError::InvalidFeeBps` | 2005 | Flash loan fee is outside the permitted range. |
 | `LendingError::InsufficientCollateral` | 2007 | Collateral is too low for the requested operation. |
+| `LendingError::SelfLiquidation` | 2008 | Liquidation rejected because the caller is also the borrower. |
 | `LendingError::InvalidOracleSignature` | 5001 | Oracle price update signature is invalid. |
 | `LendingError::StaleOracleTimestamp` | 5002 | Oracle price update is too old. |
 | `LendingError::OraclePubkeyNotSet` | 5003 | Oracle public key is missing from storage. |

--- a/stellar-lend/contracts/lending/SECURITY_NOTES.md
+++ b/stellar-lend/contracts/lending/SECURITY_NOTES.md
@@ -37,6 +37,9 @@ To ensure determinism and avoid rounding ambiguity, the protocol strictly enforc
 
 There are no edge cases where a `10_000` Health Factor allows for liquidation. All price oracle rounding uses integer truncations designed to safely error on the side of protecting the borrower from false-positive liquidations.
 
+### Self-Liquidation Guard
+The `liquidate` entry point now rejects any call where the liquidator address matches the borrower address. This guard triggers before any collateral or debt state reads, preventing a borrower from liquidating their own position to capture the liquidation incentive and profit from the protocol's close-factor mechanics.
+
 ## Oracle Migration Risks and Mitigation
 
 Changing the protocol oracle (either the legacy address or the hardened module primary/fallback slots) is a high-risk administrative action that impacts the valuation of all open positions.

--- a/stellar-lend/contracts/lending/src/error_codes_test.rs
+++ b/stellar-lend/contracts/lending/src/error_codes_test.rs
@@ -15,6 +15,7 @@ fn test_error_code_stability_and_uniqueness() {
         (LendingError::DepositCapExceeded, 2002),
         (LendingError::InvalidFeeBps, 2005),
         (LendingError::InsufficientCollateral, 2007),
+        (LendingError::SelfLiquidation, 2008),
         (LendingError::InvalidOracleSignature, 5001),
         (LendingError::StaleOracleTimestamp, 5002),
         (LendingError::OraclePubkeyNotSet, 5003),

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -21,6 +21,8 @@ mod health_factor_edge_test;
 mod interest_drift_regression_test;
 #[cfg(test)]
 mod rounding_drift_test;
+#[cfg(test)]
+mod self_liquidation_test;
 
 use debt::{
     borrow_amount, effective_debt, load_debt, repay_amount, save_debt, settle_accrual,
@@ -130,6 +132,8 @@ pub enum LendingError {
     DepositCapExceeded = 2002,
     InvalidFeeBps = 2005,
     InsufficientCollateral = 2007,
+    /// Rejects a liquidation where the liquidator and borrower are the same address.
+    SelfLiquidation = 2008,
     InvalidOracleSignature = 5001,
     StaleOracleTimestamp = 5002,
     OraclePubkeyNotSet = 5003,
@@ -484,6 +488,10 @@ impl LendingContract {
         Ok(updated.principal)
     }
 
+    /// Liquidate an under-collateralized borrower position.
+    ///
+    /// Self-liquidations are rejected immediately so a borrower cannot profit
+    /// from the liquidation incentive on their own collateral.
     pub fn liquidate(
         env: Env,
         liquidator: Address,
@@ -491,6 +499,10 @@ impl LendingContract {
         amount: i128,
     ) -> Result<i128, LendingError> {
         liquidator.require_auth();
+        if liquidator == borrower {
+            return Err(LendingError::SelfLiquidation);
+        }
+
         let col_key = DataKey::Collateral(borrower.clone());
 
         let collateral: i128 = env.storage().persistent().get(&col_key).unwrap_or(0);

--- a/stellar-lend/contracts/lending/src/self_liquidation_test.rs
+++ b/stellar-lend/contracts/lending/src/self_liquidation_test.rs
@@ -1,0 +1,49 @@
+#![cfg(test)]
+
+use crate::{LendingContract, LendingContractClient, LendingError};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let liquidator = borrower.clone();
+    client.initialize(&admin);
+    (env, client, borrower, liquidator, admin)
+}
+
+#[test]
+fn self_liquidation_is_rejected_before_any_state_change() {
+    let (env, client, borrower, liquidator, _admin) = setup();
+
+    client.deposit(&borrower, &100);
+    client.borrow(&borrower, &200);
+
+    let before_collateral = client.get_position(&borrower).collateral;
+    let before_debt = client.get_position(&borrower).debt;
+
+    let res = client.try_liquidate(&liquidator, &borrower, &100);
+
+    assert!(matches!(res, Err(Ok(LendingError::SelfLiquidation))));
+    assert_eq!(client.get_position(&borrower).collateral, before_collateral);
+    assert_eq!(client.get_position(&borrower).debt, before_debt);
+
+    let other_liquidator = Address::generate(&env);
+    let success = client.try_liquidate(&other_liquidator, &borrower, &100);
+    assert!(success.is_ok(), "distinct-address liquidation should still succeed");
+}
+
+#[test]
+fn unhealthy_self_position_is_rejected_even_when_position_is_underwater() {
+    let (_env, client, borrower, liquidator, _admin) = setup();
+
+    client.deposit(&borrower, &100);
+    client.borrow(&borrower, &200);
+
+    let res = client.try_liquidate(&liquidator, &borrower, &100);
+
+    assert!(matches!(res, Err(Ok(LendingError::SelfLiquidation))));
+}


### PR DESCRIPTION
## Summary

- Reject self-liquidations in the lending contract by adding a dedicated `LendingError::SelfLiquidation` guard in `liquidate`.
- The guard runs before any collateral or debt state is read or mutated, preventing a borrower from liquidating their own position to capture the liquidation incentive.
- Added regression tests for same-address rejection, distinct-address success, and underwater self-position rejection, and documented the new security behavior.

## Type of change

- [x] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

### Functional tests
- [x] New public functions have success-path and failure-path tests
- [x] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the known baseline

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [x] `require_auth()` called for every entry point that modifies user state
- [x] No new function bypasses the pause guard without justification

**Arithmetic**
- [x] No unchecked arithmetic on untrusted values
- [x] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [x] Floor for collateral capacity; ceiling for interest owed

### Docs
- [x] Public functions have a doc comment (error codes, params, return)
- [x] Relevant docs sections updated (`SECURITY_NOTES.md`, `README.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed

### Notes

- I could not run the Rust test suite in this environment because the Cargo toolchain is not available here, so the functional test checkbox remains unchecked pending local/CI verification.


Closes #1031 

