### PR TITLE
feat(bridge): enforce per-window inbound transfer cap

### DIFF
--- a/stellar-lend/contracts/bridge/Cargo.toml
+++ b/stellar-lend/contracts/bridge/Cargo.toml
@@ -3,6 +3,14 @@ name = "bridge"
 version = "0.1.0"
 edition = "2021"
 
+# This crate is intentionally standalone (off-chain validator/quorum
+# verification logic, not a Soroban contract) and is not a member of the
+# parent stellar-lend Soroban workspace. The empty [workspace] table below
+# opts it out of that workspace so `cargo test` / `cargo test -p bridge`
+# work when run from this directory, instead of erroring with "current
+# package believes it's in a workspace when it's not".
+[workspace]
+
 [dependencies]
 ed25519-dalek = { version = "1.0.1", features = ["std"] }
 rand = "0.7"

--- a/stellar-lend/contracts/bridge/README.md
+++ b/stellar-lend/contracts/bridge/README.md
@@ -6,10 +6,12 @@ Key features
 - `Bridge` struct with an `epoch` counter and validator set
 - `rotate_validators(new_set, epoch, proofs)` requires a quorum proof from the *current* validator set and advances the epoch atomically
 - `validate_inbound_epoch(signed_epoch)` rejects messages signed by retired epochs (signed_epoch < current epoch)
+- `set_inbound_cap(max_per_window, window_size, current_time)` / `admit_inbound(amount, current_time)` enforce a configurable, rolling-ledger-time cap on cumulative inbound value — defense-in-depth against an authorized-but-compromised validator set draining the bridge in a single window. **Fail-closed by default**: a fresh `Bridge` admits no inbound value until a cap is explicitly configured. See `SECURITY_NOTES.md` for the full threat model and design rationale.
 
 Design notes
 - Validator public keys are stored as raw bytes to keep on-disk/state serialization simple and unambiguous.
 - Quorum threshold is a supermajority > 2/3 of current validators.
 - Signatures are over a canonical payload: `bincode((new_set_bytes_vec, epoch))` — this binds the epoch to the new set.
+- This crate is intentionally standalone (off-chain validator/quorum verification logic) and is not a member of the parent Soroban workspace; run `cargo test` from this directory.
 
 See `src/lib.rs` for implementation and unit tests.

--- a/stellar-lend/contracts/bridge/SECURITY_NOTES.md
+++ b/stellar-lend/contracts/bridge/SECURITY_NOTES.md
@@ -67,3 +67,78 @@ messages.
 - `src/rotation_test.rs` — full test implementations.
 - Before deployment, run integration tests and perform a security review
   comparing the on-chain encoding and off-chain signing tools.
