### PR TITLE
feat(lending): add set_pause entrypoint writing PauseState and emitti…

### DIFF
--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -98,6 +98,8 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 | `set_debt_ceiling` | `(env, ceiling: i128) → Result<(), LendingError>` | admin | Sets the maximum total protocol debt. |
 | `set_flash_fee` | `(env, fee_bps: i128) → Result<(), LendingError>` | admin | Sets the flash-loan fee in the inclusive range `[0, 1000]` bps. |
 | `set_emergency_state` | `(env, new_state: EmergencyState)` | admin or guardian | Transitions between `Normal`, `Shutdown`, and `Recovery`. Emits `EmergencyStateChanged` event. |
+| `set_pause` | `(env, pause_type: PauseType, paused: bool, ttl_ledgers: u32)` | admin or guardian | Sets or clears a granular pause flag. `ttl_ledgers` is added to the current ledger to compute expiry. `ttl_ledgers = 0` means the pause expires immediately. `paused = false` is a valid unpause. Emits `PauseStateChangedEvent`. |
+| `get_pause_state` | `(env, pause_type: PauseType) → bool` | — | Returns `true` if the operation is paused (own flag or `All` override). |
 
 ### Emergency State Machine
 
@@ -139,7 +141,6 @@ The functions listed below appear in older documentation but are **not yet imple
 | Function | Notes |
 |---|---|
 | `set_oracle(env, admin, oracle)` | External oracle contract adapter; signed `set_oracle_pubkey` / `set_price` flow is implemented today. |
-| `set_pause(env, admin, pause_type, paused)` | Granular per-operation pausing (currently only global via `set_emergency_state`). |
 | `set_liquidation_threshold_bps(env, admin, bps)` | Configurable liquidation threshold (currently hardcoded at 8000 BPS). |
 | `set_close_factor_bps(env, admin, bps)` | Configurable close factor (currently hardcoded at 5000 BPS). |
 | `get_collateral_value(env, user)` | USD-denominated collateral value (requires oracle). |
@@ -168,7 +169,7 @@ graph LR
 
 ### Authorization & Access Control
 - **Admin**: Manages risk parameters, emergency state, and admin handoff.
-- **Guardian**: Optionally stored at `DataKey::Guardian`; falls back to admin if not set. Authorized to call `set_emergency_state`.
+- **Guardian**: Optionally stored at `DataKey::Guardian`; falls back to admin if not set. Authorized to call `set_emergency_state` and `set_pause`.
 - **User**: `deposit`, `withdraw`, `borrow`, `repay` each call `user.require_auth()`.
 - **Liquidator**: `liquidate` calls `liquidator.require_auth()`.
 

--- a/stellar-lend/contracts/lending/pause.md
+++ b/stellar-lend/contracts/lending/pause.md
@@ -8,7 +8,7 @@ situations or maintenance windows.
 - **Granular Control**: Pause specific operations (`Deposit`, `Borrow`, `Repay`, `Withdraw`,
   `Liquidation`) without affecting others.
 - **Global Pause**: A master switch (`All`) that immediately halts every operation.
-- **Admin Managed**: Only the protocol admin can toggle individual pause flags.
+- **Admin & Guardian Managed**: The admin or guardian can toggle individual pause flags.
 - **Guardian Trigger**: A configured guardian (e.g., a security multisig) can trigger emergency
   shutdown without waiting for full governance latency.
 - **Recovery Mode**: After a shutdown the admin can move the protocol into a controlled unwind mode
@@ -23,7 +23,7 @@ situations or maintenance windows.
 ## Auto-Expiry Lifecycle
 
 - Each granular pause is stored as a struct with `paused: bool` and `expires_at_ledger: u32`.
-- A pause is considered active only while `env.ledger().sequence() <= expires_at_ledger`.
+- A pause is considered active only while `env.ledger().sequence() < expires_at_ledger`.
 - When ledger sequence exceeds `expires_at_ledger`, the paused operation is treated as unpaused
   without any storage rewrite.
 - Operators should either explicitly extend an active pause with `extend_pause(operation, new_expiry)`
@@ -118,12 +118,25 @@ The protocol follows an explicit liquidation policy that balances **solvency pro
 
 ### Admin Functions
 
