### PR TITLE
test: end-to-end fuzz target for the liquidate close-factor path

### DIFF
--- a/stellar-lend/contracts/lending/fuzz/Cargo.toml
+++ b/stellar-lend/contracts/lending/fuzz/Cargo.toml
@@ -45,6 +45,10 @@ path = "fuzz_targets/fuzz_liquidation.rs"
 name = "fuzz_repay_borrow_roundtrip"
 path = "fuzz_targets/fuzz_repay_borrow_roundtrip.rs"
 
+[[bin]]
+name = "fuzz_liquidate_close_factor"
+path = "fuzz_targets/fuzz_liquidate_close_factor.rs"
+
 [profile.release]
 opt-level = 3
 debug = true

--- a/stellar-lend/contracts/lending/fuzz/README.md
+++ b/stellar-lend/contracts/lending/fuzz/README.md
@@ -1,0 +1,80 @@
+# Lending fuzz targets
+
+`cargo-fuzz` (libFuzzer) targets for the `stellarlend-lending` contract. Each
+target lives in [`fuzz_targets/`](fuzz_targets/) and is registered as a `[[bin]]`
+in [`Cargo.toml`](Cargo.toml).
+
+## Targets
+
+| Target | Surface | Level |
+| --- | --- | --- |
+| `fuzz_accrual` | `compute_compound_interest` | math |
+| `fuzz_borrow_rate` | borrow-rate model | math |
+| `fuzz_supply_rate` | supply-rate model | math |
+| `fuzz_utilization` | utilization curve | math |
+| `fuzz_health_factor` | health-factor math | math |
+| `fuzz_liquidation` | `compute_liquidation_bonus` / `compute_max_borrow` | math |
+| `fuzz_repay_borrow_roundtrip` | `borrow_amount` / `repay_amount` transforms | `debt.rs` |
+| **`fuzz_liquidate_close_factor`** | **`LendingContract::liquidate` entrypoint** | **end-to-end (Env)** |
+
+## `fuzz_liquidate_close_factor`
+
+Drives the **real `liquidate` entrypoint** through the Soroban `Env`, not just
+the bonus math. Each iteration:
+
+1. registers `LendingContract` in a fresh `Env`;
+2. seeds an arbitrary but well-formed `(collateral, debt)` position **directly
+   into contract storage** (`DataKey::Collateral` + `DataKey::Debt`); and
+3. invokes `try_liquidate(liquidator, borrower, amount)` with a fuzzed repay
+   `amount`.
+
+Positions are seeded directly rather than through `deposit` + `borrow` because
+the public entrypoints cap collateral at the deposit ceiling and never let debt
+approach `i128::MAX` — so they cannot reach the overflow, huge-collateral, and
+near-overflow-seizure states this target needs. The seeded `last_update == now`,
+so the settled debt the contract uses equals the seeded principal exactly,
+making every post-state assertion a deterministic function of the inputs.
+
+The input generator (`Arbitrary` impl) is multi-modal and deliberately straddles
+the interesting edges: tiny/zero debt, realistic and large magnitudes, the
+health-factor boundary (`hf == 10_000`), the close-factor cap
+(`amount ≈ debt·50%`), and the two arithmetic-overflow thresholds
+(`debt · 5000` and `repaid · 11000`).
+
+### Invariants asserted
+
+1. **No panic / host trap.** `try_liquidate` must resolve to a typed result
+   (`Ok(repaid)` or a typed `LendingError`); a host trap (`Err(Err(_))`) is a bug.
+2. **No mutation on the error path.** A returned `LendingError`
+   (`PositionHealthy`, `Overflow`) means an early return, so collateral and debt
+   are unchanged.
+3. **Non-negative post-state** — `debt >= 0` and `collateral >= 0`.
+4. **Close-factor cap** — `repaid <= debt · 5000 / 10_000` and `repaid <= amount`.
+5. **Seized ≤ available collateral** — collateral removed never exceeds what was
+   there.
+6. **Exact transitions** — `new_debt == debt − repaid` and `new_collateral`
+   equal the incentive formula recomputed independently from the pre-state,
+   catching off-by-one / rounding drift.
+
+> The close factor (50%) and incentive (10%) are protocol **constants** in the
+> entrypoint, not parameters. The fuzzer exercises the branches that depend on
+> them by varying `(collateral, debt, amount)` across the cap, the health
+> boundary, and the overflow edges.
+
+### Running
+
+```bash
+# from this directory (requires nightly + cargo-fuzz):
+cargo +nightly fuzz run fuzz_liquidate_close_factor -- -runs=100000
+```
+
+The companion deterministic test
+[`src/liquidate_close_factor_test.rs`](../src/liquidate_close_factor_test.rs)
+pins the same invariant checks to the explicit edge cases (tiny debt, huge
+collateral, the inclusive health boundary, close-factor clamping, and
+near-overflow seizures) and runs under plain `cargo test` with **no nightly /
+cargo-fuzz required**:
+
+```bash
+cargo test -p stellarlend-lending --lib liquidate_close_factor
+```