+
+---
+
+## Per-Window Inbound Value Cap
+
+### Threat model and rationale
+
+Validator quorum and epoch checks defend against an *unauthorized* validator
+set making changes. They do not bound how much value an *authorized* (but
+compromised, buggy, or malicious-majority) validator set can move across the
+bridge in one window. A quorum compromise or a logic bug elsewhere in the
+inbound-processing path can otherwise drain an unbounded amount in a single
+epoch.
+
+`Bridge::admit_inbound` adds a second, independent layer: a configurable cap
+on the total inbound value admitted within a rolling ledger-time window. This
+is defense-in-depth — it limits the *blast radius* of a failure elsewhere,
+it does not replace quorum/epoch validation.
+
+### Design notes
+
+- **Fail-closed by default.** A freshly constructed `Bridge` has
+  `max_per_window == 0`. Per the explicit design requirement, a cap of `0`
+  means *no inbound* — not *unlimited* — so the bridge admits nothing until
+  an operator calls `set_inbound_cap` with a positive value. This also means
+  an explicitly-configured `0` (e.g. an emergency pause) behaves identically:
+  it rejects every amount, including `0`-value transfers.
+- **Ledger time, not block/call count.** The window is tracked against a
+  `current_time: u64` passed in by the caller (intended to be the chain's
+  ledger timestamp), per the requirement that the window reset on monotonic
+  time rather than on a fixed number of calls. This means an attacker can't
+  extend or shrink the effective window by batching many small calls.
+- **Window realignment on rollover, not fixed-step advancement.** When
+  `current_time` has moved past the end of the current window,
+  `roll_window_if_expired` resets `window_start` to `current_time` directly
+  (rather than repeatedly adding `window_size`). If the bridge sits idle for
+  much longer than one window, the next inbound transfer gets a fresh full
+  window starting *now*, instead of cargo-culting forward through however
+  many idle windows elapsed. This is a deliberate simplicity/safety choice:
+  it avoids unbounded loops on a stale `window_start` and avoids any
+  ambiguity about which of several elapsed windows "counts."
+- **Checked arithmetic throughout.** `admit_inbound` uses `checked_add` on
+  the running total and rejects with an explicit "overflow" error rather
+  than panicking or wrapping. Negative amounts are rejected outright, since
+  inbound value is never negative in practice.
+- **Rejections never mutate state.** A call that fails any check
+  (negative amount, zero cap, cap exceeded, overflow) leaves
+  `window_inbound_total` untouched, so a sequence of failed admission
+  attempts can never partially consume the window.
+- **Reconfiguration starts a clean window.** `set_inbound_cap` resets
+  `window_start` to the given `current_time` and zeroes
+  `window_inbound_total`. An operator raising or lowering the cap mid-window
+  doesn't inherit whatever value was admitted under the old configuration.
+
+### Testing and coverage
+
+`inbound_cap_test.rs` covers:
+
+| Scenario | Expected outcome |
+|---|---|
+| Fresh `Bridge`, cap never configured | **Rejected** — fail-closed default |
+| Explicit `max_per_window = 0` | **Rejected**, including a `0`-value transfer |
+| Inbound strictly under the cap | **Admitted**, accumulates correctly |
+| Inbound that lands exactly on the cap | **Admitted** |
+| Inbound that would exceed the cap | **Rejected**, running total unchanged |
+| `current_time` crosses the window boundary | Window resets; previously-blocked amounts become admissible |
+| Long idle gap (many window-lengths) before next call | Window realigns to `current_time`, no stale carry-over |
+| Negative amount | **Rejected** |
+| `set_inbound_cap` with `window_size == 0` | **Rejected** |
+| `set_inbound_cap` with negative `max_per_window` | **Rejected** |
+| Reconfiguring cap mid-window | Running total resets to `0`, new window starts at the given time |
+| Running total at `i128::MAX` plus further inbound | **Rejected** — checked-add overflow guard, no panic |
+
+Every conditional branch in `admit_inbound`, `set_inbound_cap`, and
+`roll_window_if_expired` is exercised by at least one test above.

