### PR TITLE
feat: emit LiquidationEventV1 from liquidate (fixes #1025)

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -21,6 +21,8 @@ mod health_factor_edge_test;
 mod interest_drift_regression_test;
 #[cfg(test)]
 mod rounding_drift_test;
+#[cfg(test)]
+mod liquidate_event_test;
 
 use debt::{
     borrow_amount, effective_debt, load_debt, repay_amount, save_debt, settle_accrual,
@@ -41,6 +43,7 @@ pub const LIQUIDATION_THRESHOLD_BPS: i128 = 8000;
 const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
 const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
+const SCHEMA_VERSION_V1: u32 = 1;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -79,6 +82,18 @@ pub struct PauseStateChangedEvent {
     pub operation: PauseType,
     pub old_state: PauseState,
     pub new_state: PauseState,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiquidationEventV1 {
+    pub schema_version: u32,
+    pub liquidator: Address,
+    pub borrower: Address,
+    pub repaid: i128,
+    pub seized: i128,
+    pub health_factor_before: i128,
+    pub shortfall: i128,
 }
 
 #[contracttype]
@@ -552,6 +567,19 @@ impl LendingContract {
         };
         save_debt(&env, &borrower, &updated_position);
         env.storage().persistent().set(&col_key, &new_col);
+
+        let shortfall = seized_collateral - final_seized;
+
+        LiquidationEventV1 {
+            schema_version: SCHEMA_VERSION_V1,
+            liquidator: liquidator.clone(),
+            borrower: borrower.clone(),
+            repaid: actual_repay,
+            seized: final_seized,
+            health_factor_before: hf,
+            shortfall,
+        }
+        .publish(&env);
 
         Ok(actual_repay)
     }

--- a/stellar-lend/contracts/lending/src/liquidate_event_test.rs
+++ b/stellar-lend/contracts/lending/src/liquidate_event_test.rs
@@ -1,0 +1,110 @@
+use crate::{LiquidationEventV1, LendingContract, LendingContractClient};
+use soroban_sdk::{
+    events::Event,
+    testutils::{Address as _, Events},
+    Address, Env,
+};
+
+fn setup_liquidatable() -> (Env, LendingContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, cid, user, liquidator)
+}
+
+// ─── Standard liquidation event ──────────────────────────────────────────────
+
+/// deposit(100), borrow(200) → hf = 100*8000/200 = 4000 (unhealthy)
+/// amount=150, max_repay = 200*5000/10000 = 100 → actual_repay=100
+/// seized_collateral = 100*11000/10000 = 110, final_seized = min(110,100) = 100
+/// shortfall = 110-100 = 10
+#[test]
+fn liquidate_emits_event_with_correct_fields() {
+    let (env, client, cid, user, liquidator) = setup_liquidatable();
+
+    client.deposit(&user, &100);
+    client.borrow(&user, &200);
+
+    client.liquidate(&liquidator, &user, &150);
+
+    assert_eq!(
+        env.events().all(),
+        [LiquidationEventV1 {
+            schema_version: 1,
+            liquidator: liquidator.clone(),
+            borrower: user.clone(),
+            repaid: 100,
+            seized: 100,
+            health_factor_before: 4000,
+            shortfall: 10,
+        }
+        .to_xdr(&env, &cid)],
+    );
+}
+
+// ─── Close-factor-limited repay ──────────────────────────────────────────────
+
+/// deposit(200), borrow(200) → hf = 200*8000/200 = 8000 (unhealthy)
+/// amount=150, max_repay = 200*5000/10000 = 100 → actual_repay=100
+/// seized_collateral = 100*11000/10000 = 110, final_seized = 110 (not clamped)
+/// shortfall = 0
+#[test]
+fn liquidate_event_close_factor_limits_repay() {
+    let (env, client, cid, user, liquidator) = setup_liquidatable();
+
+    client.deposit(&user, &200);
+    client.borrow(&user, &200);
+
+    client.liquidate(&liquidator, &user, &150);
+
+    assert_eq!(
+        env.events().all(),
+        [LiquidationEventV1 {
+            schema_version: 1,
+            liquidator: liquidator.clone(),
+            borrower: user.clone(),
+            repaid: 100,
+            seized: 110,
+            health_factor_before: 8000,
+            shortfall: 0,
+        }
+        .to_xdr(&env, &cid)],
+    );
+}
+
+// ─── Zero shortfall (no clamping) ────────────────────────────────────────────
+
+/// deposit(500), borrow(200) → hf = 500*8000/200 = 20000 (healthy)
+/// This should fail with PositionHealthy, so we test a borderline case.
+/// deposit(100), borrow(130) → hf = 100*8000/130 ≈ 6153 (unhealthy)
+/// amount=50, max_repay = 130*5000/10000 = 65 → actual_repay=50
+/// seized_collateral = 50*11000/10000 = 55, final_seized = min(55,100) = 55
+/// shortfall = 0
+#[test]
+fn liquidate_event_zero_shortfall() {
+    let (env, client, cid, user, liquidator) = setup_liquidatable();
+
+    client.deposit(&user, &100);
+    client.borrow(&user, &130);
+
+    client.liquidate(&liquidator, &user, &50);
+
+    assert_eq!(
+        env.events().all(),
+        [LiquidationEventV1 {
+            schema_version: 1,
+            liquidator: liquidator.clone(),
+            borrower: user.clone(),
+            repaid: 50,
+            seized: 55,
+            health_factor_before: 6153,
+            shortfall: 0,
+        }
+        .to_xdr(&env, &cid)],
+    );
+}


### PR DESCRIPTION
## Summary

This PR adds a versioned `LiquidationEventV1` emitted on every successful liquidation, making liquidation activity observable through a stable on-chain event without changing any liquidation logic.

Previously, `LendingContract::liquidate` returned the repaid amount but emitted no event, requiring indexers and liquidation bots to infer state changes by diffing storage. This change aligns liquidation with the existing event-driven architecture used by other lending operations.

## Changes

* [x] Added `LiquidationEventV1` with schema versioning.
* [x] Introduced `SCHEMA_VERSION_V1` constant for the event schema.
* [x] Emit a `LiquidationEventV1` at the end of every successful `liquidate` call.
* [x] Event fields include:

  * `liquidator`
  * `borrower`
  * `repaid`
  * `seized`
  * `health_factor_before`
  * `shortfall`
* [x] Preserved all existing liquidation calculations and business logic (events only).

## Tests

Added a dedicated `liquidate_event_test.rs` covering:

* [x] Standard liquidation emits the expected event payload.
* [x] Close-factor-limited liquidation emits the correct `repaid` and `seized` values.
* [x] Zero-shortfall liquidation emits `shortfall = 0`.

## Validation

* [x] `cargo test` (154/154 library tests passing)
* [x] No new Clippy warnings
* [x] No changes to liquidation math or protocol behavior

## Notes

This change is fully backward compatible. It only introduces an additional versioned event, enabling indexers, liquidation bots, explorers, and analytics systems to consume liquidation activity through a stable event interface instead of relying on storage diffs.

#Closes #1025