--- a/stellar-lend/contracts/lending/fuzz/fuzz_targets/fuzz_liquidate_close_factor.rs
+++ b/stellar-lend/contracts/lending/fuzz/fuzz_targets/fuzz_liquidate_close_factor.rs
@@ -1,0 +1,249 @@
+//! Fuzz target: end-to-end `LendingContract::liquidate` entrypoint
+//!
+//! Unlike `fuzz_liquidation` (which fuzzes the bonus/max-borrow *math* in
+//! isolation), this target drives the **real `liquidate` entrypoint** through
+//! the Soroban `Env`: it registers the contract, seeds an arbitrary but
+//! well-formed `(collateral, debt)` position directly into contract storage,
+//! and invokes `try_liquidate` with a fuzzed repay `amount`. This is where
+//! state-machine and rounding faults hide that the pure-math target cannot see.
+//!
+//! Positions are seeded directly via `env.as_contract` (rather than through
+//! `deposit` + `borrow`) on purpose: the public entrypoints cap collateral at
+//! the deposit ceiling and never let debt approach `i128::MAX`, so they cannot
+//! reach the overflow / huge-collateral / near-overflow-seizure states this
+//! target needs to exercise. The seeded `last_update == now`, so the settled
+//! debt the contract uses equals the seeded principal exactly, keeping every
+//! post-state invariant a deterministic function of the inputs.
+//!
+//! ## Invariants asserted (per the issue)
+//!
+//! 1. **No panic / no host trap.** `try_liquidate` must resolve to a typed
+//!    result — either `Ok(repaid)` or a typed `LendingError`. A host trap
+//!    (`Err(Err(_))`) is always a bug.
+//! 2. **No mutation on the error path.** When `liquidate` returns a
+//!    `LendingError` (e.g. `PositionHealthy`, `Overflow`) it returns *before*
+//!    any storage write, so collateral and debt are unchanged.
+//! 3. **Non-negative post-state.** `debt >= 0` and `collateral >= 0` after a
+//!    successful liquidation.
+//! 4. **Close-factor cap.** `repaid <= debt * CLOSE_FACTOR_BPS / 10_000` and
+//!    `repaid <= amount` — a liquidator can never repay more than the
+//!    close-factor share of the debt, nor more than they asked for.
+//! 5. **Seized <= available collateral.** The collateral removed never exceeds
+//!    the collateral that was there.
+//! 6. **Exact transitions (rounding oracle).** `new_debt` and `new_collateral`
+//!    equal the close-factor / incentive formulas recomputed independently from
+//!    the pre-state, catching off-by-one and rounding drift.
+//!
+//! Note: the close factor (50%) and liquidation incentive (10%) are protocol
+//! *constants* baked into the entrypoint, not parameters. The fuzzer therefore
+//! exercises the branches that depend on them by varying `(collateral, debt,
+//! amount)` across the close-factor cap, the health-factor boundary, and the
+//! arithmetic-overflow edges.
+
+#![no_main]
+
+use arbitrary::{Arbitrary, Result, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use stellarlend_lending::{debt::DebtPosition, DataKey, LendingContract, LendingContractClient};
+
+// ── Protocol constants mirrored from `LendingContract::liquidate` (src/lib.rs) ──
+const CLOSE_FACTOR_BPS: i128 = 5_000; // 50% of debt may be repaid per call
+const INCENTIVE_BPS: i128 = 1_000; // 10% liquidation bonus on seized collateral
+const BPS_DENOM: i128 = 10_000;
+
+// ── Value-generation bounds ─────────────────────────────────────────────────
+/// Realistic "small" magnitude (deposit-ceiling scale, 1e12).
+const SMALL_MAX: i128 = 1_000_000_000_000;
+/// "Mid" magnitude (1e18) — large but far from the i128 overflow edges.
+const MID_MAX: i128 = 1_000_000_000_000_000_000;
+/// Debt at/above which `debt * CLOSE_FACTOR_BPS` overflows i128 (~3.4e34).
+const CLOSE_FACTOR_OVERFLOW_DEBT: i128 = i128::MAX / CLOSE_FACTOR_BPS;
+/// Repay at/above which `repay * (BPS_DENOM + INCENTIVE_BPS)` overflows (~1.5e34).
+const SEIZE_OVERFLOW_REPAY: i128 = i128::MAX / (BPS_DENOM + INCENTIVE_BPS);
+
+/// Draw a non-negative magnitude from a multi-modal distribution that
+/// deliberately straddles the interesting arithmetic edges of `liquidate`.
+fn gen_nonneg(u: &mut Unstructured) -> Result<i128> {
+    Ok(match u.int_in_range(0u8..=5)? {
+        0 => u.int_in_range(0..=4)?,         // tiny / zero debt
+        1 => u.int_in_range(0..=SMALL_MAX)?, // realistic
+        2 => u.int_in_range(0..=MID_MAX)?,   // large
+        // Straddle the close-factor multiply overflow boundary.
+        3 => u.int_in_range(CLOSE_FACTOR_OVERFLOW_DEBT - 16..=CLOSE_FACTOR_OVERFLOW_DEBT + 16)?,
+        // Debt whose 50% close-factor cap straddles the seizure-multiply overflow.
+        4 => u.int_in_range(2 * SEIZE_OVERFLOW_REPAY - 16..=2 * SEIZE_OVERFLOW_REPAY + 16)?,
+        _ => u.int_in_range(0..=i128::MAX)?, // anywhere, including near-MAX collateral
+    })
+}
+
+/// Draw a repay `amount`. Mostly non-negative (the realistic liquidator case),
+/// but occasionally zero or negative to confirm the entrypoint never traps on
+/// degenerate input, and frequently pinned near the close-factor cap so the
+/// `amount > max_repay` branch is exercised on both sides.
+fn gen_amount(u: &mut Unstructured, debt: i128) -> Result<i128> {
+    Ok(match u.int_in_range(0u8..=4)? {
+        0 => 0,
+        1 => u.int_in_range(-SMALL_MAX..=SMALL_MAX)?, // includes negatives
+        2 => gen_nonneg(u)?,
+        3 => {
+            // Straddle the per-call close-factor cap for this debt.
+            let cap = debt
+                .checked_mul(CLOSE_FACTOR_BPS)
+                .map(|v| v / BPS_DENOM)
+                .unwrap_or(i128::MAX);
+            let delta = u.int_in_range(-3i128..=3)?;
+            cap.saturating_add(delta)
+        }
+        _ => u.int_in_range(0..=i128::MAX)?,
+    })
+}
+
+/// A fuzzed liquidation scenario: the borrower's seeded position plus the
+/// liquidator's requested repay amount.
+#[derive(Debug)]
+struct LiqInput {
+    collateral: i128,
+    debt: i128,
+    amount: i128,
+}
+
+impl<'a> Arbitrary<'a> for LiqInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let collateral = gen_nonneg(u)?;
+        let mut debt = gen_nonneg(u)?;
+
+        // One time in three, derive the debt so the health factor sits right on
+        // the liquidation boundary (`hf == 10_000`), exercising the
+        // healthy/unhealthy transition that random values rarely hit.
+        if u.ratio(1, 3)? {
+            // hf == 10_000  <=>  debt == collateral * 8_000 / 10_000.
+            if let Some(boundary) = collateral.checked_mul(8_000).map(|v| v / BPS_DENOM) {
+                let delta = u.int_in_range(-3i128..=3)?;
+                debt = boundary.saturating_add(delta).max(0);
+            }
+        }
+
+        let amount = gen_amount(u, debt)?;
+        Ok(LiqInput {
+            collateral,
+            debt,
+            amount,
+        })
+    }
+}
+
+fuzz_target!(|input: LiqInput| {
+    let LiqInput {
+        collateral: col_pre,
+        debt: debt_pre,
+        amount,
+    } = input;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+
+    let liquidator = Address::generate(&env);
+    let borrower = Address::generate(&env);
+
+    // `now == last_update` so settle_accrual is a no-op: the contract's settled
+    // debt equals `debt_pre`, making every post-state invariant exact.
+    let now = env.ledger().timestamp();
+    env.as_contract(&cid, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(borrower.clone()), &col_pre);
+        env.storage().persistent().set(
+            &DataKey::Debt(borrower.clone()),
+            &DebtPosition {
+                principal: debt_pre,
+                last_update: now,
+            },
+        );
+    });
+
+    match client.try_liquidate(&liquidator, &borrower, &amount) {
+        // Invariant 1: a host trap is always a bug.
+        Err(Err(invoke)) => panic!(
+            "liquidate trapped (host error) for (col={col_pre}, debt={debt_pre}, amount={amount}): {invoke:?}"
+        ),
+        // The i128 return value must always decode cleanly.
+        Ok(Err(conv)) => panic!("liquidate return-value conversion error: {conv:?}"),
+
+        // Typed LendingError -> Invariant 2: early return, no state mutation.
+        Err(Ok(_lending_err)) => {
+            let post = client.get_position(&borrower);
+            assert_eq!(
+                post.collateral, col_pre,
+                "collateral must not change when liquidate errors"
+            );
+            assert_eq!(
+                post.debt, debt_pre,
+                "debt must not change when liquidate errors"
+            );
+        }
+
+        // Successful liquidation -> Invariants 3-6.
+        Ok(Ok(repaid)) => {
+            // Invariant 4: close-factor cap. The contract reached `Ok`, so the
+            // `debt * CLOSE_FACTOR_BPS` multiply did not overflow and we can
+            // recompute the cap with the same checked arithmetic.
+            let max_repay = debt_pre
+                .checked_mul(CLOSE_FACTOR_BPS)
+                .map(|v| v / BPS_DENOM)
+                .expect("Ok return implies the close-factor multiply did not overflow");
+            assert!(
+                repaid <= max_repay,
+                "repaid {repaid} exceeds close-factor cap {max_repay} (debt {debt_pre})"
+            );
+            assert!(
+                repaid <= amount,
+                "repaid {repaid} exceeds requested amount {amount}"
+            );
+
+            let post = client.get_position(&borrower);
+
+            // Invariant 3: non-negative post-state.
+            assert!(post.debt >= 0, "post-liquidation debt negative: {}", post.debt);
+            assert!(
+                post.collateral >= 0,
+                "post-liquidation collateral negative: {}",
+                post.collateral
+            );
+
+            // Invariant 6: exact debt transition (new_debt == debt - repaid).
+            assert_eq!(
+                post.debt,
+                debt_pre.saturating_sub(repaid),
+                "debt transition mismatch (debt {debt_pre}, repaid {repaid})"
+            );
+
+            // Invariant 5: seized <= available collateral.
+            let seized = col_pre.saturating_sub(post.collateral);
+            assert!(
+                seized <= col_pre,
+                "seized {seized} exceeds available collateral {col_pre}"
+            );
+
+            // Invariant 6: exact collateral transition mirrors the incentive math.
+            let seize = repaid
+                .checked_mul(BPS_DENOM + INCENTIVE_BPS)
+                .map(|v| v / BPS_DENOM)
+                .expect("Ok return implies the seizure multiply did not overflow");
+            let final_seized = if seize > col_pre { col_pre } else { seize };
+            assert_eq!(
+                post.collateral,
+                col_pre.saturating_sub(final_seized),
+                "collateral transition mismatch (col {col_pre}, repaid {repaid})"
+            );
+
+            // For a real (non-negative) liquidation, value only flows one way.
+            if amount >= 0 {
+                assert!(repaid >= 0, "repaid negative for non-negative amount {amount}");
+                assert!(seized >= 0, "collateral increased during liquidation");
+            }
+        }
+    }
+});

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -20,6 +20,8 @@ mod health_factor_edge_test;
 #[cfg(test)]
 mod interest_drift_regression_test;
 #[cfg(test)]
