### PR TITLE
Add flash loan max-utilization breaker

### DIFF
--- a/stellar-lend/contracts/lending/flash_loan.md
+++ b/stellar-lend/contracts/lending/flash_loan.md
@@ -48,6 +48,19 @@ The flash loan fee is configurable by the protocol admin in basis points (1 bp =
 - **Default**: 5 bps (0.05%)
 - **Maximum**: 1000 bps (10%)
 
+## Max Utilization Circuit Breaker
+
+Flash-loan size is also capped by an admin-configurable utilization ratio. Before the callback fires, the lending contract rejects any request whose principal would exceed:
+
+`max_flash_bps × available_liquidity / 10000`
+
+where `available_liquidity` is the current treasury balance available to the flash-loan path. The cap is enforced before any transfer or callback occurs.
+
+- **Setter**: `set_max_flash_bps(max_flash_bps: i128)`
+- **Getter**: `get_max_flash_bps() -> i128`
+- **Bounds**: `0..=10000`
+- **Example**: with `max_flash_bps = 5000` and `available_liquidity = 1_000`, the maximum flash loan is `500`.
+
 ## Security Assumptions
 
 - **Atomicity**: The entire process occurs in a single transaction. If repayment fails, the transaction reverts.

--- a/stellar-lend/contracts/lending/src/error_codes_test.rs
+++ b/stellar-lend/contracts/lending/src/error_codes_test.rs
@@ -14,6 +14,7 @@ fn test_error_code_stability_and_uniqueness() {
         (LendingError::DebtCeilingExceeded, 2001),
         (LendingError::DepositCapExceeded, 2002),
         (LendingError::InvalidFeeBps, 2005),
+        (LendingError::InvalidFlashUtilizationBps, 2006),
         (LendingError::InsufficientCollateral, 2007),
         (LendingError::InvalidOracleSignature, 5001),
         (LendingError::StaleOracleTimestamp, 5002),

--- a/stellar-lend/contracts/lending/src/flash_utilization_test.rs
+++ b/stellar-lend/contracts/lending/src/flash_utilization_test.rs
@@ -1,0 +1,137 @@
+#![cfg(test)]
+
+use crate::{DataKey, LendingContract, LendingContractClient, LendingError};
+use soroban_sdk::{
+    contract, contractimpl, testutils::Address as _, Address, Bytes, Env, Symbol,
+};
+
+#[contract]
+pub struct FlashLoanReceiver;
+
+#[contractimpl]
+impl FlashLoanReceiver {
+    pub fn set_lending_contract(env: Env, lending_contract: Address) {
+        env.storage().instance().set(&Symbol::new(&env, "lending"), &lending_contract);
+    }
+
+    pub fn get_callback_count(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, "callbacks"))
+            .unwrap_or(0u32)
+    }
+
+    pub fn on_flash_loan(
+        env: Env,
+        _initiator: Address,
+        asset: Address,
+        amount: i128,
+        _fee: i128,
+        _params: Bytes,
+    ) {
+        let count: u32 = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "callbacks"))
+            .unwrap_or(0u32);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "callbacks"), &(count + 1u32));
+
+        let lending_contract: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "lending"))
+            .unwrap();
+        env.as_contract(&lending_contract, || {
+            let tre_key = DataKey::Treasury(asset.clone());
+            let tre_bal: i128 = env.storage().persistent().get(&tre_key).unwrap_or(0);
+            let new_tre_bal = tre_bal
+                .checked_add(amount)
+                .expect("flash loan repayment overflow");
+            env.storage().persistent().set(&tre_key, &new_tre_bal);
+        });
+    }
+}
+
+fn setup() -> (
+    Env,
+    LendingContractClient<'static>,
+    FlashLoanReceiverClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let lending_id = env.register(LendingContract, ());
+    let lending_client = LendingContractClient::new(&env, &lending_id);
+    let receiver_id = env.register(FlashLoanReceiver, ());
+    let receiver_client = FlashLoanReceiverClient::new(&env, &receiver_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    lending_client.initialize(&admin);
+    receiver_client.set_lending_contract(&lending_id);
+
+    (env, lending_client, receiver_client, admin, asset, lending_id, receiver_id)
+}
+
+#[test]
+fn test_flash_loan_allows_amount_at_utilization_cap() {
+    let (env, client, receiver, _admin, asset, lending_id, _receiver_id) = setup();
+
+    client.set_flash_fee(&0);
+    client.set_max_flash_bps(&5_000);
+    env.as_contract(&lending_id, || {
+        env.storage().persistent().set(&DataKey::Treasury(asset.clone()), &1_000i128);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(asset.clone(), receiver.address.clone()), &500i128);
+    });
+
+    client.flash_loan(&Address::generate(&env), &receiver.address, &asset, &500i128, &Bytes::new(&env));
+
+    let callback_count = receiver.get_callback_count();
+    assert_eq!(callback_count, 1u32);
+}
+
+#[test]
+fn test_flash_loan_rejects_amount_above_utilization_cap() {
+    let (env, client, receiver, _admin, asset, lending_id, _receiver_id) = setup();
+
+    client.set_flash_fee(&0);
+    client.set_max_flash_bps(&5_000);
+    env.as_contract(&lending_id, || {
+        env.storage().persistent().set(&DataKey::Treasury(asset.clone()), &1_000i128);
+    });
+
+    let res = client.try_flash_loan(
+        &Address::generate(&env),
+        &receiver.address,
+        &asset,
+        &501i128,
+        &Bytes::new(&env),
+    );
+
+    assert!(res.is_err());
+    assert_eq!(receiver.get_callback_count(), 0u32);
+}
+
+#[test]
+fn test_set_max_flash_bps_rejects_out_of_range() {
+    let (_env, client, _receiver, _admin, _asset, _lending_id, _receiver_id) = setup();
+
+    let res = client.try_set_max_flash_bps(&10_001);
+    assert!(matches!(res, Err(Ok(LendingError::InvalidFlashUtilizationBps))));
+}
+
+#[test]
+fn test_get_max_flash_bps_returns_configured_value() {
+    let (_env, client, _receiver, _admin, _asset, _lending_id, _receiver_id) = setup();
+
+    client.set_max_flash_bps(&2_500);
+    assert_eq!(client.get_max_flash_bps(), 2_500);
+}

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -20,6 +20,8 @@ mod health_factor_edge_test;
 #[cfg(test)]
 mod interest_drift_regression_test;
 #[cfg(test)]
