### PR TITLE
feat: add protocol insurance fund with bad-debt draw-down, view and tests

### DIFF
--- a/stellar-lend/contracts/lending/INSURANCE_FUND.md
+++ b/stellar-lend/contracts/lending/INSURANCE_FUND.md
@@ -1,0 +1,62 @@
+# Protocol Insurance Fund
+
+The StellarLend Protocol Insurance Fund serves as a first-loss capital buffer to absorb bad debt before any losses are socialized or passed to depositors.
+
+---
+
+## 1. Funding Formula
+
+The insurance fund is dynamically funded by a configured percentage share of all accrued borrow interest, as well as optional explicit admin deposits.
+
+### Dynamic Funding (Interest Share)
+During any interest-accruing user operation (such as borrowing, repaying, or liquidating), the interest accrued is calculated. A percentage of this interest is directed to the insurance fund:
+
+$$\text{Insurance Share} = \frac{\text{Accrued Interest} \times \text{Insurance Share BPS}}{10,000}$$
+
+#### Configuration Bounds
+* **Minimum Share:** $0\text{ BPS}$ ($0\%$)
+* **Maximum Share:** $10,000\text{ BPS}$ ($100\%$)
+* Configured via `set_insurance_share(env, share_bps)`.
+
+---
+
+## 2. Draw-Down Order
+
+When a borrower position is liquidated and their debt exceeds their available collateral, a shortfall arises. The shortfall is processed in the following order:
+
+1. **First-Loss Buffer (Insurance Fund):** The protocol attempts to cover the shortfall using the accumulated balance of the `InsuranceFund`.
+   $$\text{Insurance Drawn} = \min(\text{Shortfall}, \text{Insurance Fund Balance})$$
+2. **Residual Socialization (Bad Debt Ledger):** Any remaining shortfall that cannot be covered by the insurance fund is added to the bad debt ledger to be eventually written off or socialized across depositors.
+   $$\text{Residual Shortfall} = \text{Shortfall} - \text{Insurance Drawn}$$
+
+### Safety Guarantees
+* **No Negative Balance:** Since the drawn amount is capped at $\min(\dots, \text{Insurance Fund Balance})$, the insurance fund balance can never be reduced below zero.
+* **No Over-payment:** The drawn amount is capped at the shortfall, meaning the fund will never pay more than the exact debt shortfall.
+
+---
+
+## 3. Worked Example
+
+### Scenario A: Full Coverage
+* **Insurance Fund Balance:** $100\text{ tokens}$
+* **Liquidation Shortfall:** $40\text{ tokens}$
+
+1. **Draw Calculation:**
+   $$\text{Drawn} = \min(40, 100) = 40\text{ tokens}$$
+2. **Update Balances:**
+   * **Insurance Fund:** $100 - 40 = 60\text{ tokens}$
+   * **Bad Debt Ledger Increase:** $40 - 40 = 0\text{ tokens}$
+
+*Result: The shortfall is fully absorbed by the insurance fund. Depositors bear zero loss.*
+
+### Scenario B: Partial Coverage (Residual Socialization)
+* **Insurance Fund Balance:** $30\text{ tokens}$
+* **Liquidation Shortfall:** $75\text{ tokens}$
+
+1. **Draw Calculation:**
+   $$\text{Drawn} = \min(75, 30) = 30\text{ tokens}$$
+2. **Update Balances:**
+   * **Insurance Fund:** $30 - 30 = 0\text{ tokens}$
+   * **Bad Debt Ledger Increase:** $75 - 30 = 45\text{ tokens}$
+
+*Result: The insurance fund is depleted to 0, and the remaining 45 tokens are recorded on-ledger as bad debt.*