+mod liquidate_close_factor_test;
+#[cfg(test)]
 mod rounding_drift_test;
 
 use debt::{

--- a/stellar-lend/contracts/lending/src/liquidate_close_factor_test.rs
+++ b/stellar-lend/contracts/lending/src/liquidate_close_factor_test.rs
@@ -1,0 +1,210 @@
+//! Deterministic companion to the `fuzz_liquidate_close_factor` fuzz target.
+//!
+//! The fuzz target drives `LendingContract::liquidate` end-to-end with random
+//! `(collateral, debt, amount)` states and asserts a set of post-state
+//! invariants. This module pins the same invariant checks to the explicit edge
+//! cases the issue calls out — tiny debt, huge collateral, the unhealthy
+//! boundary, close-factor cap enforcement, and near-overflow seizures — so the
+//! success / `PositionHealthy` / `Overflow` branches are each provably reached
+//! and the invariant oracle is exercised under plain `cargo test` (no
+//! cargo-fuzz / nightly required).
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{debt::DebtPosition, DataKey, LendingContract, LendingContractClient, LendingError};
+
+// Protocol constants mirrored from `LendingContract::liquidate` (lib.rs).
+const CLOSE_FACTOR_BPS: i128 = 5_000;
+const INCENTIVE_BPS: i128 = 1_000;
+const BPS_DENOM: i128 = 10_000;
+/// Repay at/above which `repay * (BPS_DENOM + INCENTIVE_BPS)` overflows i128.
+const SEIZE_OVERFLOW_REPAY: i128 = i128::MAX / (BPS_DENOM + INCENTIVE_BPS);
+
+/// What `liquidate` did with a seeded position.
+#[derive(Debug, PartialEq)]
+enum Outcome {
+    /// Returned `Ok(repaid)`.
+    Repaid(i128),
+    /// Returned a typed `LendingError` (early return, no mutation).
+    Errored(LendingError),
+}
+
+/// Seed a `(collateral, debt)` position directly into contract storage, invoke
+/// the real `liquidate` entrypoint, assert every universal invariant (the same
+/// ones the fuzz target checks), and report which branch was taken.
+///
+/// `last_update == now`, so the settled debt equals `debt` and the post-state
+/// is a deterministic function of the inputs.
+fn run_case(collateral: i128, debt: i128, amount: i128) -> Outcome {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+
+    let liquidator = Address::generate(&env);
+    let borrower = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    env.as_contract(&cid, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(borrower.clone()), &collateral);
+        env.storage().persistent().set(
+            &DataKey::Debt(borrower.clone()),
+            &DebtPosition {
+                principal: debt,
+                last_update: now,
+            },
+        );
+    });
+
+    match client.try_liquidate(&liquidator, &borrower, &amount) {
+        Err(Err(invoke)) => panic!("liquidate trapped (host error): {invoke:?}"),
+        Ok(Err(conv)) => panic!("return-value conversion error: {conv:?}"),
+
+        // Error path: no state mutation.
+        Err(Ok(err)) => {
+            let post = client.get_position(&borrower);
+            assert_eq!(
+                post.collateral, collateral,
+                "collateral changed on error path"
+            );
+            assert_eq!(post.debt, debt, "debt changed on error path");
+            Outcome::Errored(err)
+        }
+
+        // Success path: full invariant battery.
+        Ok(Ok(repaid)) => {
+            let max_repay = debt
+                .checked_mul(CLOSE_FACTOR_BPS)
+                .map(|v| v / BPS_DENOM)
+                .expect("Ok implies close-factor multiply did not overflow");
+            assert!(
+                repaid <= max_repay,
+                "repaid {repaid} exceeds cap {max_repay}"
+            );
+            assert!(repaid <= amount, "repaid {repaid} exceeds amount {amount}");
+
+            let post = client.get_position(&borrower);
+            assert!(post.debt >= 0, "post debt negative");
+            assert!(post.collateral >= 0, "post collateral negative");
+            assert_eq!(
+                post.debt,
+                debt.saturating_sub(repaid),
+                "debt transition mismatch"
+            );
+
+            let seized = collateral.saturating_sub(post.collateral);
+            assert!(
+                seized <= collateral,
+                "seized {seized} exceeds collateral {collateral}"
+            );
+
+            let seize = repaid
+                .checked_mul(BPS_DENOM + INCENTIVE_BPS)
+                .map(|v| v / BPS_DENOM)
+                .expect("Ok implies seizure multiply did not overflow");
+            let final_seized = if seize > collateral {
+                collateral
+            } else {
+                seize
+            };
+            assert_eq!(
+                post.collateral,
+                collateral.saturating_sub(final_seized),
+                "collateral transition mismatch"
+            );
+
+            if amount >= 0 {
+                assert!(repaid >= 0, "repaid negative for non-negative amount");
+                assert!(seized >= 0, "collateral increased during liquidation");
+            }
+            Outcome::Repaid(repaid)
+        }
+    }
+}
+
+/// Normal unhealthy liquidation: hf = 100·8000/200 = 4000 < 10000. With a 50%
+/// close factor and a request equal to the full cap, exactly half the debt is
+/// repaid and 110% of that is seized.
+#[test]
+fn normal_unhealthy_liquidation_repays_close_factor_share() {
+    // max_repay = 200·5000/10000 = 100; seize = 100·11000/10000 = 110 -> clamped to 100.
+    assert_eq!(run_case(100, 200, 100), Outcome::Repaid(100));
+}
+
+/// Close-factor cap: an over-large request is clamped to 50% of the debt, never
+/// repaying (or seizing) more than the cap allows.
+#[test]
+fn oversized_request_is_clamped_to_close_factor_cap() {
+    // amount 1_000_000 >> cap 100 -> repaid == cap == 100.
+    assert_eq!(run_case(100, 200, 1_000_000), Outcome::Repaid(100));
+}
+
+/// Partial repay below the cap leaves exactly `debt - repaid` and seizes
+/// `repaid · 110%`.
+#[test]
+fn partial_repay_below_cap_is_exact() {
+    // repaid 30; new_debt 170; seize 33; new_col 67 — all checked inside run_case.
+    assert_eq!(run_case(100, 200, 30), Outcome::Repaid(30));
+}
+
+/// Tiny / zero debt: a borrower with no debt is healthy by definition.
+#[test]
+fn zero_debt_is_healthy() {
+    assert_eq!(
+        run_case(100, 0, 10),
+        Outcome::Errored(LendingError::PositionHealthy)
+    );
+}
+
+/// A well-collateralised position (hf = 1000·8000/100 = 80_000 ≥ 10_000) cannot
+/// be liquidated.
+#[test]
+fn healthy_position_is_rejected() {
+    assert_eq!(
+        run_case(1_000, 100, 50),
+        Outcome::Errored(LendingError::PositionHealthy),
+    );
+}
+
+/// Exact unhealthy boundary: hf == 10_000 is treated as healthy (`hf >= 10000`),
+/// while one unit more debt tips it unhealthy and a liquidation succeeds.
+#[test]
+fn health_factor_boundary_is_inclusive() {
+    // hf = 10000·8000/8000 = 10000 -> healthy.
+    assert_eq!(
+        run_case(10_000, 8_000, 100),
+        Outcome::Errored(LendingError::PositionHealthy),
+    );
+    // hf = 10000·8000/8001 = 9998 -> unhealthy, liquidation proceeds.
+    assert!(matches!(run_case(10_000, 8_001, 100), Outcome::Repaid(_)));
+}
+
+/// Huge collateral: `collateral · 8000` overflows i128 in the health-factor
+/// computation and the contract fails closed with `Overflow` (no mutation).
+#[test]
+fn huge_collateral_overflows_health_factor() {
+    assert_eq!(
+        run_case(i128::MAX, 100, 50),
+        Outcome::Errored(LendingError::Overflow),
+    );
+}
+
+/// Near-overflow seizure: the position is unhealthy and the close-factor cap is
+/// computable, but `repaid · 110%` overflows i128, so the contract fails closed
+/// with `Overflow` rather than panicking.
+#[test]
+fn near_overflow_seizure_fails_closed() {
+    // debt chosen so the 50% cap lands just past the seizure-multiply overflow.
+    let debt = 2 * SEIZE_OVERFLOW_REPAY + 1_000;
+    // Collateral large enough to be unhealthy but small enough that
+    // `collateral · 8000` itself does not overflow.
+    let collateral = i128::MAX / 8_001;
+    assert_eq!(
+        run_case(collateral, debt, i128::MAX),
+        Outcome::Errored(LendingError::Overflow),
+    );
+}


