### PR TITLE
test(amm): add mint share invariant proptests

### DIFF
--- a/stellar-lend/Cargo.lock
+++ b/stellar-lend/Cargo.lock
@@ -1866,6 +1866,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarlend-amm"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "stellarlend-lending"
 version = "0.1.0"
 dependencies = [

--- a/stellar-lend/Cargo.toml
+++ b/stellar-lend/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "contracts/common",
+  "contracts/amm",
   "contracts/hello-world",
   "contracts/lending",
   "contracts/multisig",

--- a/stellar-lend/contracts/amm/MINT_INVARIANTS.md
+++ b/stellar-lend/contracts/amm/MINT_INVARIANTS.md
@@ -1,0 +1,85 @@
+# Mint Share Invariants
+
+`calculate_mint_shares` protects existing LPs by minting new shares from the
+smaller side of the deposit:
+
+```text
+liquidity_0 = amount_0 * total_supply / reserve_0
+liquidity_1 = amount_1 * total_supply / reserve_1
+minted      = min(liquidity_0, liquidity_1)
+```
+
+That rule means a successful deposit cannot reduce an existing holder's reserve
+claim. For token 0, non-dilution is checked without floating point as:
+
+```text
+(reserve_0 + amount_0) / (total_supply + minted) >= reserve_0 / total_supply
+```
+
+Cross-multiplied:
+
+```text
+(reserve_0 + amount_0) * total_supply >= reserve_0 * (total_supply + minted)
+```
+
+The same check is applied to token 1.
+
+## First Deposit Lock
+
+On the first deposit, the pool mints:
+
+```text
+sqrt(amount_0 * amount_1)
+```
+
+`MINIMUM_LIQUIDITY` is permanently locked, and the user receives the remainder.
+The property test asserts:
+
+```text
+locked == MINIMUM_LIQUIDITY
+minted + locked == sqrt(amount_0 * amount_1)
+```
+
+## Worked Example
+
+Given:
+
+```text
+total_supply = 10_000
+reserve_0    = 10_000
+reserve_1    = 20_000
+amount_0     = 1_000
+amount_1     = 4_000
+```
+
+The candidate share amounts are:
+
+```text
+liquidity_0 = 1_000 * 10_000 / 10_000 = 1_000
+liquidity_1 = 4_000 * 10_000 / 20_000 = 2_000
+minted      = min(1_000, 2_000) = 1_000
+```
+
+After minting:
+
+```text
+supply_after  = 11_000
+reserve_0_after = 11_000
+reserve_1_after = 24_000
+```
+
+Token 0 backing stays equal:
+
+```text
+11_000 / 11_000 == 10_000 / 10_000
+```
+
+Token 1 backing increases:
+
+```text
+24_000 / 11_000 > 20_000 / 10_000
+```
+
+The new proptest suite checks this over random pool states and deposit
+sequences, while also covering lopsided deposits and the first-deposit
+minimum-liquidity lock.

--- a/stellar-lend/contracts/amm/src/lib.rs
+++ b/stellar-lend/contracts/amm/src/lib.rs
@@ -1,6 +1,13 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[cfg(test)]
+mod liquidity_math;
+#[cfg(test)]
+mod math;
+#[cfg(test)]
+mod mint_shares_proptest;
 
 #[contract]
 pub struct AmmContract;
@@ -62,12 +69,14 @@ impl AmmContract {
         let numerator = amount_in_with_fee.checked_mul(rb).expect("overflow");
         // denominator = reserve_in * 10000 + amount_in_with_fee
         let denom_part = ra.checked_mul(10_000_i128).expect("overflow");
-        let denominator = denom_part.checked_add(amount_in_with_fee).expect("overflow");
+        let denominator = denom_part
+            .checked_add(amount_in_with_fee)
+            .expect("overflow");
 
         let amount_out = numerator / denominator;
 
         let new_ra = ra.checked_add(amount_in).expect("overflow");
-        let new_rb = rb.checked_sub(amount_out);
+        let new_rb = rb.checked_sub(amount_out).expect("overflow");
         assert_k_monotonic(ra, rb, new_ra, new_rb, true);
 
         env.storage().persistent().set(&KEY_RES_A, &new_ra);
@@ -86,16 +95,28 @@ impl AmmContract {
 // ---------------------------------------------------------------------------
 // Core invariant helper
 // ---------------------------------------------------------------------------
-fn assert_k_monotonic(before_a: i128, before_b: i128, after_a: i128, after_b: i128, expect_increase: bool) {
+fn assert_k_monotonic(
+    before_a: i128,
+    before_b: i128,
+    after_a: i128,
+    after_b: i128,
+    expect_increase: bool,
+) {
     let k_before = before_a.checked_mul(before_b).expect("k overflow before");
     let k_after = after_a.checked_mul(after_b).expect("k overflow after");
     if expect_increase {
         if k_after < k_before {
-            panic!("Invariant violation: k decreased (before={}, after={})", k_before, k_after);
+            panic!(
+                "Invariant violation: k decreased (before={}, after={})",
+                k_before, k_after
+            );
         }
     } else {
         if k_after > k_before {
-            panic!("Invariant violation: k increased on removal (before={}, after={})", k_before, k_after);
+            panic!(
+                "Invariant violation: k increased on removal (before={}, after={})",
+                k_before, k_after
+            );
         }
     }
 }
@@ -106,7 +127,6 @@ fn assert_k_monotonic(before_a: i128, before_b: i128, after_a: i128, after_b: i1
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
 
     #[test]
     fn fuzz_swap_k_monotonic() {
@@ -127,7 +147,15 @@ mod test {
                     let (new_ra, new_rb) = client.get_reserves();
                     let k_before = ra.checked_mul(rb).unwrap();
                     let k_after = new_ra.checked_mul(new_rb).unwrap();
-                    assert!(k_after >= k_before, "k decreased: ra={}, rb={}, amt={}, k_before={}, k_after={}", ra, rb, amt, k_before, k_after);
+                    assert!(
+                        k_after >= k_before,
+                        "k decreased: ra={}, rb={}, amt={}, k_before={}, k_after={}",
+                        ra,
+                        rb,
+                        amt,
+                        k_before,
+                        k_after
+                    );
                 }
             }
         }

--- a/stellar-lend/contracts/amm/src/liquidity_math.rs
+++ b/stellar-lend/contracts/amm/src/liquidity_math.rs
@@ -1,18 +1,16 @@
-#![no_std]
-
 use crate::math::sqrt;
 
 /// Minimum liquidity permanently locked in the pool on the first deposit.
-/// 
+///
 /// This constant mitigates the "donation attack" where an attacker deposits
 /// a microscopic amount of liquidity, receives 1 LP share, and then donates
 /// a massive amount of tokens directly to the pool reserves. Without a minimum
 /// locked liquidity, the share price would inflate proportionally, causing
-/// subsequent depositors to receive 0 shares due to integer truncation, 
+/// subsequent depositors to receive 0 shares due to integer truncation,
 /// allowing the attacker to steal their deposits by withdrawing their 1 share.
 ///
-/// By locking a minimum amount of shares (e.g., 1000) to a dead address (or 
-/// simply permanently adding to `total_supply` without a valid owner), the 
+/// By locking a minimum amount of shares (e.g., 1000) to a dead address (or
+/// simply permanently adding to `total_supply` without a valid owner), the
 /// attacker's cost to inflate the share price to a degree that rounds a victim's
 /// deposit to 0 increases by a factor of MINIMUM_LIQUIDITY, making the attack
 /// economically unviable.
@@ -41,8 +39,14 @@ pub fn calculate_mint_shares(
         }
         (liquidity - MINIMUM_LIQUIDITY, MINIMUM_LIQUIDITY)
     } else {
-        let liquidity_0 = amount_0.checked_mul(total_supply).expect("overflow in liquidity_0") / reserve_0;
-        let liquidity_1 = amount_1.checked_mul(total_supply).expect("overflow in liquidity_1") / reserve_1;
+        let liquidity_0 = amount_0
+            .checked_mul(total_supply)
+            .expect("overflow in liquidity_0")
+            / reserve_0;
+        let liquidity_1 = amount_1
+            .checked_mul(total_supply)
+            .expect("overflow in liquidity_1")
+            / reserve_1;
         let liquidity = core::cmp::min(liquidity_0, liquidity_1);
         if liquidity == 0 {
             panic!("InsufficientLiquidityMinted");
@@ -79,40 +83,45 @@ mod tests {
 
     #[test]
     fn test_donation_attack_mitigation() {
-        // Scenario: 
+        // Scenario:
         // An attacker tries to steal a victim's deposit by inflating the LP share price.
-        
+
         // 1. Attacker makes the initial deposit with minimal amounts.
         // Since MINIMUM_LIQUIDITY is 1000, attacker deposits 1001 of each token.
         let attacker_amount_0 = 1001;
         let attacker_amount_1 = 1001;
-        let (attacker_shares, locked_shares) = calculate_mint_shares(0, attacker_amount_0, attacker_amount_1, 0, 0);
-        
+        let (attacker_shares, locked_shares) =
+            calculate_mint_shares(0, attacker_amount_0, attacker_amount_1, 0, 0);
+
         assert_eq!(attacker_shares, 1); // sqrt(1001*1001) - 1000 = 1
         assert_eq!(locked_shares, 1000); // permanently locked
-        
+
         let total_supply = attacker_shares + locked_shares; // 1001
-        
+
         // 2. Attacker "donates" a large amount directly to the pool's reserves without minting shares.
         // This artificially inflates the value of a single share.
         let donation = 1_000_000;
         let reserve_0 = attacker_amount_0 + donation;
         let reserve_1 = attacker_amount_1 + donation;
-        
+
         // 3. Victim deposits a large amount of liquidity (e.g., 500,000 of each token).
         let victim_amount_0 = 500_000;
         let victim_amount_1 = 500_000;
-        
+
         let (victim_shares, new_locked) = calculate_mint_shares(
-            total_supply, victim_amount_0, victim_amount_1, reserve_0, reserve_1
+            total_supply,
+            victim_amount_0,
+            victim_amount_1,
+            reserve_0,
+            reserve_1,
         );
-        
+
         // Because of the locked minimum liquidity (total_supply = 1001 instead of 1),
         // the victim still receives a proportional amount of shares.
-        // shares = min(500,000 * 1001 / 1,001,001, ...) = 500
-        assert_eq!(victim_shares, 500);
+        // shares = min(500,000 * 1001 / 1,001,001, ...) = 499 after integer flooring.
+        assert_eq!(victim_shares, 499);
         assert_eq!(new_locked, 0);
-        
+
         // If MINIMUM_LIQUIDITY was 0, total_supply would be 1, reserve_0 would be 1_000_001.
         // victim_shares would be 500_000 * 1 / 1_000_001 = 0.
         // The attacker would then own 100% of the pool and steal the victim's 500k.

--- a/stellar-lend/contracts/amm/src/math.rs
+++ b/stellar-lend/contracts/amm/src/math.rs
@@ -1,5 +1,3 @@
-#![no_std]
-
 /// Calculates the integer square root of `y` using Newton's method.
 /// This implementation ensures fast convergence and avoids overflow
 /// by carefully choosing the initial guess and avoiding additions

--- a/stellar-lend/contracts/amm/src/mint_shares_proptest.rs
+++ b/stellar-lend/contracts/amm/src/mint_shares_proptest.rs
@@ -1,0 +1,190 @@
+#![cfg(test)]
+
+use crate::liquidity_math::{calculate_mint_shares, MINIMUM_LIQUIDITY};
+use crate::math::sqrt;
+use proptest::prelude::*;
+
+/// Upper bound chosen so all cross-multiplied reserve/share comparisons remain
+/// comfortably below `i128::MAX` while still covering large pool states.
+const MAX_TEST_AMOUNT: i128 = 1_000_000_000;
+
+/// Produces positive reserves, supply, and deposit amounts for established pools.
+fn established_pool_strategy() -> impl Strategy<Value = (i128, i128, i128, i128, i128)> {
+    (
+        1i128..=MAX_TEST_AMOUNT,
+        1i128..=MAX_TEST_AMOUNT,
+        1i128..=MAX_TEST_AMOUNT,
+        1i128..=MAX_TEST_AMOUNT,
+        1i128..=MAX_TEST_AMOUNT,
+    )
+}
+
+/// Produces first-deposit amounts large enough to mint more than the permanent
+/// minimum-liquidity lock.
+fn first_deposit_strategy() -> impl Strategy<Value = (i128, i128)> {
+    (
+        (MINIMUM_LIQUIDITY + 1)..=MAX_TEST_AMOUNT,
+        (MINIMUM_LIQUIDITY + 1)..=MAX_TEST_AMOUNT,
+    )
+}
+
+/// Returns the integer LP shares implied by the production minting formula.
+fn expected_subsequent_mint(
+    total_supply: i128,
+    amount_0: i128,
+    amount_1: i128,
+    reserve_0: i128,
+    reserve_1: i128,
+) -> i128 {
+    let liquidity_0 = amount_0
+        .checked_mul(total_supply)
+        .expect("liquidity_0 overflow")
+        / reserve_0;
+    let liquidity_1 = amount_1
+        .checked_mul(total_supply)
+        .expect("liquidity_1 overflow")
+        / reserve_1;
+    core::cmp::min(liquidity_0, liquidity_1)
+}
+
+/// Asserts that an existing LP share is backed by at least as much of a reserve
+/// after minting as it was before minting.
+fn assert_per_share_backing_non_decreasing(
+    reserve_before: i128,
+    reserve_after: i128,
+    supply_before: i128,
+    supply_after: i128,
+) {
+    let before_scaled = reserve_before
+        .checked_mul(supply_after)
+        .expect("reserve_before * supply_after overflow");
+    let after_scaled = reserve_after
+        .checked_mul(supply_before)
+        .expect("reserve_after * supply_before overflow");
+
+    assert!(
+        after_scaled >= before_scaled,
+        "per-share reserve backing decreased: before={}/{} after={}/{}",
+        reserve_before,
+        supply_before,
+        reserve_after,
+        supply_after
+    );
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn subsequent_mints_follow_min_liquidity_rule_and_do_not_dilute_existing_lps(
+        (total_supply, amount_0, amount_1, reserve_0, reserve_1) in established_pool_strategy(),
+    ) {
+        let expected_minted = expected_subsequent_mint(
+            total_supply,
+            amount_0,
+            amount_1,
+            reserve_0,
+            reserve_1,
+        );
+        prop_assume!(expected_minted > 0);
+
+        let (minted, locked) = calculate_mint_shares(
+            total_supply,
+            amount_0,
+            amount_1,
+            reserve_0,
+            reserve_1,
+        );
+
+        prop_assert_eq!(locked, 0);
+        prop_assert_eq!(minted, expected_minted);
+
+        let supply_after = total_supply.checked_add(minted).expect("supply_after overflow");
+        let reserve_0_after = reserve_0.checked_add(amount_0).expect("reserve_0_after overflow");
+        let reserve_1_after = reserve_1.checked_add(amount_1).expect("reserve_1_after overflow");
+
+        assert_per_share_backing_non_decreasing(reserve_0, reserve_0_after, total_supply, supply_after);
+        assert_per_share_backing_non_decreasing(reserve_1, reserve_1_after, total_supply, supply_after);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn first_mint_locks_minimum_liquidity_and_mints_remainder(
+        (amount_0, amount_1) in first_deposit_strategy(),
+    ) {
+        let initial_liquidity = sqrt(amount_0.checked_mul(amount_1).expect("initial product overflow"));
+        prop_assume!(initial_liquidity > MINIMUM_LIQUIDITY);
+
+        let (minted, locked) = calculate_mint_shares(0, amount_0, amount_1, 0, 0);
+
+        prop_assert_eq!(locked, MINIMUM_LIQUIDITY);
+        prop_assert_eq!(minted + locked, initial_liquidity);
+        prop_assert!(minted > 0);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    #[test]
+    fn deposit_sequences_preserve_existing_lp_reserve_claim(
+        initial in first_deposit_strategy(),
+        deposits in proptest::collection::vec((1i128..=MAX_TEST_AMOUNT, 1i128..=MAX_TEST_AMOUNT), 1..8),
+    ) {
+        let initial_liquidity = sqrt(initial.0.checked_mul(initial.1).expect("initial product overflow"));
+        prop_assume!(initial_liquidity > MINIMUM_LIQUIDITY);
+
+        let (first_minted, first_locked) = calculate_mint_shares(0, initial.0, initial.1, 0, 0);
+        let mut total_supply = first_minted + first_locked;
+        let mut reserve_0 = initial.0;
+        let mut reserve_1 = initial.1;
+
+        prop_assert_eq!(first_locked, MINIMUM_LIQUIDITY);
+        prop_assert_eq!(total_supply, initial_liquidity);
+
+        for (amount_0, amount_1) in deposits {
+            let expected_minted = expected_subsequent_mint(
+                total_supply,
+                amount_0,
+                amount_1,
+                reserve_0,
+                reserve_1,
+            );
+
+            if expected_minted == 0 {
+                continue;
+            }
+
+            let (minted, locked) = calculate_mint_shares(
+                total_supply,
+                amount_0,
+                amount_1,
+                reserve_0,
+                reserve_1,
+            );
+
+            prop_assert_eq!(locked, 0);
+            prop_assert_eq!(minted, expected_minted);
+
+            let next_supply = total_supply.checked_add(minted).expect("next_supply overflow");
+            let next_reserve_0 = reserve_0.checked_add(amount_0).expect("next_reserve_0 overflow");
+            let next_reserve_1 = reserve_1.checked_add(amount_1).expect("next_reserve_1 overflow");
+
+            assert_per_share_backing_non_decreasing(reserve_0, next_reserve_0, total_supply, next_supply);
+            assert_per_share_backing_non_decreasing(reserve_1, next_reserve_1, total_supply, next_supply);
+
+            total_supply = next_supply;
+            reserve_0 = next_reserve_0;
+            reserve_1 = next_reserve_1;
+        }
+    }
+}
+
+#[test]
+#[should_panic(expected = "InsufficientLiquidityMinted")]
+fn lopsided_tiny_deposit_still_rejects_zero_share_mint() {
+    calculate_mint_shares(10_000, 1, 1_000, 1_000_000_000, 10_000);
+}


### PR DESCRIPTION
Closes #1131

## Summary
- Add property-based tests for `calculate_mint_shares` covering established pools, first deposits, and random deposit sequences.
- Assert subsequent mints follow `min(liquidity_0, liquidity_1)` and preserve existing LP reserve backing by cross-multiplying the per-share ratios.
- Assert the first deposit permanently locks `MINIMUM_LIQUIDITY` and mints the remainder.
- Document the mint-share invariants and a worked example in `contracts/amm/MINT_INVARIANTS.md`.
- Add `contracts/amm` to the workspace so the AMM package and its tests are reachable from workspace test commands.
- Fix AMM compile/test blockers exposed by adding the package to the workspace: unwrap `checked_sub`, correct the donation-attack expected floor from 500 to 499, and remove duplicate module-level `#![no_std]` attributes.

## Validation
- `cargo test -p stellarlend-amm` passes locally: 12 passed, 0 failed.

Note: the existing repository CI job named `Lending Contract CI` currently fails in `contracts/lending` formatting before reaching AMM-specific checks; that failure is outside this PR's changed AMM paths.

If this PR is considered reward-eligible by the Stellar Wave / GrantFox campaign, payout preference is USDT ERC-20: `0x06f44f4839fd5df4f4670036d028b29dec939363`.