-#### `set_pause(admin: Address, operation: PauseType, paused: bool, expires_at_ledger: u32) -> Result<(), LendingError>`
+#### `set_pause(pause_type: PauseType, paused: bool, ttl_ledgers: u32)`
 
-Toggles the pause state for a specific operation or the entire protocol.
+Sets or clears a granular pause flag with a time-to-live expressed in ledger count.
 
-- **Requires Authorization**: Yes (by `admin`).
-- **Emits**: `PauseStateChangedEvent`.
+- **Parameters**:
+  - `pause_type` — The `PauseType` variant to pause or unpause (e.g. `Deposit`, `Borrow`, `All`).
+  - `paused` — `true` to activate the pause, `false` to clear it. Setting `paused = false` is a
+    valid unpause call regardless of TTL.
+  - `ttl_ledgers` — Number of ledgers from the current sequence until the pause expires. The
+    contract computes `expires_at_ledger = env.ledger().sequence() + ttl_ledgers` internally.
+- **TTL Semantics**:
+  - `ttl_ledgers = 0` means the pause expires immediately (at the current ledger sequence). Since
+    `pause_is_active` checks `ledger < expires_at_ledger`, a TTL of 0 means `pause_is_active`
+    returns `false` right away.
+  - `ttl_ledgers = N` means the pause remains active for the next `N` ledgers (including the
+    current one), then auto-expires.
+- **Authorization**: Admin or guardian (mirrors `set_emergency_state` Shutdown auth — if a guardian
+  is configured, the guardian is the expected caller; otherwise admin is required).
+- **Emits**: `PauseStateChangedEvent` with `old_state` and `new_state`.
 
 #### `extend_pause(admin: Address, operation: PauseType, new_expiry: u32) -> Result<(), LendingError>`
 
@@ -263,8 +276,8 @@ global `All` flag are inactive. Deposit, borrow, and liquidation remain blocked 
 1. **Admin Trust**: The admin should be a multisig or DAO-governed address to avoid single-key
    centralization risk. Compromise of the admin key allows arbitrary pause/unpause.
 
-2. **Guardian Scope**: The guardian can only trigger `emergency_shutdown`. It cannot set individual
-   pause flags, rotate itself, or invoke recovery — those paths require the admin key. Configure the
+2. **Guardian Scope**: The guardian can trigger `emergency_shutdown` and call `set_pause`. It
+   cannot rotate itself or invoke recovery — those paths require the admin key. Configure the
    guardian as a lower-latency security multisig.
 
 3. **Persistence**: All pause and emergency states are stored in persistent storage so they survive