### PR DESCRIPTION
## Summary

Adds `fuzz_liquidate_close_factor`, a `cargo-fuzz` target that drives the **real `LendingContract::liquidate` entrypoint end-to-end through the Soroban `Env`** — not just the bonus math. The existing `fuzz_liquidation` target only fuzzes `compute_liquidation_bonus` / `compute_max_borrow` in isolation; this one exercises the full state machine (collateral, debt, close-factor cap, incentive, overflow) where rounding and state-transition bugs hide.

Closes #1040.

## What it does

Each iteration:
1. registers `LendingContract` in a fresh `Env`;
2. seeds an arbitrary but well-formed `(collateral, debt)` position **directly into contract storage** (`DataKey::Collateral` + `DataKey::Debt`); and
3. invokes `try_liquidate(liquidator, borrower, amount)` with a fuzzed repay `amount`.

Positions are seeded directly rather than via `deposit` + `borrow` on purpose: the public entrypoints cap collateral at the deposit ceiling and never let debt approach `i128::MAX`, so they cannot reach the overflow / huge-collateral / near-overflow-seizure states this target needs. The seeded `last_update == now`, so the settled debt equals the seeded principal exactly, making every post-state assertion a deterministic function of the inputs.

The multi-modal `Arbitrary` generator straddles the interesting edges: tiny/zero debt, realistic and large magnitudes, the health-factor boundary (`hf == 10_000`), the close-factor cap (`amount ≈ debt·50%`), and the two overflow thresholds (`debt·5000` and `repaid·11000`) — so the `Ok` / `PositionHealthy` / `Overflow` branches are all reached.

