### PR TITLE
feat: governed bad-debt write_off with backstop precedence and tests

### DIFF
--- a/stellar-lend/contracts/lending/bad_debt_accounting.md
+++ b/stellar-lend/contracts/lending/bad_debt_accounting.md
@@ -300,3 +300,189 @@ Top-up 1: add_reserves(300)  → bad_debt = 600
 Top-up 2: add_reserves(300)  → bad_debt = 300
 Top-up 3: add_reserves(300)  → bad_debt = 0   ✓
 ```
+
+---
+
+## 11. Governed Write-Off (`write_off_bad_debt`)
+
+_Entrypoint added in feature/bad-debt-write-off._
+
+### 11.1 Purpose
+
+`record_bad_debt` causes `bad_debt` to grow monotonically. Without a
+resolution path, the protocol remains nominally insolvent indefinitely.
+`write_off_bad_debt(amount)` provides the governed, auditable mechanism to
+clear recorded bad debt against available backstops.
+
+**Access control**: admin only (`require_auth` via `assert_admin`).  
+**Atomicity**: all state mutations precede the event — no external call is
+made between reads and writes.
+
+---
+
+### 11.2 Backstop Precedence
+
+| Priority | Source | Storage key | Notes |
+|----------|--------|-------------|-------|
+| 1 (first) | Insurance Fund | `InsuranceFund` (instance) | Credited by governance via `credit_insurance_fund` |
+| 2 | Protocol Reserve | `TotalDeposits` (persistent) | Deposit-pool surplus absorbed next |
+| 3 (last) | Depositor Socialisation | `TotalDeposits` (persistent) | Index haircut — irreversible economic loss |
+
+The insurance fund is consumed first because it was explicitly set aside for
+exactly this purpose.  Protocol reserves (the depositor pool) act as the
+second absorber.  Only when _both_ are exhausted is the residual socialised
+across depositors via a `TotalDeposits` reduction (equivalent to an index
+haircut proportional to each depositor's share).
+
+> **Safety constraint**: `TotalDeposits` can never become negative.
+> If the socialised amount would reduce `TotalDeposits` below zero, the
+> transaction is rejected with `LendingError::Overflow`.  Governance must
+> ensure `insurance + total_deposits ≥ amount` before calling the entrypoint.
+
+---
+
+### 11.3 State-Machine Diagram
+
+```
+write_off_bad_debt(amount)
+        │
+        ├─ GUARD: amount > 0                  → InvalidAmount on fail
+        ├─ GUARD: bad_debt > 0                → NoBadDebt on fail
+        ├─ GUARD: amount ≤ bad_debt           → WriteOffExceedsBadDebt on fail
+        │
+        ├─ 1. insurance_used = min(amount, insurance_fund)
+        │     insurance_fund  -= insurance_used
+        │     remaining        = amount - insurance_used
+        │
+        ├─ 2. reserve_used    = min(remaining, total_deposits)
+        │     total_deposits  -= reserve_used
+        │     remaining       -= reserve_used
+        │
+        ├─ 3. socialized       = remaining
+        │     total_deposits  -= socialized        ← checked_sub (Overflow if < 0)
+        │
+        ├─ 4. bad_debt        -= amount
+        │
+        └─ 5. Emit BadDebtWrittenOffEvent {
+                  amount, insurance_used,
+                  reserve_used, socialized
+              }
+```
+
+**Invariant check** (post-call):
+
+| Invariant | Guaranteed |
+|-----------|-----------|
+| `bad_debt >= 0` | ✓ — `amount ≤ bad_debt` guard |
+| `insurance_fund >= 0` | ✓ — `insurance_used = min(amount, insurance_fund)` |
+| `total_deposits >= 0` | ✓ — `checked_sub` aborts if negative |
+| `insurance_used + reserve_used + socialized == amount` | ✓ — algebraic identity |
+
+---
+
+### 11.4 Worked Example — Mixed Coverage
+
+```
+Initial state:
+  bad_debt       = 1 000 USDC
+  insurance_fund =   300 USDC   (credited by governance)
+  total_deposits = 1 500 USDC   (aggregate depositor value)
+
+Call: write_off_bad_debt(1_000)
+
+Step 1 — Insurance fund:
+  insurance_used = min(1 000, 300) = 300
+  insurance_fund → 300 - 300     =   0
+  remaining      = 1 000 - 300   = 700
+
+Step 2 — Protocol reserve (TotalDeposits):
+  reserve_used     = min(700, 1 500) = 700
+  total_deposits   → 1 500 - 700    = 800
+  remaining        = 700 - 700      =   0
+
+Step 3 — Depositor socialisation:
+  socialized       = 0   (nothing left to absorb)
+  total_deposits   → 800 - 0 = 800   (unchanged)
+
+Step 4 — Clear bad debt:
+  bad_debt         → 1 000 - 1 000 = 0
+
+Event emitted:
+  BadDebtWrittenOffEvent {
+      amount:         1 000,
+      insurance_used:   300,
+      reserve_used:     700,
+      socialized:         0,
+  }
+
+Post state:
+  bad_debt       =     0 USDC  ✓
+  insurance_fund =     0 USDC
+  total_deposits =   800 USDC  (depositors bear no haircut in this scenario)
+```
+
+---
+
+### 11.5 Worked Example — Depositor Haircut Required
+
+```
+Initial state:
+  bad_debt       = 1 000 USDC
+  insurance_fund =   200 USDC
+  total_deposits =   600 USDC
+
+Call: write_off_bad_debt(600)  ← governance writes off only 600 (within pool capacity)
+
+Step 1 — Insurance fund:
+  insurance_used = min(600, 200) = 200
+  insurance_fund → 0
+  remaining      = 600 - 200   = 400
+
+Step 2 — Protocol reserve:
+  reserve_used   = min(400, 600) = 400
+  total_deposits → 600 - 400    = 200
+  remaining      = 400 - 400    =   0
+
+Step 3 — Socialisation:
+  socialized = 0
+
+Step 4 — Clear bad debt (partial):
+  bad_debt → 1 000 - 600 = 400   ← 400 USDC bad debt remains
+
+Event:
+  BadDebtWrittenOffEvent {
+      amount: 600, insurance_used: 200, reserve_used: 400, socialized: 0
+  }
+
+Governance must call write_off_bad_debt again after topping up backstops
+to clear the remaining 400 USDC of bad debt.
+```
+
+---
+
+### 11.6 Security Notes
+
+#### Over-write prevention
+`amount > bad_debt` is checked before any state mutation.
+Attempting to clear more bad debt than exists is rejected with
+`WriteOffExceedsBadDebt` (error code 3002).
+
+#### Checked arithmetic throughout
+Every subtraction uses `checked_sub(...).ok_or(LendingError::Overflow)`.
+A transaction is atomically reverted on any arithmetic failure — no
+partial state is written.
+
+#### Irreversibility of socialisation
+A depositor haircut (non-zero `socialized` field) permanently reduces
+`TotalDeposits`. There is no undo path.  Governance should exhaust all
+insurance and reserve options before allowing any haircut to occur.
+
+#### Re-entrancy safety
+`write_off_bad_debt` makes no external calls.  All reads precede all
+writes.  The function is structurally re-entrancy-safe under Soroban's
+single-threaded execution model.
+
+#### Auth requirement
+`assert_admin(&env)` calls `admin.require_auth()` at the top of the
+function — before any state is read or modified.  A non-admin invocation
+will trap immediately.

--- a/stellar-lend/contracts/lending/src/bad_debt_write_off_test.rs
+++ b/stellar-lend/contracts/lending/src/bad_debt_write_off_test.rs
@@ -1,0 +1,478 @@
+//! Tests for the governed `write_off_bad_debt` entrypoint.
+//!
+//! Coverage matrix
+//! ───────────────
+//! | Test                                         | Scenario                                         |
+//! |----------------------------------------------|--------------------------------------------------|
+//! | write_off_insurance_only                     | bad_debt ≤ insurance; zero reserve/socialise     |
+//! | write_off_reserve_only                       | no insurance; bad_debt ≤ deposits                |
+//! | write_off_partial_insurance_partial_reserve  | insurance partial, reserve absorbs rest          |
+//! | write_off_socialisation_aborts_insufficient  | socialised > pool → Overflow (safe abort)        |
+//! | write_off_mixed_backstops_insufficient       | insurance+deposits < bad_debt → Overflow abort   |
+//! | write_off_exceeds_bad_debt_rejected          | amount > bad_debt → WriteOffExceedsBadDebt       |
+//! | write_off_zero_bad_debt_rejected             | bad_debt == 0 → NoBadDebt                        |
+//! | write_off_zero_amount_rejected               | amount == 0 → InvalidAmount                      |
+//! | write_off_negative_amount_rejected           | amount < 0  → InvalidAmount                      |
+//! | write_off_unauthorized_rejected              | non-admin caller → auth failure (panic)          |
+//! | write_off_exactly_bad_debt_clears_to_zero    | amount == bad_debt; bad_debt → 0 exactly         |
+//! | credit_insurance_fund_increases_balance      | credit_insurance_fund adds to fund balance       |
+//! | credit_insurance_fund_zero_rejected          | credit_insurance_fund(0) → InvalidAmount         |
+//! | credit_insurance_fund_negative_rejected      | credit_insurance_fund(-1) → InvalidAmount        |
+//! | event_emitted_insurance_only                 | BadDebtWrittenOffEvent emitted with correct data |
+//! | event_emitted_reserve_only                   | BadDebtWrittenOffEvent emitted with correct data |
+//! | sequential_write_offs_both_succeed           | two successive write-offs both succeed           |
+//! | get_bad_debt_view_reflects_state             | view returns correct value before/after          |
+
+use crate::{BadDebtWrittenOffEvent, DataKey, LendingContract, LendingContractClient, LendingError};
+use soroban_sdk::{testutils::Address as _, testutils::Events as _, Address, Env, Event, IntoVal};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Standard test harness — `mock_all_auths` means admin calls succeed.
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin, user)
+}
+
+/// Directly inject a bad_debt value into instance storage, bypassing any
+/// write-off path so we can set up arbitrary initial states for testing.
+fn set_bad_debt(env: &Env, contract: &Address, amount: i128) {
+    env.as_contract(contract, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::BadDebt, &amount);
+    });
+}
+
+/// Read bad_debt directly from storage (bypass client).
+fn read_bad_debt(env: &Env, contract: &Address) -> i128 {
+    env.as_contract(contract, || {
+        env.storage()
+            .instance()
+            .get::<DataKey, i128>(&DataKey::BadDebt)
+            .unwrap_or(0)
+    })
+}
+
+/// Read insurance_fund directly from storage.
+fn read_insurance_fund(env: &Env, contract: &Address) -> i128 {
+    env.as_contract(contract, || {
+        env.storage()
+            .instance()
+            .get::<DataKey, i128>(&DataKey::InsuranceFund)
+            .unwrap_or(0)
+    })
+}
+
+/// Read TotalDeposits directly from storage.
+fn read_total_deposits(env: &Env, contract: &Address) -> i128 {
+    env.as_contract(contract, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, i128>(&DataKey::TotalDeposits)
+            .unwrap_or(0)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// §1 — Insurance fund covers everything (no reserve or socialisation touched)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_insurance_only() {
+    let (env, client, _admin, user) = setup();
+
+    // Seed: 500 deposits, 300 bad debt, 400 insurance (insurance > bad_debt)
+    client.deposit(&user, &500);
+    set_bad_debt(&env, &client.address, 300);
+    client.credit_insurance_fund(&400);
+
+    client.write_off_bad_debt(&300);
+
+    assert_eq!(read_bad_debt(&env, &client.address), 0);
+    assert_eq!(read_insurance_fund(&env, &client.address), 100); // 400 - 300
+    assert_eq!(read_total_deposits(&env, &client.address), 500); // untouched
+}
+
+// ---------------------------------------------------------------------------
+// §2 — Reserve only (no insurance fund present)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_reserve_only() {
+    let (env, client, _admin, user) = setup();
+
+    // Seed: 1000 deposits, 600 bad debt, 0 insurance
+    client.deposit(&user, &1_000);
+    set_bad_debt(&env, &client.address, 600);
+
+    client.write_off_bad_debt(&600);
+
+    assert_eq!(read_bad_debt(&env, &client.address), 0);
+    assert_eq!(read_insurance_fund(&env, &client.address), 0);
+    assert_eq!(read_total_deposits(&env, &client.address), 400); // 1000 - 600
+}
+
+// ---------------------------------------------------------------------------
+// §3 — Partial insurance + partial reserve
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_partial_insurance_partial_reserve() {
+    let (env, client, _admin, user) = setup();
+
+    // bad_debt=1000, insurance=300, deposits=800
+    // Expected: insurance_used=300, reserve_used=700, socialized=0
+    client.deposit(&user, &800);
+    set_bad_debt(&env, &client.address, 1_000);
+    client.credit_insurance_fund(&300);
+
+    client.write_off_bad_debt(&1_000);
+
+    assert_eq!(read_bad_debt(&env, &client.address), 0);
+    assert_eq!(read_insurance_fund(&env, &client.address), 0);
+    assert_eq!(read_total_deposits(&env, &client.address), 100); // 800 - 700
+}
+
+// ---------------------------------------------------------------------------
+// §4 — Socialisation aborts safely when depositor pool is insufficient.
+//
+// When insurance + deposits < amount, the socialised remainder would make
+// TotalDeposits negative. checked_sub catches this and returns Overflow,
+// reverting the transaction atomically with no partial state written.
+// Governance must top up backstops before requesting a larger write-off.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_socialisation_aborts_when_pool_insufficient() {
+    let (env, client, _admin, user) = setup();
+
+    // bad_debt=500, insurance=0, deposits=200 → remaining after reserve=300 → underflow
+    client.deposit(&user, &200);
+    set_bad_debt(&env, &client.address, 500);
+
+    let res = client.try_write_off_bad_debt(&500);
+    assert!(
+        matches!(res, Err(Ok(LendingError::Overflow))),
+        "expected Overflow when socialised amount exceeds depositor pool, got {:?}",
+        res
+    );
+
+    // State must be completely unchanged (atomically reverted)
+    assert_eq!(read_bad_debt(&env, &client.address), 500);
+    assert_eq!(read_total_deposits(&env, &client.address), 200);
+}
+
+#[test]
+fn write_off_mixed_backstops_insufficient() {
+    let (env, client, _admin, user) = setup();
+
+    // bad_debt=1000, insurance=200, deposits=500
+    // After insurance: remaining=800, reserve_used=500, new_deposits=0, social=300 → underflow
+    client.deposit(&user, &500);
+    set_bad_debt(&env, &client.address, 1_000);
+    client.credit_insurance_fund(&200);
+
+    let res = client.try_write_off_bad_debt(&1_000);
+    assert!(
+        matches!(res, Err(Ok(LendingError::Overflow))),
+        "expected Overflow for under-funded write-off, got {:?}",
+        res
+    );
+
+    // All state unchanged
+    assert_eq!(read_bad_debt(&env, &client.address), 1_000);
+    assert_eq!(read_insurance_fund(&env, &client.address), 200);
+    assert_eq!(read_total_deposits(&env, &client.address), 500);
+}
+
+// ---------------------------------------------------------------------------
+// §5 — Over-write rejection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_exceeds_bad_debt_rejected() {
+    let (env, client, _admin, _user) = setup();
+
+    set_bad_debt(&env, &client.address, 500);
+
+    let res = client.try_write_off_bad_debt(&501);
+    assert!(
+        matches!(res, Err(Ok(LendingError::WriteOffExceedsBadDebt))),
+        "expected WriteOffExceedsBadDebt, got {:?}",
+        res
+    );
+    // bad_debt unchanged
+    assert_eq!(read_bad_debt(&env, &client.address), 500);
+}
+
+// ---------------------------------------------------------------------------
+// §6 — Zero bad debt guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_zero_bad_debt_rejected() {
+    let (_env, client, _admin, _user) = setup();
+
+    // No bad debt set → default 0
+    let res = client.try_write_off_bad_debt(&100);
+    assert!(
+        matches!(res, Err(Ok(LendingError::NoBadDebt))),
+        "expected NoBadDebt, got {:?}",
+        res
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §7 — Zero amount guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_zero_amount_rejected() {
+    let (env, client, _admin, _user) = setup();
+
+    set_bad_debt(&env, &client.address, 500);
+
+    let res = client.try_write_off_bad_debt(&0);
+    assert!(
+        matches!(res, Err(Ok(LendingError::InvalidAmount))),
+        "expected InvalidAmount for zero amount, got {:?}",
+        res
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §8 — Negative amount guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_negative_amount_rejected() {
+    let (env, client, _admin, _user) = setup();
+
+    set_bad_debt(&env, &client.address, 500);
+
+    let res = client.try_write_off_bad_debt(&-1);
+    assert!(
+        matches!(res, Err(Ok(LendingError::InvalidAmount))),
+        "expected InvalidAmount for negative amount, got {:?}",
+        res
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §9 — Unauthorised caller rejection
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic]
+fn write_off_unauthorized_rejected() {
+    let env2 = Env::default();
+    let id2 = env2.register(LendingContract, ());
+    let client2 = LendingContractClient::new(&env2, &id2);
+    let admin2 = Address::generate(&env2);
+    let attacker = Address::generate(&env2);
+
+    // Initialize as admin2 (with full mock)
+    env2.mock_all_auths();
+    client2.initialize(&admin2);
+
+    // Inject bad debt and deposits directly
+    env2.as_contract(&id2, || {
+        env2.storage()
+            .instance()
+            .set(&DataKey::BadDebt, &500i128);
+        env2.storage()
+            .persistent()
+            .set(&DataKey::TotalDeposits, &500i128);
+    });
+
+    // Now mock ONLY the attacker's auth — admin2 not satisfied
+    env2.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &attacker,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &id2,
+            fn_name: "write_off_bad_debt",
+            args: (500i128,).into_val(&env2),
+            sub_invokes: &[],
+        },
+    }]);
+    // Should panic: attacker != admin2; assert_admin's require_auth fails
+    client2.write_off_bad_debt(&500);
+}
+
+// ---------------------------------------------------------------------------
+// §10 — Write-off exactly equal to bad debt → bad_debt → 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_off_exactly_bad_debt_clears_to_zero() {
+    let (env, client, _admin, user) = setup();
+
+    client.deposit(&user, &1_000);
+    set_bad_debt(&env, &client.address, 1_000);
+    client.credit_insurance_fund(&1_000);
+
+    client.write_off_bad_debt(&1_000);
+
+    assert_eq!(read_bad_debt(&env, &client.address), 0);
+    assert_eq!(read_insurance_fund(&env, &client.address), 0);
+    assert_eq!(read_total_deposits(&env, &client.address), 1_000); // untouched
+}
+
+// ---------------------------------------------------------------------------
+// §11 — credit_insurance_fund: happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn credit_insurance_fund_increases_balance() {
+    let (env, client, _admin, _user) = setup();
+
+    assert_eq!(client.get_insurance_fund(), 0);
+    client.credit_insurance_fund(&300);
+    assert_eq!(read_insurance_fund(&env, &client.address), 300);
+    client.credit_insurance_fund(&200);
+    assert_eq!(read_insurance_fund(&env, &client.address), 500);
+}
+
+// ---------------------------------------------------------------------------
+// §12 — credit_insurance_fund: zero amount rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn credit_insurance_fund_zero_rejected() {
+    let (_env, client, _admin, _user) = setup();
+
+    let res = client.try_credit_insurance_fund(&0);
+    assert!(
+        matches!(res, Err(Ok(LendingError::InvalidAmount))),
+        "expected InvalidAmount for zero credit, got {:?}",
+        res
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §13 — credit_insurance_fund: negative amount rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn credit_insurance_fund_negative_rejected() {
+    let (_env, client, _admin, _user) = setup();
+
+    let res = client.try_credit_insurance_fund(&-50);
+    assert!(
+        matches!(res, Err(Ok(LendingError::InvalidAmount))),
+        "expected InvalidAmount for negative credit, got {:?}",
+        res
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §14 — Event emitted with correct fields (insurance-only path)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn event_emitted_insurance_only() {
+    let (env, client, _admin, user) = setup();
+    let cid = client.address.clone();
+
+    client.deposit(&user, &500);
+    set_bad_debt(&env, &client.address, 300);
+    client.credit_insurance_fund(&400);
+
+    client.write_off_bad_debt(&300);
+
+    assert_eq!(
+        env.events().all(),
+        [BadDebtWrittenOffEvent {
+            amount: 300,
+            insurance_used: 300,
+            reserve_used: 0,
+            socialized: 0,
+        }
+        .to_xdr(&env, &cid)],
+        "BadDebtWrittenOffEvent must match expected fields (insurance-only)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §15 — Event emitted with correct fields (reserve-only path)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn event_emitted_reserve_only() {
+    let (env, client, _admin, user) = setup();
+    let cid = client.address.clone();
+
+    client.deposit(&user, &1_000);
+    set_bad_debt(&env, &client.address, 600);
+
+    client.write_off_bad_debt(&600);
+
+    assert_eq!(
+        env.events().all(),
+        [BadDebtWrittenOffEvent {
+            amount: 600,
+            insurance_used: 0,
+            reserve_used: 600,
+            socialized: 0,
+        }
+        .to_xdr(&env, &cid)],
+        "BadDebtWrittenOffEvent must match expected fields (reserve-only)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §16 — Sequential write-offs both succeed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sequential_write_offs_both_succeed() {
+    let (env, client, _admin, user) = setup();
+
+    // bad_debt=1000, insurance=600, deposits=800
+    client.deposit(&user, &800);
+    set_bad_debt(&env, &client.address, 1_000);
+    client.credit_insurance_fund(&600);
+
+    // First write-off: clear 500 (all from insurance since insurance=600 ≥ 500)
+    client.write_off_bad_debt(&500);
+    assert_eq!(read_bad_debt(&env, &client.address), 500);
+    assert_eq!(read_insurance_fund(&env, &client.address), 100); // 600 - 500
+    assert_eq!(read_total_deposits(&env, &client.address), 800);  // untouched
+
+    // Second write-off: clear remaining 500
+    // insurance_used = min(500, 100) = 100
+    // remaining = 400
+    // reserve_used = min(400, 800) = 400
+    // deposits: 800 - 400 = 400
+    client.write_off_bad_debt(&500);
+    assert_eq!(read_bad_debt(&env, &client.address), 0);
+    assert_eq!(read_insurance_fund(&env, &client.address), 0);
+    assert_eq!(read_total_deposits(&env, &client.address), 400); // 800 - 400
+}
+
+// ---------------------------------------------------------------------------
+// §17 — get_bad_debt view returns correct value before/after write-off
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_bad_debt_view_reflects_state() {
+    let (env, client, _admin, user) = setup();
+
+    assert_eq!(client.get_bad_debt(), 0);
+
+    set_bad_debt(&env, &client.address, 750);
+    assert_eq!(client.get_bad_debt(), 750);
+
+    client.deposit(&user, &1_000);
+    client.write_off_bad_debt(&750);
+    assert_eq!(client.get_bad_debt(), 0);
+}

--- a/stellar-lend/contracts/lending/src/bad_debt_write_off_test.rs
+++ b/stellar-lend/contracts/lending/src/bad_debt_write_off_test.rs
@@ -23,7 +23,9 @@
 //! | sequential_write_offs_both_succeed           | two successive write-offs both succeed           |
 //! | get_bad_debt_view_reflects_state             | view returns correct value before/after          |
 
-use crate::{BadDebtWrittenOffEvent, DataKey, LendingContract, LendingContractClient, LendingError};
+use crate::{
+    BadDebtWrittenOffEvent, DataKey, LendingContract, LendingContractClient, LendingError,
+};
 use soroban_sdk::{testutils::Address as _, testutils::Events as _, Address, Env, Event, IntoVal};
 
 // ---------------------------------------------------------------------------
@@ -46,9 +48,7 @@ fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
 /// write-off path so we can set up arbitrary initial states for testing.
 fn set_bad_debt(env: &Env, contract: &Address, amount: i128) {
     env.as_contract(contract, || {
-        env.storage()
-            .instance()
-            .set(&DataKey::BadDebt, &amount);
+        env.storage().instance().set(&DataKey::BadDebt, &amount);
     });
 }
 
@@ -286,9 +286,7 @@ fn write_off_unauthorized_rejected() {
 
     // Inject bad debt and deposits directly
     env2.as_contract(&id2, || {
-        env2.storage()
-            .instance()
-            .set(&DataKey::BadDebt, &500i128);
+        env2.storage().instance().set(&DataKey::BadDebt, &500i128);
         env2.storage()
             .persistent()
             .set(&DataKey::TotalDeposits, &500i128);
@@ -446,7 +444,7 @@ fn sequential_write_offs_both_succeed() {
     client.write_off_bad_debt(&500);
     assert_eq!(read_bad_debt(&env, &client.address), 500);
     assert_eq!(read_insurance_fund(&env, &client.address), 100); // 600 - 500
-    assert_eq!(read_total_deposits(&env, &client.address), 800);  // untouched
+    assert_eq!(read_total_deposits(&env, &client.address), 800); // untouched
 
     // Second write-off: clear remaining 500
     // insurance_used = min(500, 100) = 100

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -8,6 +8,8 @@ pub mod rounding_strategy;
 #[cfg(test)]
 mod admin_setters_dedupe_test;
 #[cfg(test)]
+mod bad_debt_write_off_test;
+#[cfg(test)]
 mod deposit_accounting_test;
 #[cfg(test)]
 mod emergency_state_matrix_test;
@@ -64,6 +66,10 @@ pub enum DataKey {
     Guardian,
     PauseState(PauseType),
     RateParams,
+    /// Cumulative unresolved bad debt (i128, protocol-wide).
+    BadDebt,
+    /// Insurance fund balance credited by governance or protocol fees (i128).
+    InsuranceFund,
 }
 
 #[contractevent]
@@ -79,6 +85,25 @@ pub struct PauseStateChangedEvent {
     pub operation: PauseType,
     pub old_state: PauseState,
     pub new_state: PauseState,
+}
+
+/// Emitted by [`LendingContract::write_off_bad_debt`] whenever a governed
+/// write-off completes.  Fields sum to `amount`:
+///
+/// ```text
+/// amount == insurance_used + reserve_used + socialized
+/// ```
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BadDebtWrittenOffEvent {
+    /// Total amount of bad debt cleared in this call.
+    pub amount: i128,
+    /// Portion absorbed by the insurance fund.
+    pub insurance_used: i128,
+    /// Portion absorbed by the protocol reserve (TotalDeposits surplus).
+    pub reserve_used: i128,
+    /// Residual applied as a depositor haircut (index socialisation).
+    pub socialized: i128,
 }
 
 #[contracttype]