+mod flash_utilization_test;
+#[cfg(test)]
 mod rounding_drift_test;
 
 use debt::{
@@ -41,6 +43,7 @@ pub const LIQUIDATION_THRESHOLD_BPS: i128 = 8000;
 const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
 const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
+const DEFAULT_MAX_FLASH_BPS: i128 = 10_000;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -55,6 +58,7 @@ pub enum DataKey {
     DepositCap,
     FlashActive,
     FlashFeeBps,
+    MaxFlashUtilizationBps,
     BorrowMinAmount,
     Admin,
     PendingAdmin,
@@ -129,6 +133,7 @@ pub enum LendingError {
     DebtCeilingExceeded = 2001,
     DepositCapExceeded = 2002,
     InvalidFeeBps = 2005,
+    InvalidFlashUtilizationBps = 2006,
     InsufficientCollateral = 2007,
     InvalidOracleSignature = 5001,
     StaleOracleTimestamp = 5002,
@@ -252,6 +257,31 @@ impl LendingContract {
             .instance()
             .get(&DataKey::FlashFeeBps)
             .unwrap_or(5)
+    }
+
+    fn max_flash_bps_config(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxFlashUtilizationBps)
+            .unwrap_or(DEFAULT_MAX_FLASH_BPS)
+    }
+
+    /// Set the maximum flash-loan utilization ratio in basis points (admin-only).
+    /// The requested amount must not exceed `max_flash_bps × available_liquidity / 10000`.
+    pub fn set_max_flash_bps(env: Env, max_flash_bps: i128) -> Result<(), LendingError> {
+        assert_admin(&env);
+        if max_flash_bps < 0 || max_flash_bps > BPS_DENOM {
+            return Err(LendingError::InvalidFlashUtilizationBps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxFlashUtilizationBps, &max_flash_bps);
+        Ok(())
+    }
+
+    /// Return the configured maximum flash-loan utilization ratio in basis points.
+    pub fn get_max_flash_bps(env: Env) -> i128 {
+        Self::max_flash_bps_config(&env)
     }
 
     /// Propose a new admin (current admin only).
@@ -663,6 +693,15 @@ impl LendingContract {
         let tre_bal: i128 = env.storage().persistent().get(&tre_key).unwrap_or(0);
         if amount > tre_bal {
             panic!("InsufficientLiquidity");
+        }
+
+        let max_flash_bps = Self::max_flash_bps_config(&env);
+        let max_flash_amount = tre_bal
+            .checked_mul(max_flash_bps)
+            .and_then(|value| value.checked_div(BPS_DENOM))
+            .expect("flash_loan: max-utilization calculation overflow");
+        if amount > max_flash_amount {
+            panic!("FlashLoanUtilizationExceeded");
         }
 
         initiator.require_auth();


### PR DESCRIPTION
## Add flash loan max-utilization circuit breaker

## Summary
This PR adds a flash-loan max-utilization circuit breaker to the lending contract.

### What changed
- Added a configurable max flash-loan utilization setting via admin setter/getter
- Enforced the cap before the flash-loan callback is invoked
- Added regression tests covering:
  - allowing a loan at the utilization cap
  - rejecting a loan above the cap
  - rejecting invalid max-utilization configuration values
- Updated flash-loan documentation and error-code regression coverage

### Verification
I verified the change with:
- `cargo test -p stellarlend-lending --lib flash_utilization_test -- --nocapture`
- `cargo test -p stellarlend-lending --lib`

Closes: #1030 