--- a/stellar-lend/contracts/bridge/src/inbound_cap_test.rs
+++ b/stellar-lend/contracts/bridge/src/inbound_cap_test.rs
@@ -1,0 +1,175 @@
+//! Tests for Bridge::admit_inbound and Bridge::set_inbound_cap — the
+//! per-window inbound-transfer value cap.
+//!
+//! Coverage targets:
+//!   - Fail-closed default: a freshly constructed Bridge rejects all inbound
+//!     before set_inbound_cap is ever called
+//!   - Cap of zero explicitly configured rejects all inbound, regardless of amount
+//!   - Under-cap inbound is admitted and accumulates correctly
+//!   - At-cap (exact boundary) inbound is admitted
+//!   - Over-cap inbound is rejected and does not mutate window state
+//!   - Window reset/rollover: once current_time crosses the window boundary,
+//!     the running total resets and previously-rejected amounts become admissible
+//!   - Negative amount is rejected
+//!   - set_inbound_cap validates window_size > 0 and max_per_window >= 0
+//!   - checked-arithmetic overflow guard on the running total
+
+#[cfg(test)]
+mod inbound_cap_tests {
+    use crate::{Bridge, ValidatorSet};
+
+    /// A Bridge with no rotation history needed for these tests — a single
+    /// dummy validator is enough since admit_inbound doesn't touch quorum.
+    fn make_bridge() -> Bridge {
+        let vs = ValidatorSet { validators: vec![vec![1, 2, 3]] };
+        Bridge::new(vs)
+    }
+
+    const DAY: u64 = 86_400;
+
+    #[test]
+    fn fail_closed_by_default_before_any_configuration() {
+        let mut bridge = make_bridge();
+        assert_eq!(bridge.max_per_window, 0, "cap must default to 0 (fail-closed)");
+
+        let err = bridge.admit_inbound(1, 1_000).unwrap_err();
+        assert!(err.to_string().contains("fail-closed"));
+        assert_eq!(bridge.window_inbound_total, 0, "rejected call must not mutate state");
+    }
+
+    #[test]
+    fn explicit_zero_cap_rejects_every_amount_including_zero() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(0, DAY, 0).expect("zero cap is a valid, explicit configuration");
+
+        assert!(bridge.admit_inbound(0, 100).is_err(), "even a zero-value transfer is rejected when cap is 0");
+        assert!(bridge.admit_inbound(1, 100).is_err());
+        assert!(bridge.admit_inbound(1_000_000, 100).is_err());
+    }
+
+    #[test]
+    fn under_cap_inbound_is_admitted_and_accumulates() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(1_000, DAY, 0).unwrap();
+
+        bridge.admit_inbound(100, 10).expect("under cap");
+        assert_eq!(bridge.window_inbound_total, 100);
+
+        bridge.admit_inbound(400, 20).expect("still under cap (cumulative 500)");
+        assert_eq!(bridge.window_inbound_total, 500);
+    }
+
+    #[test]
+    fn at_cap_exact_boundary_is_admitted() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(1_000, DAY, 0).unwrap();
+
+        bridge.admit_inbound(700, 10).unwrap();
+        // exactly hits the cap: 700 + 300 == 1000
+        bridge.admit_inbound(300, 20).expect("landing exactly on the cap must be admitted");
+        assert_eq!(bridge.window_inbound_total, 1_000);
+    }
+
+    #[test]
+    fn over_cap_is_rejected_and_does_not_mutate_state() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(1_000, DAY, 0).unwrap();
+
+        bridge.admit_inbound(700, 10).unwrap();
+        let err = bridge.admit_inbound(301, 20).unwrap_err();
+        assert!(err.to_string().contains("inbound cap exceeded"));
+
+        // rejected call must not have moved the running total
+        assert_eq!(bridge.window_inbound_total, 700);
+
+        // a smaller amount that does fit should still succeed afterwards
+        bridge.admit_inbound(300, 30).expect("the rejected call should not have consumed any cap");
+        assert_eq!(bridge.window_inbound_total, 1_000);
+    }
+
+    #[test]
+    fn window_resets_on_rollover_based_on_ledger_time_not_call_count() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(1_000, DAY, 0).unwrap();
+
+        bridge.admit_inbound(1_000, 10).expect("fill the window completely");
+        assert!(bridge.admit_inbound(1, 20).is_err(), "window is full, still within the same day");
+
+        // Time advances by exactly one window length: the window must roll
+        // over even though no explicit reset call was made.
+        let next_window_time = 0 + DAY;
+        bridge
+            .admit_inbound(1_000, next_window_time)
+            .expect("a new window has started, so the cap is available again");
+        assert_eq!(bridge.window_inbound_total, 1_000);
+        assert_eq!(bridge.window_start, next_window_time);
+
+        // Within this *new* window, the previous-window amount must not count.
+        assert!(bridge.admit_inbound(1, next_window_time + 10).is_err());
+    }
+
+    #[test]
+    fn window_rollover_realigns_to_current_time_after_a_long_idle_gap() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(1_000, DAY, 0).unwrap();
+        bridge.admit_inbound(500, 10).unwrap();
+
+        // Bridge sits idle for far longer than one window (e.g. 10 days).
+        let much_later = 10 * DAY + 12_345;
+        bridge.admit_inbound(900, much_later).expect("idle gap must not leave the window artificially full");
+        assert_eq!(bridge.window_inbound_total, 900, "stale pre-gap total must not carry over");
+        assert_eq!(bridge.window_start, much_later, "window realigns to current_time, not a stale multiple of window_size");
+    }
+
+    #[test]
+    fn negative_amount_is_rejected() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(1_000, DAY, 0).unwrap();
+
+        let err = bridge.admit_inbound(-1, 10).unwrap_err();
+        assert!(err.to_string().contains("must be >= 0"));
+        assert_eq!(bridge.window_inbound_total, 0);
+    }
+
+    #[test]
+    fn set_inbound_cap_rejects_zero_window_size() {
+        let mut bridge = make_bridge();
+        let err = bridge.set_inbound_cap(1_000, 0, 0).unwrap_err();
+        assert!(err.to_string().contains("window_size must be > 0"));
+    }
+
+    #[test]
+    fn set_inbound_cap_rejects_negative_max() {
+        let mut bridge = make_bridge();
+        let err = bridge.set_inbound_cap(-1, DAY, 0).unwrap_err();
+        assert!(err.to_string().contains("max_per_window must be >= 0"));
+    }
+
+    #[test]
+    fn set_inbound_cap_starts_a_fresh_window_and_clears_prior_total() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(1_000, DAY, 0).unwrap();
+        bridge.admit_inbound(900, 10).unwrap();
+        assert_eq!(bridge.window_inbound_total, 900);
+
+        // Reconfiguring (e.g. an operator raising the cap) must not let the
+        // old window's accumulated value silently persist under new terms.
+        bridge.set_inbound_cap(5_000, DAY, 500).unwrap();
+        assert_eq!(bridge.window_inbound_total, 0);
+        assert_eq!(bridge.window_start, 500);
+
+        bridge.admit_inbound(5_000, 600).expect("full new cap should be available after reconfiguration");
+    }
+
+    #[test]
+    fn checked_arithmetic_overflow_on_running_total_is_rejected_not_panicked() {
+        let mut bridge = make_bridge();
+        bridge.set_inbound_cap(i128::MAX, DAY, 0).unwrap();
+
+        bridge.admit_inbound(i128::MAX - 1, 10).unwrap();
+        let err = bridge.admit_inbound(2, 20).unwrap_err();
+        assert!(err.to_string().contains("overflow"));
+        // must not panic, and must not corrupt the existing total
+        assert_eq!(bridge.window_inbound_total, i128::MAX - 1);
+    }
+}

