### PR TITLE
test: add liquidation bonus proptests

### DIFF
--- a/stellar-lend/contracts/lending/LIQUIDATION_BONUS_INVARIANTS.md
+++ b/stellar-lend/contracts/lending/LIQUIDATION_BONUS_INVARIANTS.md
@@ -1,0 +1,18 @@
+# Liquidation bonus invariants
+
+## Summary
+
+This note documents the property-based invariants covered by the liquidation-bonus proptest suite.
+
+## Invariants and proofs
+
+- Non-negative bonus: `compute_liquidation_bonus` must never return a negative value for any valid input.
+  - Proven by `liquidation_bonus_is_non_negative_and_bounded_by_debt`.
+- Bonus bounded by debt coverage: the bonus must not exceed the debt amount being covered.
+  - Proven by `liquidation_bonus_is_non_negative_and_bounded_by_debt`.
+- Monotonicity in repay amount: increasing the debt-to-cover input must not decrease the computed bonus.
+  - Proven by `liquidation_bonus_is_monotonic_in_debt_to_cover`.
+- Interaction with max borrow: a liquidation bonus computed from a borrow cap must remain within that cap.
+  - Proven by `liquidation_bonus_stays_within_max_borrow_bound`.
+- Overflow safety: inputs that overflow the checked multiply must return `MathError::Overflow` instead of panicking.
+  - Proven by `liquidation_bonus_overflow_returns_math_error` and `max_borrow_overflow_returns_math_error`.

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -20,6 +20,8 @@ mod health_factor_edge_test;
 #[cfg(test)]
 mod interest_drift_regression_test;
 #[cfg(test)]
+mod liquidation_bonus_proptest;
+#[cfg(test)]
 mod rounding_drift_test;
 
 use debt::{

--- a/stellar-lend/contracts/lending/src/liquidation_bonus_proptest.rs
+++ b/stellar-lend/contracts/lending/src/liquidation_bonus_proptest.rs
@@ -1,0 +1,103 @@
+#![cfg(test)]
+
+use super::math::{compute_liquidation_bonus, compute_max_borrow, MathError, BPS_SCALE};
+use proptest::prelude::*;
+
+/// Restrict the property suite to inputs that can be exercised without
+/// hitting the checked-multiply overflow path in the bonus helper.
+fn safe_debt_strategy() -> impl Strategy<Value = i128> {
+    0i128..=i128::MAX / 10_000
+}
+
+/// Focus overflow cases on values that are guaranteed to overflow the
+/// multiplication in `compute_liquidation_bonus` when the bonus rate is non-zero.
+fn overflow_debt_strategy() -> impl Strategy<Value = i128> {
+    (i128::MAX / 10_000 + 1)..=i128::MAX
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn liquidation_bonus_is_non_negative_and_bounded_by_debt(
+        debt_to_cover in safe_debt_strategy(),
+        liquidation_bonus_bps in 0u32..=BPS_SCALE,
+    ) {
+        let bonus = compute_liquidation_bonus(debt_to_cover, liquidation_bonus_bps)
+            .expect("safe inputs should not overflow");
+        assert!(bonus >= 0, "bonus must stay non-negative");
+        assert!(bonus <= debt_to_cover, "bonus must not exceed debt coverage");
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn liquidation_bonus_is_monotonic_in_debt_to_cover(
+        debt_a in safe_debt_strategy(),
+        debt_b in safe_debt_strategy(),
+        liquidation_bonus_bps in 0u32..=BPS_SCALE,
+    ) {
+        let bonus_a = compute_liquidation_bonus(debt_a, liquidation_bonus_bps)
+            .expect("safe inputs should not overflow");
+        let bonus_b = compute_liquidation_bonus(debt_b, liquidation_bonus_bps)
+            .expect("safe inputs should not overflow");
+
+        if debt_a <= debt_b {
+            assert!(bonus_a <= bonus_b, "bonus should not decrease as debt rises");
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn liquidation_bonus_stays_within_max_borrow_bound(
+        collateral_value in safe_debt_strategy(),
+        ltv_bps in 0u32..=BPS_SCALE,
+        liquidation_bonus_bps in 0u32..=BPS_SCALE,
+    ) {
+        let max_borrow = compute_max_borrow(collateral_value, ltv_bps)
+            .expect("safe inputs should not overflow");
+        let bonus = compute_liquidation_bonus(max_borrow, liquidation_bonus_bps)
+            .expect("safe inputs should not overflow");
+
+        assert!(bonus <= max_borrow, "liquidation bonus must stay within the borrow cap");
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn liquidation_bonus_overflow_returns_math_error(
+        debt_to_cover in overflow_debt_strategy(),
+        liquidation_bonus_bps in 1u32..=BPS_SCALE,
+    ) {
+        let result = compute_liquidation_bonus(debt_to_cover, liquidation_bonus_bps);
+        assert!(
+            matches!(result, Err(MathError::Overflow)),
+            "overflowing multiply should return MathError::Overflow, got {:?}",
+            result
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn max_borrow_overflow_returns_math_error(
+        collateral_value in overflow_debt_strategy(),
+        ltv_bps in 1u32..=BPS_SCALE,
+    ) {
+        let result = compute_max_borrow(collateral_value, ltv_bps);
+        assert!(
+            matches!(result, Err(MathError::Overflow)),
+            "overflowing multiply should return MathError::Overflow, got {:?}",
+            result
+        );
+    }
+}


### PR DESCRIPTION
## Add property-based invariant tests for liquidation bonus math

## Summary
This PR adds property-based invariant tests for the liquidation-bonus math helpers in the lending contract.

## What changed
- Added proptest coverage for:
  - non-negativity and upper bounds of liquidation bonuses
  - monotonicity of the bonus with respect to debt coverage
  - keeping liquidation bonuses within the max-borrow bound
  - overflow handling for liquidation-bonus and max-borrow calculations
- Wired the new property-test module into the lending crate test suite.
- Added a short invariant document describing the covered properties.

## Verification
Ran:
- cargo test -p stellarlend-lending --lib liquidation_bonus_proptest -- --nocapture

Result:
- 5 tests passed
- 0 failed

Closes: #1038 