### PR TITLE
test(amm): sqrt precision-bound and boundary coverage

### DIFF
--- a/stellar-lend/contracts/amm/SQRT_PRECISION.md
+++ b/stellar-lend/contracts/amm/SQRT_PRECISION.md
@@ -1,0 +1,14 @@
+# Square Root Precision Guarantee
+
+The `sqrt` function provided in `amm::math::sqrt` computes the exact integer floor of the real square root for all non-negative `i128` values. 
+
+Formally, for any non-negative integer `y`, the returned integer `r = sqrt(y)` satisfies the precision bound:
+
+`r^2 <= y < (r + 1)^2`
+
+This mathematical property is guaranteed across the full valid input range (0 to `i128::MAX`). 
+
+## Edge Cases and Boundaries
+- The implementation natively handles inputs of `0` and `1`.
+- Negative inputs will result in a panic as they do not have a real number representation.
+- The boundary near `i128::MAX`, including the largest representable perfect square (`13043817825332782212^2`), is fully supported. Note that for values very close to `i128::MAX`, evaluating `(r + 1)^2` might overflow standard `i128` bounds and requires evaluation in a wider type like `u128` to verify the mathematical upper bound.

--- a/stellar-lend/contracts/amm/src/lib.rs
+++ b/stellar-lend/contracts/amm/src/lib.rs
@@ -1,5 +1,11 @@
 #![no_std]
 
+pub mod math;
+pub mod liquidity_math;
+
+#[cfg(test)]
+mod sqrt_precision_test;
+
 use soroban_sdk::{contract, contractimpl, Address, Env};
 
 #[contract]

--- a/stellar-lend/contracts/amm/src/sqrt_precision_test.rs
+++ b/stellar-lend/contracts/amm/src/sqrt_precision_test.rs
@@ -1,0 +1,69 @@
+use crate::math::sqrt;
+
+/// Helper to verify the mathematical precision bound of the integer square root.
+/// For a given non-negative integer `y`, `r = sqrt(y)` must satisfy:
+/// `r^2 <= y < (r + 1)^2`.
+/// 
+/// Because `(r + 1)^2` can overflow `i128` for values near `i128::MAX`,
+/// we perform the upper bound verification using `u128`.
+fn assert_precision_bound(y: i128) {
+    let r = sqrt(y);
+    let r_u128 = r as u128;
+    let y_u128 = y as u128;
+    
+    // Lower bound: r^2 <= y
+    let lower_bound = r_u128.pow(2);
+    assert!(lower_bound <= y_u128, "Lower bound failed for y = {}, r = {}", y, r);
+    
+    // Upper bound: y < (r + 1)^2
+    let upper_bound = (r_u128 + 1).pow(2);
+    assert!(y_u128 < upper_bound, "Upper bound failed for y = {}, r = {}", y, r);
+}
+
+#[test]
+fn test_sqrt_precision_boundaries() {
+    // 0 and 1
+    assert_precision_bound(0);
+    assert_precision_bound(1);
+    
+    // Some small perfect squares and values just below/above
+    assert_precision_bound(3);
+    assert_precision_bound(4);
+    assert_precision_bound(8);
+    assert_precision_bound(9);
+    assert_precision_bound(15);
+    assert_precision_bound(16);
+    
+    // Large values
+    assert_precision_bound(100_000_000);
+    assert_precision_bound(100_000_000_000_000);
+    
+    // i128 boundary values
+    
+    // The largest perfect square in i128 is 13043817825332782212^2
+    // Let's test it, and the value just below and above it.
+    let max_r: i128 = 13043817825332782212;
+    // We can't use pow(2) on i128 directly if it overflows, but max_r squared is within i128.
+    let largest_perfect_square = max_r.pow(2);
+    
+    assert_precision_bound(largest_perfect_square - 1);
+    assert_precision_bound(largest_perfect_square);
+    assert_precision_bound(largest_perfect_square + 1);
+    
+    // Also test exactly i128::MAX
+    assert_precision_bound(i128::MAX);
+    assert_precision_bound(i128::MAX - 1);
+}
+
+#[test]
+#[should_panic(expected = "negative sqrt")]
+fn test_sqrt_negative_input() {
+    // Assert negative input handling matches the existing contract.
+    sqrt(-1);
+}
+
+#[test]
+#[should_panic(expected = "negative sqrt")]
+fn test_sqrt_min_input() {
+    sqrt(i128::MIN);
+}


### PR DESCRIPTION
closes #1142 