--- a/stellar-lend/contracts/bridge/src/lib.rs
+++ b/stellar-lend/contracts/bridge/src/lib.rs
@@ -35,11 +35,40 @@ impl ValidatorSet {
 pub struct Bridge {
     pub epoch: u64,
     pub validators: ValidatorSet,
+    /// Maximum cumulative inbound value (in the bridge's native token unit,
+    /// matching the `i128` amount convention used elsewhere in this workspace)
+    /// that may be admitted within a single rolling window.
+    ///
+    /// A value of `0` means "no inbound" (fail-closed) — not "unlimited".
+    /// Defaults to `0` so a freshly constructed `Bridge` admits no inbound
+    /// value until an operator explicitly opts in via [`Bridge::set_inbound_cap`].
+    pub max_per_window: i128,
+    /// Length of the rolling inbound-value window, in ledger-time seconds
+    /// (e.g. `86_400` for a calendar-day window). Must be > 0 once configured.
+    pub window_size: u64,
+    /// Ledger time at which the current window began.
+    pub window_start: u64,
+    /// Cumulative inbound value admitted so far within `[window_start, window_start + window_size)`.
+    pub window_inbound_total: i128,
 }
 
+/// Default rolling window length: one day, in seconds.
+pub const DEFAULT_INBOUND_WINDOW_SECS: u64 = 86_400;
+
 impl Bridge {
+    /// Construct a new bridge. Inbound value transfer is **fail-closed by
+    /// default**: `max_per_window` starts at `0`, so [`Bridge::admit_inbound`]
+    /// rejects everything until [`Bridge::set_inbound_cap`] is called with a
+    /// non-zero cap.
     pub fn new(initial: ValidatorSet) -> Self {
-        Bridge { epoch: 0, validators: initial }
+        Bridge {
+            epoch: 0,
+            validators: initial,
+            max_per_window: 0,
+            window_size: DEFAULT_INBOUND_WINDOW_SECS,
+            window_start: 0,
+            window_inbound_total: 0,
+        }
     }
 
     /// Verify a quorum proof from the current validator set over the (new_set, epoch) payload
@@ -98,10 +127,86 @@ impl Bridge {
         }
         Ok(())
     }
+
+    /// Reconfigure the per-window inbound value cap and (re)start the
+    /// window fresh at `current_time`.
+    ///
+    /// `max_per_window == 0` is a valid, intentional configuration meaning
+    /// "no inbound" (fail-closed) — use a positive value to actually permit
+    /// inbound transfers. `window_size` must be greater than zero.
+    pub fn set_inbound_cap(&mut self, max_per_window: i128, window_size: u64, current_time: u64) -> Result<()> {
+        if max_per_window < 0 {
+            return Err(anyhow!("max_per_window must be >= 0"));
+        }
+        if window_size == 0 {
+            return Err(anyhow!("window_size must be > 0"));
+        }
+
+        self.max_per_window = max_per_window;
+        self.window_size = window_size;
+        self.window_start = current_time;
+        self.window_inbound_total = 0;
+        Ok(())
+    }
+
+    /// Roll the inbound-value window forward if `current_time` has moved
+    /// past the end of the current window. Resetting realigns the window to
+    /// start at `current_time` rather than stepping forward in fixed
+    /// `window_size` increments, so a bridge that sat idle for a long time
+    /// doesn't pay for that idle period with a stale, partially-consumed
+    /// window (see SECURITY_NOTES.md for the rationale).
+    fn roll_window_if_expired(&mut self, current_time: u64) {
+        let window_end = self.window_start.saturating_add(self.window_size);
+        if current_time >= window_end {
+            self.window_start = current_time;
+            self.window_inbound_total = 0;
+        }
+    }
+
+    /// Admit an inbound transfer of `amount` against the per-window inbound
+    /// value cap, tracked on rolling ledger time (not block count).
+    ///
+    /// Rejects (without mutating any state) if:
+    /// - `amount` is negative,
+    /// - the cap is configured as `0` (fail-closed — no inbound permitted
+    ///   regardless of amount), or
+    /// - admitting `amount` would push the window's cumulative inbound value
+    ///   above `max_per_window`.
+    ///
+    /// On success, `amount` is added to the current window's running total
+    /// and `Ok(())` is returned. Callers are expected to have already
+    /// validated validator quorum and inbound epoch separately — this check
+    /// is purely the value-cap defense-in-depth layer.
+    pub fn admit_inbound(&mut self, amount: i128, current_time: u64) -> Result<()> {
+        if amount < 0 {
+            return Err(anyhow!("inbound amount must be >= 0"));
+        }
+
+        if self.max_per_window == 0 {
+            return Err(anyhow!("inbound cap is zero (fail-closed): no inbound transfers permitted"));
+        }
+
+        self.roll_window_if_expired(current_time);
+
+        let new_total = self
+            .window_inbound_total
+            .checked_add(amount)
+            .ok_or_else(|| anyhow!("inbound window total overflow"))?;
+
+        if new_total > self.max_per_window {
+            return Err(anyhow!("inbound cap exceeded for current window"));
+        }
+
+        self.window_inbound_total = new_total;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod rotation_test;
+
+#[cfg(test)]
+mod inbound_cap_test;
 
 #[cfg(test)]
 mod tests {

--- a/stellar-lend/contracts/bridge/src/rotation_test.rs
+++ b/stellar-lend/contracts/bridge/src/rotation_test.rs
@@ -86,7 +86,6 @@ mod rotation_tests {
         let initial = validator_set_from(&kps);
         let mut bridge = Bridge::new(initial);
 
-        let new_kps = det_keypairs(3);
         // start indices after existing set to avoid overlap
         let new_kps: Vec<Keypair> = (10..13).map(det_keypair).collect();
         let new_set = validator_set_from(&new_kps);
@@ -459,7 +458,10 @@ mod rotation_tests {
         let mut bridge = Bridge::new(initial);
 
         let sets: Vec<(Vec<Keypair>, Vec<Keypair>)> = vec![
-            (kps_a.clone(), (10..13).map(det_keypair).collect()),
+            // `det_keypair` is deterministic, so regenerating kps_a's range is
+            // equivalent to cloning it — and ed25519-dalek::Keypair doesn't
+            // implement Clone, so we can't clone it directly.
+            ((0..3).map(det_keypair).collect(), (10..13).map(det_keypair).collect()),
             ((10..13).map(det_keypair).collect(), (20..23).map(det_keypair).collect()),
             ((20..23).map(det_keypair).collect(), (30..33).map(det_keypair).collect()),
         ];


### PR DESCRIPTION
Adds a configurable, rolling-ledger-time cap on cumulative inbound value to the bridge crate, as defense-in-depth alongside the existing validator-quorum and inbound-epoch checks (#1126).

- Bridge::set_inbound_cap(max_per_window, window_size, current_time): configures the cap and starts a fresh window. max_per_window == 0 is explicit fail-closed ("no inbound"), not "unlimited". window_size must be > 0.
- Bridge::admit_inbound(amount, current_time): checked-arithmetic admission against the cap. Rejects negative amounts, a zero cap, cap-exceeding amounts, and running-total overflow -- without mutating state on any rejection path.
- roll_window_if_expired: window resets are driven by ledger time (current_time), not call/block count, and realign to "now" on rollover rather than stepping forward in fixed increments, so a long idle period doesn't leave a stale partially-consumed window.
- Bridge::new() defaults to max_per_window == 0 (fail-closed by default) so inbound is disabled until explicitly configured.

Also includes two minimal, pre-existing-bug fixes discovered while getting this crate to compile/test at all (it isn't wired into CI and has no committed Cargo.lock):
- bridge/Cargo.toml: add an empty [workspace] table so the crate can be built/tested standalone (it isn't a member of the parent Soroban workspace, and cargo refuses to build it otherwise).
- rotation_test.rs: fix a compile error from calling .clone() on Vec<Keypair>, which ed25519-dalek 1.0.1 doesn't implement Clone for; regenerate deterministically instead. Also drops one dead, instantly shadowed local variable.

Tests: contracts/bridge/src/inbound_cap_test.rs, covering fail-closed default, explicit zero cap, under/at/over-cap, window reset on ledger time (including a long-idle-gap realignment case), reconfiguration mid-window, negative amounts, invalid set_inbound_cap parameters, and checked-arithmetic overflow. All 31 tests in the crate (12 new + 19 pre-existing) pass via `cargo test` run from contracts/bridge.

Docs: SECURITY_NOTES.md gets a new "Per-Window Inbound Value Cap" section (threat model, design rationale, coverage table). README.md points to it.

Note: I couldn't run cargo-tarpaulin in my environment (its lockfile needs a newer Cargo than was available), so coverage is asserted via manual branch mapping in SECURITY_NOTES.md rather than a generated report -- worth confirming with the project's own coverage tooling before merge.

Closes #1126

## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [x] New public functions have success-path and failure-path tests
- [x] All new error codes are reachable through a test
- [x] Zero/negative/boundary values tested for numeric inputs
- [x] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)
-   N/A — these are lending-contract-specific invariants (cross-asset views, repay semantics, interest ceiling). The bridge crate doesn't touch any of that.v

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)
-    N/A — this crate has no Soroban on-chain storage (env.storage()/DataKey) at all; Bridge is a plain in-memory Rust struct. No storage keys, migrations, or initialize entrypoint exist here.

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently
-     N/A — this crate doesn't use Soroban's event system; it's not currently wired into any deployed contract.

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
-    N/A at this layer — this crate has no Env/Address, so there's no caller-auth concept inside it. set_inbound_cap has no built-in access control of its own — whatever contract eventually wires this in (e.g., the hello-world bridge module) must gate who can call it, admin-only. Flagging for reviewer awareness since this is a real gap to close before production use.
- [ ] No new function bypasses the pause guard without justification
-     N/A — no pause concept in this crate.

**Arithmetic**
- [x] No unchecked arithmetic on untrusted values
- [x] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [x] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [x] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [x] No secrets or key material committed
