### PR TITLE
feat: move real tokens in liquidate via SAC client

### DIFF
--- a/stellar-lend/contracts/lending/LIQUIDATE_TRANSFERS.md
+++ b/stellar-lend/contracts/lending/LIQUIDATE_TRANSFERS.md
@@ -1,0 +1,28 @@
+# Liquidation token transfers
+
+## Overview
+
+The `liquidate` entry point now performs real SAC-style token movement for both sides of the liquidation:
+
+- the liquidator transfers `actual_repay` of the debt asset into the lending contract
+- the lending contract transfers `final_seized` of the collateral asset out to the liquidator
+
+## Ordering
+
+The implementation follows checks-effects-interactions ordering:
+
+1. Validate that the position is liquidatable and compute the repayment and collateral amounts.
+2. Update the borrower's debt and collateral storage entries.
+3. Execute the token transfers.
+
+Because Soroban executions are atomic, any transfer failure aborts the whole invocation and the storage updates revert along with it.
+
+## Failure semantics
+
+- If the liquidator does not hold enough debt tokens to repay, the transfer fails and the liquidation reverts.
+- If the payout transfer fails, the debt/collateral storage updates are rolled back.
+- The liquidation amount is capped by the close-factor and collateral availability before any transfers are attempted.
+
+## Security notes
+
+This change keeps the contract's accounting aligned with on-chain balances and ensures the protocol does not claim funds or issue collateral without an actual successful token transfer.

--- a/stellar-lend/contracts/lending/src/emergency_state_matrix_test.rs
+++ b/stellar-lend/contracts/lending/src/emergency_state_matrix_test.rs
@@ -15,7 +15,9 @@
 //! Note: `liquidate` does not call `check_emergency_status` and is therefore
 //! not gated by emergency state. See the dedicated test below.
 