--- a/stellar-lend/contracts/lending/src/cross_asset.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset.rs
@@ -356,7 +356,8 @@ pub fn borrow_asset_internal(
     let rate = crate::current_borrow_rate(env);
     let position = load_debt_asset(env, user, asset);
     let prev_principal = position.principal;
-    let updated = crate::debt::borrow_amount(position, now, amount, rate)
+    let settled_position = crate::settle_and_accrue_insurance(env, &position, now, rate)?;
+    let updated = crate::debt::borrow_amount(settled_position, now, amount, rate)
         .map_err(|_| LendingError::Overflow)?;
     save_debt_asset(env, user, asset, &updated);
     add_to_user_debt_list(env, user, asset);
@@ -448,7 +449,8 @@ pub fn repay_asset_internal(
     let rate = crate::current_borrow_rate(env);
     let position = load_debt_asset(env, user, asset);
     let prev_principal = position.principal;
-    let updated = crate::debt::repay_amount(position, now, amount, rate)
+    let settled_position = crate::settle_and_accrue_insurance(env, &position, now, rate)?;
+    let updated = crate::debt::repay_amount(settled_position, now, amount, rate)
         .map_err(|_| LendingError::Overflow)?;
     save_debt_asset(env, user, asset, &updated);
     if updated.principal == 0 {

--- a/stellar-lend/contracts/lending/src/insurance_fund_test.rs
+++ b/stellar-lend/contracts/lending/src/insurance_fund_test.rs
@@ -1,0 +1,209 @@
+#![cfg(test)]
+
+use crate::{LendingContract, LendingContractClient, DataKey};
+use crate::debt::DebtPosition;
+use crate::rounding_strategy::SECONDS_PER_YEAR;
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, id, admin, user, liquidator)
+}
+
+/// Advance ledger time by specified seconds
+fn advance_ledger_time(env: &Env, seconds: u64) {
+    let mut ledger_info = env.ledger().get();
+    ledger_info.timestamp = ledger_info.timestamp.saturating_add(seconds);
+    ledger_info.sequence_number = ledger_info.sequence_number.saturating_add(1);
+    env.ledger().set(ledger_info);
+}
+
+#[test]
+fn test_configure_insurance_share_bounds() {
+    let (_env, client, _id, admin, _user, _liquidator) = setup();
+
+    // Check default is 0
+    assert_eq!(client.get_insurance_share(), 0);
+
+    // Set valid share (e.g. 20%)
+    client.set_insurance_share(&2000);
+    assert_eq!(client.get_insurance_share(), 2000);
+
+    // Set maximum valid share (100%)
+    client.set_insurance_share(&10000);
+    assert_eq!(client.get_insurance_share(), 10000);
+
+    // Set invalid negative share should panic/error
+    let result_neg = client.try_set_insurance_share(&-1);
+    assert!(result_neg.is_err());
+
+    // Set invalid >10000 share should panic/error
+    let result_too_high = client.try_set_insurance_share(&10001);
+    assert!(result_too_high.is_err());
+}
+
+#[test]
+fn test_admin_explicit_funding() {
+    let (_env, client, _id, admin, _user, _liquidator) = setup();
+
+    assert_eq!(client.get_insurance_fund(), 0);
+
+    // Fund with 500 tokens
+    client.fund_insurance(&500);
+    assert_eq!(client.get_insurance_fund(), 500);
+
+    // Fund with another 300 tokens
+    client.fund_insurance(&300);
+    assert_eq!(client.get_insurance_fund(), 800);
+
+    // Try to fund with invalid amount (<= 0)
+    let result_zero = client.try_fund_insurance(&0);
+    assert!(result_zero.is_err());
+
+    let result_neg = client.try_fund_insurance(&-100);
+    assert!(result_neg.is_err());
+}
+
+#[test]
+fn test_accrual_interest_split() {
+    let (env, client, _id, _admin, user, _liquidator) = setup();
+
+    // Configure 30% insurance share
+    client.set_insurance_share(&3000);
+
+    // Borrow 10,000 units
+    let borrow_amount = 10_000i128;
+    client.borrow(&user, &borrow_amount).unwrap();
+
+    // Advance time by exactly one year to accrue 5% interest (500 tokens)
+    advance_ledger_time(&env, SECONDS_PER_YEAR);
+
+    // Trigger accrual by executing a borrow or repay (or repayment here)
+    // Let's do a repay of 1,000 units.
+    // Interest accrued: 500 units.
+    // Expected insurance share: 30% of 500 = 150 units.
+    client.repay(&user, &1000);
+
+    // Verify insurance fund holds 150 units
+    assert_eq!(client.get_insurance_fund(), 150);
+
+    // Verify borrower's debt was updated with the full 500 interest units.
+    // Remaining debt: 10,000 (principal) + 500 (interest) - 1000 (repay) = 9,500
+    let pos = client.get_debt_position(&user);
+    assert_eq!(pos.principal, 9500);
+}
+
+#[test]
+fn test_liquidation_empty_insurance_fund() {
+    let (env, client, id, _admin, user, liquidator) = setup();
+
+    // Set up shortfall: collateral = 10, debt = 200.
+    // max_repay = 200 * 50% = 100.
+    // seized_collateral = 100 * 110% = 110.
+    // available_collateral = 10.
+    // shortfall = 110 - 10 = 100.
+    env.as_contract(&id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user.clone()), &10_i128);
+    });
+    env.as_contract(&id, || {
+        crate::debt::save_debt(
+            &env,
+            &user,
+            &DebtPosition {
+                principal: 200,
+                last_update: env.ledger().timestamp(),
+            },
+        );
+    });
+
+    // Verify insurance fund is empty and bad debt is 0
+    assert_eq!(client.get_insurance_fund(), 0);
+    assert_eq!(client.get_bad_debt(), 0);
+
+    // Perform liquidation
+    let repaid = client.liquidate(&liquidator, &user, &1000);
+    assert_eq!(repaid, 100);
+
+    // Shortfall (100) must be recorded fully as bad debt
+    assert_eq!(client.get_bad_debt(), 100);
+    assert_eq!(client.get_insurance_fund(), 0);
+}
+
+#[test]
+fn test_liquidation_partial_insurance_coverage() {
+    let (env, client, id, _admin, user, liquidator) = setup();
+
+    // Fund the insurance fund with 40 tokens
+    client.fund_insurance(&40);
+    assert_eq!(client.get_insurance_fund(), 40);
+
+    // Set up shortfall: collateral = 10, debt = 200.
+    // shortfall = 100.
+    env.as_contract(&id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user.clone()), &10_i128);
+    });
+    env.as_contract(&id, || {
+        crate::debt::save_debt(
+            &env,
+            &user,
+            &DebtPosition {
+                principal: 200,
+                last_update: env.ledger().timestamp(),
+            },
+        );
+    });
+
+    // Perform liquidation
+    let repaid = client.liquidate(&liquidator, &user, &1000);
+    assert_eq!(repaid, 100);
+
+    // Insurance fund covers 40, leaving 60 to bad debt
+    assert_eq!(client.get_insurance_fund(), 0);
+    assert_eq!(client.get_bad_debt(), 60);
+}
+
+#[test]
+fn test_liquidation_full_insurance_coverage() {
+    let (env, client, id, _admin, user, liquidator) = setup();
+
+    // Fund the insurance fund with 150 tokens
+    client.fund_insurance(&150);
+    assert_eq!(client.get_insurance_fund(), 150);
+
+    // Set up shortfall: collateral = 10, debt = 200.
+    // shortfall = 100.
+    env.as_contract(&id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user.clone()), &10_i128);
+    });
+    env.as_contract(&id, || {
+        crate::debt::save_debt(
+            &env,
+            &user,
+            &DebtPosition {
+                principal: 200,
+                last_update: env.ledger().timestamp(),
+            },
+        );
+    });
+
+    // Perform liquidation
+    let repaid = client.liquidate(&liquidator, &user, &1000);
+    assert_eq!(repaid, 100);
+
+    // Insurance fund covers all 100 shortfall, 50 remains in fund, bad debt remains 0
+    assert_eq!(client.get_insurance_fund(), 50);
+    assert_eq!(client.get_bad_debt(), 0);
+}

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -67,6 +67,8 @@ mod liquidate_event_test;
 mod bad_debt_ledger_test;
 #[cfg(test)]
 mod supply_rate_split_test;