## Invariants asserted (each documented with `///`)

1. **No panic / host trap** — `try_liquidate` must resolve to a typed result; `Err(Err(_))` is a bug.
2. **No mutation on the error path** — a returned `LendingError` means an early return, so collateral/debt are unchanged.
3. **Non-negative post-state** — `debt >= 0` and `collateral >= 0`.
4. **Close-factor cap** — `repaid <= debt·5000/10_000` and `repaid <= amount`.
5. **Seized ≤ available collateral**.
6. **Exact transitions (rounding oracle)** — `new_debt == debt − repaid` and `new_collateral` equal the incentive formula recomputed independently from the pre-state.

## Changes

| File | Change |
|---|---|
| `fuzz/fuzz_targets/fuzz_liquidate_close_factor.rs` | New end-to-end fuzz target |
| `fuzz/Cargo.toml` | Registered the `[[bin]]` |
| `fuzz/README.md` | Documents all targets + the new one's invariants and run commands |
| `src/liquidate_close_factor_test.rs` | Deterministic companion test (8 cases) |
| `src/lib.rs` | Registered the test module |

## Validation

- **`cargo build`** of the fuzz crate — compiles & links cleanly against the real API.
- **100,000-iteration run** of the target — zero crashes / invariant violations:

```
#100000	DONE   corp: 1/1b lim: 994 exec/s: 735 rss: 34Mb
Done 100000 runs in 136 second(s)
stat::number_of_executed_units: 100000
stat::average_exec_per_sec:     735
stat::peak_rss_mb:              34
```