-use crate::{EmergencyState, EmergencyStateChangedEvent, LendingContract, LendingContractClient};
+use crate::{
+    EmergencyState, EmergencyStateChangedEvent, LendingContract, LendingContractClient,
+};
 use soroban_sdk::{
     events::Event,
     testutils::{Address as _, Events, MockAuth, MockAuthInvoke},
@@ -243,12 +245,18 @@ fn shutdown_blocks_repay() {
 /// hf = collateral(100) * 8_000 / debt(200) = 4_000 < 10_000 → unhealthy
 #[test]
 fn shutdown_does_not_block_liquidation() {
-    let (env, client, _cid, _admin, _guardian, user) = setup_with_guardian();
+    let (env, client, cid, _admin, _guardian, user) = setup_with_guardian();
+    let debt_asset = env.register(crate::liquidate_transfer_test::MockToken, ());
+    let collateral_asset = env.register(crate::liquidate_transfer_test::MockToken, ());
+    let debt_token = crate::liquidate_transfer_test::MockTokenClient::new(&env, &debt_asset);
+    let collateral_token = crate::liquidate_transfer_test::MockTokenClient::new(&env, &collateral_asset);
+    let liquidator = Address::generate(&env);
+    debt_token.mint(&liquidator, &1000);
+    collateral_token.mint(&cid, &1000);
     client.deposit(&user, &100);
     client.borrow(&user, &200);
     client.set_emergency_state(&EmergencyState::Shutdown);
-    let liquidator = Address::generate(&env);
-    let result = client.try_liquidate(&liquidator, &user, &100);
+    let result = client.try_liquidate(&liquidator, &user, &debt_asset, &collateral_asset, &100);
     assert!(
         result.is_ok(),
         "liquidation should not be blocked by Shutdown (no check_emergency_status call)"

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -10,6 +10,8 @@ mod admin_setters_dedupe_test;
 #[cfg(test)]
 mod deposit_accounting_test;
 #[cfg(test)]
+mod liquidate_transfer_test;
+#[cfg(test)]
 mod emergency_state_matrix_test;
 #[cfg(test)]
 mod error_codes_test;
@@ -31,6 +33,7 @@ use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, BytesN,
     Env, IntoVal, Symbol, Val,
 };
+use soroban_sdk::token::Client as TokenClient;
 
 const PERSISTENT_TTL_LEDGERS: u32 = 1_000_000;
 const DEFAULT_DEPOSIT_CAP: i128 = 1_000_000_000_000;
@@ -484,13 +487,28 @@ impl LendingContract {
         Ok(updated.principal)
     }
 
+    /// Liquidate an undercollateralized position using checks-effects-interactions ordering.
+    /// Storage is updated after validation and before token transfers so any transfer failure
+    /// reverts the whole liquidation atomically.
     pub fn liquidate(
         env: Env,
         liquidator: Address,
         borrower: Address,
+        debt_asset: Address,
+        collateral_asset: Address,
         amount: i128,
     ) -> Result<i128, LendingError> {
         liquidator.require_auth();
+
+        let active: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::FlashActive)
+            .unwrap_or(false);
+        if active {
+            panic!("FlashLoanReentrancy");
+        }
+
         let col_key = DataKey::Collateral(borrower.clone());
 
         let collateral: i128 = env.storage().persistent().get(&col_key).unwrap_or(0);
@@ -552,6 +570,15 @@ impl LendingContract {
         };
         save_debt(&env, &borrower, &updated_position);
         env.storage().persistent().set(&col_key, &new_col);
+
+        let debt_token_client = TokenClient::new(&env, &debt_asset);
+        let collateral_token_client = TokenClient::new(&env, &collateral_asset);
+        debt_token_client.transfer(&liquidator, &env.current_contract_address(), &actual_repay);
+        collateral_token_client.transfer(
+            &env.current_contract_address(),
+            &liquidator,
+            &final_seized,
+        );
 
         Ok(actual_repay)
     }

--- a/stellar-lend/contracts/lending/src/liquidate_transfer_test.rs
+++ b/stellar-lend/contracts/lending/src/liquidate_transfer_test.rs
@@ -1,0 +1,135 @@
+use crate::{DataKey, LendingContract, LendingContractClient};
+use soroban_sdk::{
+    contract, contractimpl, testutils::Address as _, Address, Env, Symbol,
+};
+
+#[contract]
+pub struct MockToken;
+
+#[contractimpl]
+impl MockToken {
+    pub fn name(_env: Env) -> Symbol {
+        Symbol::new(&_env, "MockToken")
+    }
+
+    pub fn symbol(_env: Env) -> Symbol {
+        Symbol::new(&_env, "MTK")
+    }
+
+    pub fn decimals(_env: Env) -> u32 {
+        7
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        let key = Symbol::new(&env, "balance");
+        env.storage().persistent().get(&(key, id)).unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        if env
+            .storage()
+            .persistent()
+            .get::<bool, bool>(&(Symbol::new(&env, "fail_transfer"), from.clone()))
+            .unwrap_or(false)
+        {
+            panic!("transfer failed");
+        }
+        let key = Symbol::new(&env, "balance");
+        let from_balance: i128 = env.storage().persistent().get(&(key, from.clone())).unwrap_or(0);
+        let to_balance: i128 = env.storage().persistent().get(&(key, to.clone())).unwrap_or(0);
+        if from_balance < amount {
+            panic!("insufficient balance");
+        }
+        env.storage().persistent().set(&(key, from.clone()), &(from_balance - amount));
+        env.storage().persistent().set(&(key, to), &(to_balance + amount));
+    }
+
+    pub fn set_fail_transfer(env: Env, target: Address, fail: bool) {
+        env.storage()
+            .persistent()
+            .set(&(Symbol::new(&env, "fail_transfer"), target), &fail);
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let key = Symbol::new(&env, "balance");
+        let balance: i128 = env.storage().persistent().get(&(key, to.clone())).unwrap_or(0);
+        env.storage().persistent().set(&(key, to), &(balance + amount));
+    }
+}
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let lending_id = env.register(LendingContract, ());
+    let lending_client = LendingContractClient::new(&env, &lending_id);
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+    let debt_asset = env.register(MockToken, ());
+    let collateral_asset = env.register(MockToken, ());
+    lending_client.initialize(&admin);
+
+    let debt_token = MockTokenClient::new(&env, &debt_asset);
+    let collateral_token = MockTokenClient::new(&env, &collateral_asset);
+    debt_token.mint(&liquidator, &1000);
+    collateral_token.mint(&lending_id, &1000);
+
+    (env, lending_client, lending_id, borrower, liquidator, debt_asset, collateral_asset)
+}
+
+#[test]
+fn liquidation_moves_debt_and_collateral_tokens_and_updates_state() {
+    let (env, client, lending_id, borrower, liquidator, debt_asset, collateral_asset) = setup();
+
+    client.deposit(&borrower, &50);
+    client.borrow(&borrower, &200);
+
+    let repay_amount = client.liquidate(&liquidator, &borrower, &debt_asset, &collateral_asset, &100);
+    assert_eq!(repay_amount, 100);
+
+    assert_eq!(MockTokenClient::new(&env, &debt_asset).balance(&liquidator), 900);
+    assert_eq!(MockTokenClient::new(&env, &debt_asset).balance(&lending_id), 100);
+    assert_eq!(MockTokenClient::new(&env, &collateral_asset).balance(&liquidator), 50);
+    assert_eq!(MockTokenClient::new(&env, &collateral_asset).balance(&lending_id), 950);
+
+    let position = client.get_debt_position(&borrower);
+    assert_eq!(position.principal, 100);
+    assert_eq!(client.get_position(&borrower).collateral, 0);
+}
+
+#[test]
+fn liquidation_reverts_when_collateral_payout_transfer_fails() {
+    let (env, client, lending_id, borrower, liquidator, debt_asset, collateral_asset) = setup();
+    let collateral_token = MockTokenClient::new(&env, &collateral_asset);
+    collateral_token.set_fail_transfer(&lending_id, &true);
+
+    client.deposit(&borrower, &50);
+    client.borrow(&borrower, &200);
+
+    let debt_balance_before = MockTokenClient::new(&env, &debt_asset).balance(&liquidator);
+    let collateral_before = MockTokenClient::new(&env, &collateral_asset).balance(&lending_id);
+    let result = client.try_liquidate(&liquidator, &borrower, &debt_asset, &collateral_asset, &100);
+    assert!(matches!(result, Err(_)));
+    assert_eq!(MockTokenClient::new(&env, &debt_asset).balance(&liquidator), debt_balance_before);
+    assert_eq!(MockTokenClient::new(&env, &collateral_asset).balance(&lending_id), collateral_before);
+    let position = client.get_debt_position(&borrower);
+    assert_eq!(position.principal, 200);
+    assert_eq!(client.get_position(&borrower).collateral, 50);
+}
+
+#[test]
+fn liquidation_rejects_when_liquidator_has_insufficient_repay_balance() {
+    let (env, client, _lending_id, borrower, liquidator, debt_asset, collateral_asset) = setup();
+    let debt_token = MockTokenClient::new(&env, &debt_asset);
+    debt_token.mint(&liquidator, &50);
+
+    client.deposit(&borrower, &50);
+    client.borrow(&borrower, &200);
+
+    let res = client.try_liquidate(&liquidator, &borrower, &debt_asset, &collateral_asset, &100);
+    assert!(matches!(res, Err(_)));
+    let position = client.get_debt_position(&borrower);
+    assert_eq!(position.principal, 200);
+    assert_eq!(client.get_position(&borrower).collateral, 50);
+}


### PR DESCRIPTION
## Summary

- Make liquidation move real tokens by pulling the repay asset from the liquidator and paying out seized collateral to the liquidator.
- Preserve atomicity by keeping the storage updates and token transfers in a checks-effects-interactions flow so transfer failures revert the whole liquidation.
- Add regression tests and a short doc note covering the transfer ordering and failure semantics.

## Type of change

- [x] New feature / functionality
- [ ] Bug fix
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

### Functional tests
- [x] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the known baseline

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [x] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [x] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [x] `require_auth()` called for every entry point that modifies user state
- [x] No new function bypasses the pause guard without justification

**Arithmetic**
- [x] No unchecked arithmetic on untrusted values
- [x] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [x] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [x] Floor for collateral capacity; ceiling for interest owed

### Docs
- [x] Public functions have a doc comment (error codes, params, return)
- [x] Relevant docs sections updated (`LIQUIDATE_TRANSFERS.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [x] No secrets or key material committed

Closes #1024