+#[cfg(test)]
+mod insurance_fund_test;
 
 use debt::{
     borrow_amount, cached_borrow_rate, effective_debt, load_debt, repay_amount, save_debt,
@@ -132,6 +134,8 @@ pub enum DataKey {
     TotalDebtAsset(Address),
     /// Insurance fund balance credited by governance or protocol fees (i128).
     InsuranceFund,
+    /// Configured share of accrued interest directed to the insurance fund (i128, bps).
+    InsuranceShareBps,
 }
 
 #[contractevent]
@@ -706,7 +710,8 @@ impl LendingContract {
         let position = load_debt(&env, &user);
         let prev_principal = position.principal;
         let rate = current_borrow_rate(&env);
-        let updated = borrow_amount(position, now, amount, rate).map_err(|e| match e {
+        let settled_position = settle_and_accrue_insurance(&env, &position, now, rate)?;
+        let updated = borrow_amount(settled_position, now, amount, rate).map_err(|e| match e {
             debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
             debt::DebtError::Overflow => LendingError::Overflow,
         })?;
@@ -790,7 +795,7 @@ impl LendingContract {
         // Settle the borrower's debt once and reuse the settled principal for
         // the health-factor check, close-factor cap, and final debt write.
         let settled_position =
-            settle_accrual(&position, now, DEFAULT_APR_BPS).unwrap_or(DebtPosition {
+            settle_and_accrue_insurance(&env, &position, now, DEFAULT_APR_BPS).unwrap_or_else(|_| DebtPosition {
                 principal: position.principal,
                 last_update: now,
             });
@@ -849,21 +854,27 @@ impl LendingContract {
             let shortfall = seized_collateral
                 .checked_sub(available_collateral)
                 .ok_or(LendingError::Overflow)?;
-            let current_bad_debt: i128 = env
-                .storage()
-                .persistent()
-                .get(&DataKey::BadDebt)
-                .unwrap_or(0i128);
-            let new_bad_debt = current_bad_debt
-                .checked_add(shortfall)
+            let insurance_drawn = draw_insurance(&env, shortfall)?;
+            let residual = shortfall
+                .checked_sub(insurance_drawn)
                 .ok_or(LendingError::Overflow)?;
-            env.storage()
-                .persistent()
-                .set(&DataKey::BadDebt, &new_bad_debt);
-            env.events().publish(
-                (Symbol::new(&env, "bad_debt"), borrower.clone()),
-                shortfall,
-            );
+            if residual > 0 {
+                let current_bad_debt: i128 = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::BadDebt)
+                    .unwrap_or(0i128);
+                let new_bad_debt = current_bad_debt
+                    .checked_add(residual)
+                    .ok_or(LendingError::Overflow)?;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::BadDebt, &new_bad_debt);
+                env.events().publish(
+                    (Symbol::new(&env, "bad_debt"), borrower.clone()),
+                    residual,
+                );
+            }
             available_collateral
         } else {
             seized_collateral
@@ -933,7 +944,8 @@ impl LendingContract {
         let position = load_debt(&env, &user);
         let prev_principal = position.principal;
         let rate = current_borrow_rate(&env);
-        let updated = repay_amount(position, now, amount, rate).map_err(|e| match e {
+        let settled_position = settle_and_accrue_insurance(&env, &position, now, rate)?;
+        let updated = repay_amount(settled_position, now, amount, rate).map_err(|e| match e {
             debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
             debt::DebtError::Overflow => LendingError::Overflow,
         })?;
@@ -1232,6 +1244,55 @@ impl LendingContract {
             .instance()
             .get(&DataKey::InsuranceFund)
             .unwrap_or(0)
+    }
+
+    /// Return the configured insurance fund interest share in basis points.
+    pub fn get_insurance_share(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::InsuranceShareBps)
+            .unwrap_or(0)
+    }
+
+    /// Fund the insurance fund by an explicit amount.
+    ///
+    /// Only the protocol admin can call this.
+    ///
+    /// # Errors
+    /// - [`LendingError::InvalidAmount`] if `amount <= 0`.
+    /// - [`LendingError::Overflow`] if the resulting balance would overflow i128.
+    pub fn fund_insurance(env: Env, amount: i128) -> Result<(), LendingError> {
+        assert_admin(&env);
+        if amount <= 0 {
+            return Err(LendingError::InvalidAmount);
+        }
+        let current: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceFund)
+            .unwrap_or(0);
+        let new_balance = current.checked_add(amount).ok_or(LendingError::Overflow)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceFund, &new_balance);
+        Ok(())
+    }
+
+    /// Set the insurance fund interest share in basis points (admin-only).
+    ///
+    /// The share must be between 0 and 10000 bps (0% to 100%).
+    ///
+    /// # Errors
+    /// - [`LendingError::InvalidAmount`] if `share_bps < 0 || share_bps > 10000`.
+    pub fn set_insurance_share(env: Env, share_bps: i128) -> Result<(), LendingError> {
+        assert_admin(&env);
+        if share_bps < 0 || share_bps > 10000 {
+            return Err(LendingError::InvalidAmount);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceShareBps, &share_bps);
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -1581,6 +1642,64 @@ impl LendingContract {
     pub fn get_min_upgrade_delay_ledgers(env: Env) -> u32 {
         upgrade::get_min_upgrade_delay_ledgers(&env)
     }
+}
+
+pub(crate) fn settle_and_accrue_insurance(
+    env: &Env,
+    position: &DebtPosition,
+    now: u64,
+    rate_bps: i128,
+) -> Result<DebtPosition, LendingError> {
+    let elapsed = debt::elapsed_seconds(now, position.last_update);
+    let interest = debt::accrue_interest(position.principal, elapsed, rate_bps)
+        .map_err(|_| LendingError::Overflow)?;
+
+    if interest > 0 {
+        let share_bps: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceShareBps)
+            .unwrap_or(0);
+        if share_bps > 0 {
+            let share = interest
+                .checked_mul(share_bps)
+                .ok_or(LendingError::Overflow)?
+                .checked_div(BPS_DENOM)
+                .ok_or(LendingError::Overflow)?;
+            if share > 0 {
+                let current_fund: i128 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::InsuranceFund)
+                    .unwrap_or(0);
+                let new_fund = current_fund.checked_add(share).ok_or(LendingError::Overflow)?;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::InsuranceFund, &new_fund);
+            }
+        }
+    }
+
+    let settled = debt::settle_accrual(position, now, rate_bps)
+        .map_err(|_| LendingError::Overflow)?;
+    Ok(settled)
+}
+
+fn draw_insurance(env: &Env, amount: i128) -> Result<i128, LendingError> {
+    if amount <= 0 {
+        return Ok(0);
+    }
+    let current: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::InsuranceFund)
+        .unwrap_or(0);
+    let drawn = amount.min(current);
+    let new_balance = current.checked_sub(drawn).ok_or(LendingError::Overflow)?;
+    env.storage()
+        .instance()
+        .set(&DataKey::InsuranceFund, &new_balance);
+    Ok(drawn)
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
closes #1026

This pull request introduces a protocol insurance fund to the lending contract. The insurance fund acts as a first-loss capital buffer to absorb bad debt incurred during liquidation shortfalls before any losses are passed to depositors. Under this design, the protocol can insulate depositor collateral from liquidation inefficiencies and oracle gaps, ensuring that socialized losses remain a last resort.

The insurance fund is dynamically capitalized by a configurable share of all accrued borrow interest (measured in basis points up to 100%), which is split and stored during any interest-accruing operation such as borrowing, repayment, or liquidation. It can also be directly funded through explicit admin deposits via the new public interface.

During liquidation, if the borrower's debt exceeds the available collateral, the contract automatically draws from the insurance fund to cover the difference. If the fund balance is sufficient to absorb the shortfall, no bad debt is recorded. If the fund is partially depleted, the remaining residual shortfall is recorded on the bad-debt ledger, keeping the system's ledger and event logs fully reconciled.

Comprehensive unit tests have been added to verify configuration limits, explicit funding, dynamic interest accrual splits, and all drawdown edge cases (empty fund, partial coverage, and full coverage). Detailed documentation is also included under INSURANCE_FUND.md to outline the funding formulas, drawdown precedence, and worked examples.