- **Companion test — 8/8 pass** (proves the success / `PositionHealthy` / `Overflow` branches are each reached and the invariant oracle holds):

```
running 8 tests
test liquidate_close_factor_test::healthy_position_is_rejected ... ok
test liquidate_close_factor_test::near_overflow_seizure_fails_closed ... ok
test liquidate_close_factor_test::huge_collateral_overflows_health_factor ... ok
test liquidate_close_factor_test::zero_debt_is_healthy ... ok
test liquidate_close_factor_test::oversized_request_is_clamped_to_close_factor_cap ... ok
test liquidate_close_factor_test::normal_unhealthy_liquidation_repays_close_factor_share ... ok
test liquidate_close_factor_test::partial_repay_below_cap_is_exact ... ok
test liquidate_close_factor_test::health_factor_boundary_is_inclusive ... ok

test result: ok. 8 passed; 0 failed; 0 ignored
```

Edge cases covered (issue requirement): tiny/zero debt, huge collateral, inclusive unhealthy boundary, close-factor clamping, and near-overflow seizures. Both new files are `rustfmt`-clean; no existing targets changed.

## ⚠️ Environment note — how this was validated

The dev environment used here has **no `cargo-fuzz` and no nightly toolchain** (the repo pins stable `1.91.0`), and the `wasm32v1-none` target isn't installed, so the literal commands in the issue could not be run as-is:

- `cargo fuzz run fuzz_liquidate_close_factor -- -runs=100000` → substituted by building the target with `cargo build` and running the compiled libFuzzer binary directly for 100,000 iterations (black-box, since a non-cargo-fuzz build lacks coverage instrumentation).
- `cargo test --target wasm32v1-none --release` → ran the companion test on the host (`cargo test -p stellarlend-lending --lib liquidate_close_factor`).

On a fuzz-capable CI the canonical command (documented in `fuzz/README.md`) is:

```bash
cargo +nightly fuzz run fuzz_liquidate_close_factor -- -runs=100000
```