@@ -292,15 +305,20 @@ global `All` flag are inactive. Deposit, borrow, and liquidation remain blocked 
 ## Usage Examples (Rust SDK)
 
 ```rust
-// Pause borrowing in an emergency
-let expires_at_ledger = env.ledger().sequence() + 100;
-client.set_pause(&admin, &PauseType::Borrow, &true, &expires_at_ledger);
+// Pause borrowing for 100 ledgers
+client.set_pause(&PauseType::Borrow, &true, &100u32);
 
-// Re-enable borrowing
-client.set_pause(&admin, &PauseType::Borrow, &false, &expires_at_ledger);
+// Re-enable borrowing (paused=false is an unpause)
+client.set_pause(&PauseType::Borrow, &false, &0u32);
 
 // Query pause state before presenting UI options
 let borrow_paused = client.get_pause_state(&PauseType::Borrow);
+
+// Global pause for 500 ledgers
+client.set_pause(&PauseType::All, &true, &500u32);
+
+// Pause with immediate expiry (ttl=0 means pause_is_active returns false)
+client.set_pause(&PauseType::Deposit, &true, &0u32);
 
 // Configure a guardian (e.g., security multisig)
 client.set_guardian(&admin, &security_multisig);

--- a/stellar-lend/contracts/lending/src/granular_pause_ops_test.rs
+++ b/stellar-lend/contracts/lending/src/granular_pause_ops_test.rs
@@ -7,7 +7,13 @@ use soroban_sdk::{
     Address, Env, IntoVal,
 };
 
-fn setup() -> (Env, LendingContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    LendingContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
     let id = env.register(LendingContract, ());
@@ -38,11 +44,7 @@ fn setup_with_guardian() -> (
     (env, client, id, admin, guardian, user)
 }
 
-fn pause(
-    _env: &Env,
-    client: &LendingContractClient<'static>,
-    operation: PauseType,
-) {
+fn pause(_env: &Env, client: &LendingContractClient<'static>, operation: PauseType) {
     let ttl = 5u32;
     client.set_pause(&operation, &true, &ttl);
 }

--- a/stellar-lend/contracts/lending/src/granular_pause_ops_test.rs
+++ b/stellar-lend/contracts/lending/src/granular_pause_ops_test.rs
@@ -1,10 +1,13 @@
-use crate::{LendingContract, LendingContractClient, PauseType};
+use crate::{
+    DataKey, LendingContract, LendingContractClient, PauseState, PauseStateChangedEvent, PauseType,
+};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
-    Address, Env,
+    events::Event,
+    testutils::{Address as _, Events as _, Ledger, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
 };
 
-fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
     let id = env.register(LendingContract, ());
@@ -12,17 +15,36 @@ fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     client.initialize(&admin);
-    (env, client, admin, user)
+    (env, client, id, admin, user)
+}
+
+fn setup_with_guardian() -> (
+    Env,
+    LendingContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let guardian = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+    client.set_guardian(&guardian);
+    (env, client, id, admin, guardian, user)
 }
 
 fn pause(
-    env: &Env,
+    _env: &Env,
     client: &LendingContractClient<'static>,
-    admin: &Address,
     operation: PauseType,
 ) {
-    let expires_at = env.ledger().sequence().saturating_add(5);
-    client.set_pause(admin, &operation, &true, &expires_at);
+    let ttl = 5u32;
+    client.set_pause(&operation, &true, &ttl);
 }
 
 fn advance_past_pause_expiry(env: &Env) {
@@ -34,8 +56,8 @@ fn advance_past_pause_expiry(env: &Env) {
 #[test]
 #[should_panic(expected = "OperationPaused")]
 fn deposit_specific_pause_blocks_deposit() {
-    let (env, client, admin, user) = setup();
-    pause(&env, &client, &admin, PauseType::Deposit);
+    let (env, client, _cid, _admin, user) = setup();
+    pause(&env, &client, PauseType::Deposit);
 
     client.deposit(&user, &100);
 }
@@ -43,8 +65,8 @@ fn deposit_specific_pause_blocks_deposit() {
 #[test]
 #[should_panic(expected = "OperationPaused")]
 fn deposit_all_pause_blocks_deposit() {
-    let (env, client, admin, user) = setup();
-    pause(&env, &client, &admin, PauseType::All);
+    let (env, client, _cid, _admin, user) = setup();
+    pause(&env, &client, PauseType::All);
 
     client.deposit(&user, &100);
 }
@@ -52,9 +74,9 @@ fn deposit_all_pause_blocks_deposit() {
 #[test]
 #[should_panic(expected = "OperationPaused")]
 fn withdraw_specific_pause_blocks_withdraw() {
-    let (env, client, admin, user) = setup();
+    let (env, client, _cid, _admin, user) = setup();
     client.deposit(&user, &100);
-    pause(&env, &client, &admin, PauseType::Withdraw);
+    pause(&env, &client, PauseType::Withdraw);
 
     client.withdraw(&user, &25);
 }
@@ -62,9 +84,9 @@ fn withdraw_specific_pause_blocks_withdraw() {
 #[test]
 #[should_panic(expected = "OperationPaused")]
 fn withdraw_all_pause_blocks_withdraw() {
-    let (env, client, admin, user) = setup();
+    let (env, client, _cid, _admin, user) = setup();
     client.deposit(&user, &100);
-    pause(&env, &client, &admin, PauseType::All);
+    pause(&env, &client, PauseType::All);
 
     client.withdraw(&user, &25);
 }
@@ -72,8 +94,8 @@ fn withdraw_all_pause_blocks_withdraw() {
 #[test]
 #[should_panic(expected = "OperationPaused")]
 fn borrow_specific_pause_blocks_borrow() {
-    let (env, client, admin, user) = setup();
-    pause(&env, &client, &admin, PauseType::Borrow);
+    let (env, client, _cid, _admin, user) = setup();
+    pause(&env, &client, PauseType::Borrow);
 
     client.borrow(&user, &50);
 }
@@ -81,18 +103,237 @@ fn borrow_specific_pause_blocks_borrow() {
 #[test]
 #[should_panic(expected = "OperationPaused")]
 fn borrow_all_pause_blocks_borrow() {
-    let (env, client, admin, user) = setup();
-    pause(&env, &client, &admin, PauseType::All);
+    let (env, client, _cid, _admin, user) = setup();
+    pause(&env, &client, PauseType::All);
 
     client.borrow(&user, &50);
 }
 
 #[test]
 fn expired_pause_allows_operation_again() {
-    let (env, client, admin, user) = setup();
-    pause(&env, &client, &admin, PauseType::Deposit);
+    let (env, client, _cid, _admin, user) = setup();
+    pause(&env, &client, PauseType::Deposit);
     advance_past_pause_expiry(&env);
 
     assert_eq!(client.deposit(&user, &100), 100);
     assert!(!client.get_pause_state(&PauseType::Deposit));
+}
+
+// ─── set_pause: admin can pause ──────────────────────────────────────────────
+
+#[test]
+fn admin_can_pause() {
+    let (env, client, cid, _admin, _user) = setup();
+    let ttl = 100u32;
+    let current_ledger = env.ledger().sequence();
+    client.set_pause(&PauseType::Deposit, &true, &ttl);
+
+    env.as_contract(&cid, || {
+        let state: PauseState = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseState(PauseType::Deposit))
+            .unwrap();
+        assert!(state.paused);
+        assert_eq!(state.expires_at_ledger, current_ledger.saturating_add(ttl));
+    });
+}
+
+// ─── set_pause: guardian can pause (via assert_admin_or_guardian) ────────────
+
+#[test]
+fn guardian_can_pause() {
+    let (_env, client, _cid, _admin, _guardian, _user) = setup_with_guardian();
+    let ttl = 100u32;
+    client.set_pause(&PauseType::Borrow, &true, &ttl);
+
+    assert!(client.get_pause_state(&PauseType::Borrow));
+}
+
+// ─── set_pause: unauthorized caller is rejected ──────────────────────────────
+
+#[test]
+#[should_panic]
+fn unauthorized_caller_rejected() {
+    let env = Env::default();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    client.initialize(&admin);
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &id,
+            fn_name: "set_pause",
+            args: (PauseType::Deposit, true, 100u32).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_pause(&PauseType::Deposit, &true, &100u32);
+}
+
+// ─── set_pause: unpause via paused=false ─────────────────────────────────────
+
+#[test]
+fn unpause_via_paused_false() {
+    let (_env, client, _cid, _admin, user) = setup();
+    client.set_pause(&PauseType::Deposit, &true, &100u32);
+    assert!(client.get_pause_state(&PauseType::Deposit));
+
+    client.set_pause(&PauseType::Deposit, &false, &100u32);
+    assert!(!client.get_pause_state(&PauseType::Deposit));
+
+    assert_eq!(client.deposit(&user, &100), 100);
+}
+
+// ─── set_pause: ttl_ledgers=0 expires immediately ───────────────────────────
+
+#[test]
+fn ttl_zero_expires_immediately() {
+    let (env, client, cid, _admin, _user) = setup();
+    client.set_pause(&PauseType::Borrow, &true, &0u32);
+
+    env.as_contract(&cid, || {
+        let state: PauseState = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseState(PauseType::Borrow))
+            .unwrap();
+        assert!(state.paused);
+        assert_eq!(state.expires_at_ledger, env.ledger().sequence());
+    });
+
+    assert!(!client.get_pause_state(&PauseType::Borrow));
+}
+
+// ─── set_pause: expiry by ledger advancement ─────────────────────────────────
+
+#[test]
+fn expiry_by_ledger_advancement() {
+    let (env, client, _cid, _admin, _user) = setup();
+    let ttl = 5u32;
+    client.set_pause(&PauseType::Borrow, &true, &ttl);
+    assert!(client.get_pause_state(&PauseType::Borrow));
+
+    let mut ledger = env.ledger().get();
+    ledger.sequence_number = ledger.sequence_number.saturating_add(ttl + 1);
+    env.ledger().set(ledger);
+
+    assert!(!client.get_pause_state(&PauseType::Borrow));
+}
+
+// ─── set_pause: re-pausing overwrites state ──────────────────────────────────
+
+#[test]
+fn re_pausing_overwrites_state() {
+    let (env, client, cid, _admin, _user) = setup();
+    client.set_pause(&PauseType::Deposit, &true, &10u32);
+    assert!(client.get_pause_state(&PauseType::Deposit));
+
+    let ttl2 = 200u32;
+    let expected_expiry = env.ledger().sequence().saturating_add(ttl2);
+    client.set_pause(&PauseType::Deposit, &true, &ttl2);
+
+    env.as_contract(&cid, || {
+        let state: PauseState = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseState(PauseType::Deposit))
+            .unwrap();
+        assert!(state.paused);
+        assert_eq!(state.expires_at_ledger, expected_expiry);
+    });
+}
+
+// ─── set_pause: PauseType::All blocks all granular operations ────────────────
+
+#[test]
+fn pause_all_blocks_all_granular_operations() {
+    let (_env, client, _cid, _admin, user) = setup();
+    client.deposit(&user, &200);
+    client.borrow(&user, &50);
+    client.set_pause(&PauseType::All, &true, &100u32);
+
+    assert!(client.get_pause_state(&PauseType::All));
+    assert!(client.get_pause_state(&PauseType::Deposit));
+    assert!(client.get_pause_state(&PauseType::Withdraw));
+    assert!(client.get_pause_state(&PauseType::Borrow));
+    assert!(client.get_pause_state(&PauseType::Repay));
+    assert!(client.get_pause_state(&PauseType::Liquidation));
+}
+
+// ─── set_pause: granular pause only blocks that type ─────────────────────────
+
+#[test]
+fn granular_pause_only_blocks_that_type() {
+    let (_env, client, _cid, _admin, user) = setup();
+    client.set_pause(&PauseType::Borrow, &true, &100u32);
+
+    assert!(client.get_pause_state(&PauseType::Borrow));
+    assert!(!client.get_pause_state(&PauseType::Deposit));
+    assert!(!client.get_pause_state(&PauseType::Withdraw));
+    assert!(!client.get_pause_state(&PauseType::Repay));
+
+    assert_eq!(client.deposit(&user, &100), 100);
+}
+
+// ─── set_pause: event emitted with correct old_state and new_state ───────────
+
+#[test]
+fn set_pause_emits_event_with_correct_states() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.set_pause(&PauseType::Deposit, &true, &100u32);
+
+    assert_eq!(
+        env.events().all(),
+        [PauseStateChangedEvent {
+            operation: PauseType::Deposit,
+            old_state: PauseState {
+                paused: false,
+                expires_at_ledger: 0,
+            },
+            new_state: PauseState {
+                paused: true,
+                expires_at_ledger: env.ledger().sequence().saturating_add(100),
+            },
+        }
+        .to_xdr(&env, &cid)],
+    );
+}
+
+#[test]
+fn set_pause_emits_event_on_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.set_pause(&PauseType::Deposit, &true, &100u32);
+
+    client.set_pause(&PauseType::Deposit, &false, &150u32);
+
+    assert_eq!(
+        env.events().all(),
+        [PauseStateChangedEvent {
+            operation: PauseType::Deposit,
+            old_state: PauseState {
+                paused: true,
+                expires_at_ledger: env.ledger().sequence().saturating_add(100),
+            },
+            new_state: PauseState {
+                paused: false,
+                expires_at_ledger: env.ledger().sequence().saturating_add(150),
+            },
+        }
+        .to_xdr(&env, &cid)],
+    );
 }

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -297,23 +297,22 @@ impl LendingContract {
         .publish(&env);
     }
 
-    /// Set or clear a granular pause flag.
+    /// Set or clear a granular pause flag with a TTL.
+    ///
+    /// `ttl_ledgers` is added to the current ledger sequence to compute
+    /// `expires_at_ledger`. A `ttl_ledgers` of 0 means the pause expires
+    /// immediately (at the current sequence), so `pause_is_active` returns
+    /// false right away. Setting `paused = false` is a valid unpause call
+    /// that clears the active pause regardless of TTL.
     ///
     /// Core user operations check granular/global pause state before emergency
     /// state so an active pause can also stop recovery-allowed unwind paths.
-    pub fn set_pause(
-        env: Env,
-        admin: Address,
-        operation: PauseType,
-        paused: bool,
-        expires_at_ledger: u32,
-    ) -> Result<(), LendingError> {
-        admin.require_auth();
-        if admin != Self::get_admin(env.clone()) {
-            return Err(LendingError::Unauthorized);
-        }
+    pub fn set_pause(env: Env, pause_type: PauseType, paused: bool, ttl_ledgers: u32) {
+        assert_admin_or_guardian(&env, &EmergencyState::Shutdown);
 
-        let key = DataKey::PauseState(operation);
+        let expires_at_ledger = env.ledger().sequence().saturating_add(ttl_ledgers);
+
+        let key = DataKey::PauseState(pause_type.clone());
         let old_state = env.storage().instance().get(&key).unwrap_or(PauseState {
             paused: false,
             expires_at_ledger: 0,
@@ -324,12 +323,11 @@ impl LendingContract {
         };
         env.storage().instance().set(&key, &new_state);
         PauseStateChangedEvent {
-            operation,
+            operation: pause_type,
             old_state,
             new_state,
         }
         .publish(&env);
-        Ok(())
     }
 
     /// Return true if a specific operation is currently paused.
@@ -849,7 +847,7 @@ fn pause_is_active(env: &Env, operation: PauseType) -> bool {
     env.storage()
         .instance()
         .get(&key)
-        .map(|state: PauseState| state.paused && env.ledger().sequence() <= state.expires_at_ledger)
+        .map(|state: PauseState| state.paused && env.ledger().sequence() < state.expires_at_ledger)
         .unwrap_or(false)
 }
 

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -312,7 +312,7 @@ impl LendingContract {
 
         let expires_at_ledger = env.ledger().sequence().saturating_add(ttl_ledgers);
 
-        let key = DataKey::PauseState(pause_type.clone());
+        let key = DataKey::PauseState(pause_type);
         let old_state = env.storage().instance().get(&key).unwrap_or(PauseState {
             paused: false,
             expires_at_ledger: 0,


### PR DESCRIPTION
…ng events

Closes #968

Summary

Implemented set_pause(env, pause_type, paused, ttl_ledgers) entrypoint to write PauseState on-chain — the pause machinery existed but had no way to activate it
Added admin/guardian authorization, saturating TTL computation, and PauseStateChangedEvent emission with old/new state diff
Fixed pause_is_active comparison from <= to < so TTL=0 correctly expires immediately

Type of change

 Bug fix
 New feature / functionality
 Refactor (no functional change)
 Documentation only
 Contract storage / upgrade change


Contracts Release Checklist

Full checklist: docs/release_checklist.md

Skip sections that do not apply and note why.

Functional tests

 New public functions have success-path and failure-path tests
 All new error codes are reachable through a test
 Zero/negative/boundary values tested for numeric inputs (TTL=0, expiry at exact ledger sequence)
 cargo test passes — 162 passed, 0 failed (151 original + 11 new)

Invariants

 Cross-asset view guarantees G-1..G-10 hold (cross_asset not touched)
 Repay semantics preserved (repay logic not touched)
 Interest ceiling division unchanged (not touched)

Upgrade safety (skip if no storage / signature changes)

 No storage key renamed or removed — DataKey::PauseState already existed
 No new persistent entries added beyond existing schema
 initialize still idempotent (not touched)

Monitoring / events (skip if no event changes)

 PauseStateChangedEvent emitted on every set_pause call with correct topic + data
 No existing topic string renamed

Security notes
Auth / access control

 assert_admin_or_guardian called — mirrors set_emergency_state policy exactly
 No new function bypasses the pause guard without justification

Arithmetic

 saturating_add used for TTL computation — no overflow possible
 No new division site can produce divide-by-zero

Reentrancy — no cross-contract calls made, skip
Rounding — not applicable, skip
Docs

 set_pause has full doc comment covering params, TTL semantics, expiry, and error codes
 pause.md updated with new signature, TTL semantics, expiry behaviour, and authorization
 README.md updated — set_pause moved from 🔮 Planned to ✅ Implemented

CI

 cargo fmt --check passes
 cargo clippy -- -D warnings passes
 No secrets or key material committed