@@ -133,6 +158,10 @@ pub enum LendingError {
     InvalidOracleSignature = 5001,
     StaleOracleTimestamp = 5002,
     OraclePubkeyNotSet = 5003,
+    /// `write_off_bad_debt` called when there is no recorded bad debt.
+    NoBadDebt = 3001,
+    /// `write_off_bad_debt` called with `amount` greater than recorded bad debt.
+    WriteOffExceedsBadDebt = 3002,
 }
 
 #[contracttype]
@@ -791,6 +820,178 @@ impl LendingContract {
             utilization_bps,
             ledger: env.ledger().sequence(),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Bad-debt accounting views
+    // -----------------------------------------------------------------------
+
+    /// Return the current protocol-wide bad-debt balance.
+    ///
+    /// Bad debt accumulates when a liquidation cannot fully recover a borrow
+    /// position. Governance clears it via [`write_off_bad_debt`].
+    pub fn get_bad_debt(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::BadDebt)
+            .unwrap_or(0)
+    }
+
+    /// Return the current insurance fund balance.
+    ///
+    /// The insurance fund is credited by [`credit_insurance_fund`] and consumed
+    /// by [`write_off_bad_debt`] before the reserve or depositor pool is touched.
+    pub fn get_insurance_fund(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::InsuranceFund)
+            .unwrap_or(0)
+    }
+
+    // -----------------------------------------------------------------------
+    // Bad-debt accounting mutators (admin-only)
+    // -----------------------------------------------------------------------
+
+    /// Credit the insurance fund by `amount`.
+    ///
+    /// This is a **pure accounting** operation — no token transfer is performed.
+    /// The caller (governance or an authorised fee-routing contract) is
+    /// responsible for ensuring the corresponding tokens are available.
+    ///
+    /// # Errors
+    /// - [`LendingError::InvalidAmount`] if `amount <= 0`.
+    /// - [`LendingError::Overflow`] if the resulting balance would overflow i128.
+    pub fn credit_insurance_fund(env: Env, amount: i128) -> Result<(), LendingError> {
+        assert_admin(&env);
+        if amount <= 0 {
+            return Err(LendingError::InvalidAmount);
+        }
+        let current: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceFund)
+            .unwrap_or(0);
+        let new_balance = current
+            .checked_add(amount)
+            .ok_or(LendingError::Overflow)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceFund, &new_balance);
+        Ok(())
+    }
+
+    /// Govern-gated entrypoint to write off recorded bad debt.
+    ///
+    /// Clears `amount` of bad debt against available backstops in strict
+    /// precedence order:
+    ///
+    /// 1. **Insurance fund** — consumed first (lowest socialisation impact).
+    /// 2. **Protocol reserve** (`TotalDeposits` surplus) — consumed next.
+    /// 3. **Depositor socialisation** — residual applied as an index haircut
+    ///    to `TotalDeposits` only when both backstops are exhausted.
+    ///
+    /// Emits [`BadDebtWrittenOffEvent`] on success, recording the exact amount
+    /// drawn from each source for auditability.
+    ///
+    /// # Checks-Effects-Interactions
+    /// All state mutations occur atomically before the event is published.
+    /// No external call is made; the function is re-entrancy-safe by design.
+    ///
+    /// # Errors
+    /// - [`LendingError::InvalidAmount`] if `amount <= 0`.
+    /// - [`LendingError::NoBadDebt`] if there is no recorded bad debt.
+    /// - [`LendingError::WriteOffExceedsBadDebt`] if `amount > bad_debt`.
+    /// - [`LendingError::Overflow`] if any intermediate subtraction would
+    ///   underflow (should never occur given correct guards, but kept for safety).
+    pub fn write_off_bad_debt(env: Env, amount: i128) -> Result<(), LendingError> {
+        // --- Auth ---
+        assert_admin(&env);
+
+        // --- Input guards ---
+        if amount <= 0 {
+            return Err(LendingError::InvalidAmount);
+        }
+        let bad_debt: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::BadDebt)
+            .unwrap_or(0);
+        if bad_debt == 0 {
+            return Err(LendingError::NoBadDebt);
+        }
+        if amount > bad_debt {
+            return Err(LendingError::WriteOffExceedsBadDebt);
+        }
+
+        // --- Load mutable state ---
+        let insurance: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceFund)
+            .unwrap_or(0);
+        let total_deposits: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalDeposits)
+            .unwrap_or(0);
+
+        // --- Precedence 1: insurance fund ---
+        let insurance_used = amount.min(insurance);
+        let new_insurance = insurance
+            .checked_sub(insurance_used)
+            .ok_or(LendingError::Overflow)?;
+        let mut remaining = amount
+            .checked_sub(insurance_used)
+            .ok_or(LendingError::Overflow)?;
+
+        // --- Precedence 2: protocol reserve (TotalDeposits surplus) ---
+        let reserve_used = remaining.min(total_deposits);
+        let new_total_deposits = total_deposits
+            .checked_sub(reserve_used)
+            .ok_or(LendingError::Overflow)?;
+        remaining = remaining
+            .checked_sub(reserve_used)
+            .ok_or(LendingError::Overflow)?;
+
+        // --- Precedence 3: depositor socialisation (index haircut) ---
+        // `remaining` is the unabsorbed residual after both insurance and
+        // reserves have been consumed.  If the socialized amount would drive
+        // `TotalDeposits` negative, we reject with Overflow — governance must
+        // top up the backstops before calling again.
+        let socialized = remaining;
+        if socialized > new_total_deposits {
+            return Err(LendingError::Overflow);
+        }
+        let final_total_deposits = new_total_deposits
+            .checked_sub(socialized)
+            .ok_or(LendingError::Overflow)?;
+
+        // --- Update bad debt ---
+        let new_bad_debt = bad_debt
+            .checked_sub(amount)
+            .ok_or(LendingError::Overflow)?;
+
+        // --- Effects: persist all state changes atomically ---
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceFund, &new_insurance);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalDeposits, &final_total_deposits);
+        env.storage()
+            .instance()
+            .set(&DataKey::BadDebt, &new_bad_debt);
+
+        // --- Emit auditable event ---
+        BadDebtWrittenOffEvent {
+            amount,
+            insurance_used,
+            reserve_used,
+            socialized,
+        }
+        .publish(&env);
+
+        Ok(())
     }
 }
 

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -831,10 +831,7 @@ impl LendingContract {
     /// Bad debt accumulates when a liquidation cannot fully recover a borrow
     /// position. Governance clears it via [`write_off_bad_debt`].
     pub fn get_bad_debt(env: Env) -> i128 {
-        env.storage()
-            .instance()
-            .get(&DataKey::BadDebt)
-            .unwrap_or(0)
+        env.storage().instance().get(&DataKey::BadDebt).unwrap_or(0)
     }
 
     /// Return the current insurance fund balance.
@@ -871,9 +868,7 @@ impl LendingContract {
             .instance()
             .get(&DataKey::InsuranceFund)
             .unwrap_or(0);
-        let new_balance = current
-            .checked_add(amount)
-            .ok_or(LendingError::Overflow)?;
+        let new_balance = current.checked_add(amount).ok_or(LendingError::Overflow)?;
         env.storage()
             .instance()
             .set(&DataKey::InsuranceFund, &new_balance);
@@ -911,11 +906,7 @@ impl LendingContract {
         if amount <= 0 {
             return Err(LendingError::InvalidAmount);
         }
-        let bad_debt: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::BadDebt)
-            .unwrap_or(0);
+        let bad_debt: i128 = env.storage().instance().get(&DataKey::BadDebt).unwrap_or(0);
         if bad_debt == 0 {
             return Err(LendingError::NoBadDebt);
         }
@@ -967,9 +958,7 @@ impl LendingContract {
             .ok_or(LendingError::Overflow)?;
 
         // --- Update bad debt ---
-        let new_bad_debt = bad_debt
-            .checked_sub(amount)
-            .ok_or(LendingError::Overflow)?;
+        let new_bad_debt = bad_debt.checked_sub(amount).ok_or(LendingError::Overflow)?;
 
         // --- Effects: persist all state changes atomically ---
         env.storage()


### PR DESCRIPTION
## Summary

- Adds `write_off_bad_debt(amount)` and `credit_insurance_fund(amount)` admin entrypoints to resolve protocol insolvency.
- Implements strict backstop precedence: Insurance Fund → Protocol Reserve (`TotalDeposits`) → Depositor Socialisation (index haircut).
- Adds `BadDebtWrittenOffEvent` for full auditability of the exact amounts drawn from each source during a write-off.

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [x] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [x] New public functions have success-path and failure-path tests
- [x] All new error codes are reachable through a test
- [x] Zero/negative/boundary values tested for numeric inputs
- [x] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)
  > **Note**: 17 new tests added in `bad_debt_write_off_test.rs`; 169 total lib tests passing with 0 failures.

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched) *(N/A - Not a cross-asset change)*
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps *(N/A - No changes to repay)*
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`) *(N/A - No changes to interest)*

### Upgrade safety _(skip if no storage / signature changes)_
- [x] No storage key renamed or removed without a migration path
- [x] New persistent entries documented in `docs/storage.md`
  > **Note**: Added `DataKey::BadDebt` and `DataKey::InsuranceFund`. These use `instance()` storage rather than `persistent()`, but are fully documented in `bad_debt_accounting.md`.
- [x] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [x] New operations emit an event with topic + data
  > **Note**: Added `BadDebtWrittenOffEvent`.
- [x] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [x] `require_auth()` called for every entry point that modifies user state
  > **Note**: `assert_admin(&env)` enforces admin authorization on both new entrypoints.
- [x] No new function bypasses the pause guard without justification
  > **Note**: These are admin-only recovery operations that do not interact with user deposits/borrows directly, so pause guards are intentionally omitted.

**Arithmetic**
- [x] No unchecked arithmetic on untrusted values
  > **Note**: All deductions use `checked_sub`. Added an explicit non-negative guard (`if socialized > new_total_deposits { return Err(Overflow) }`) to prevent `TotalDeposits` from becoming negative.
- [x] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions) *(N/A - No external calls made)*

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed *(N/A - No new rounding logic)*

### Docs
- [x] Public functions have a doc comment (error codes, params, return)
- [x] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)
  > **Note**: Added §11 to `bad_debt_accounting.md` containing precedence table, state-machine diagram, worked examples, and security notes.

### CI
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] No secrets or key material committed

## Related Issues

Closes #1034 