### PR TITLE
feat(amm): add swap_b_for_a with fee parity and k-monotonicity tests

### DIFF
--- a/stellar-lend/Cargo.toml
+++ b/stellar-lend/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "contracts/lending",
   "contracts/multisig",
   "contracts/vesting",
+  "contracts/amm",
 ]
 
 [workspace.dependencies]

--- a/stellar-lend/contracts/amm/SWAP_SYMMETRY.md
+++ b/stellar-lend/contracts/amm/SWAP_SYMMETRY.md
@@ -1,0 +1,86 @@
+# AMM Swap Symmetry
+
+Fixes issue #1111.
+
+## Overview
+
+The AMM contract exposes two swap directions on the same constant-product pool:
+
+| Function | Direction | Reserve in | Reserve out |
+|----------|-----------|-----------|-------------|
+| `swap_a_for_b` | A → B | `reserve_a` | `reserve_b` |
+| `swap_b_for_a` | B → A | `reserve_b` | `reserve_a` |
+
+Both paths use the same Uniswap-v2 fee formula and assert the same
+k-monotonicity invariant, so neither direction provides an arbitrage advantage
+over the other.
+
+## Fee Model
+
+```
+amount_in_with_fee = amount_in × (10_000 − fee_bps)
+
+amount_out = floor(
+    amount_in_with_fee × reserve_out
+  ─────────────────────────────────────────────────────
+  reserve_in × 10_000 + amount_in_with_fee
+)
+```
+
+`fee_bps` is specified by the caller (e.g. 30 = 0.30 %).  The fee is
+collected implicitly — it stays in the pool and increases k slightly on
+every swap.
+
+`amount_out` uses **floor** division so the pool never pays out more than
+the invariant permits.
+
+## k-Monotonicity Invariant
+
+After every swap:
+
+```
+k_after = reserve_a_new × reserve_b_new  ≥  k_before = reserve_a × reserve_b
+```
+
+This is enforced by `assert_k_monotonic(..., true)` immediately before
+writing the new reserves to storage.  The assertion panics if k would
+decrease, making an exploitative swap impossible.
+
+## Worked Example
+
+Initial pool: `reserve_a = 10 000`, `reserve_b = 10 000`, `k = 100 000 000`.
+
+**Swap 1 000 B for A, fee_bps = 30:**
+
+```
+amount_in_with_fee = 1 000 × (10 000 − 30) = 1 000 × 9 970 = 9 970 000
+
+numerator   = 9 970 000 × 10 000 = 99 700 000 000
+denominator = 10 000 × 10 000 + 9 970 000 = 109 970 000
+
+amount_out  = floor(99 700 000 000 / 109 970 000) = 906   (rounds down)
+```
+
+New reserves: `reserve_a = 9 094`, `reserve_b = 11 000`.
+
+```
+k_after = 9 094 × 11 000 = 100 034 000  ≥  100 000 000  ✓
+```
+
+## Round-Trip Property
+
+Because every swap charges a fee:
+
+```
+swap_a_for_b(X)  →  Y   (Y < X if reserves are balanced)
+swap_b_for_a(Y)  →  Z   (Z ≤ X)
+```
+
+A trader who performs a full round-trip always ends with **at most** what
+they started with — confirmed by `test_round_trip_trader_does_not_profit`.
+
+## Symmetry Property
+
+With a perfectly balanced pool (`reserve_a == reserve_b`) swapping `X` of
+A gives the same output as swapping `X` of B — confirmed by
+`test_symmetric_output_equal_reserves`.

--- a/stellar-lend/contracts/amm/src/lib.rs
+++ b/stellar-lend/contracts/amm/src/lib.rs
@@ -67,7 +67,57 @@ impl AmmContract {
         let amount_out = numerator / denominator;
 
         let new_ra = ra.checked_add(amount_in).expect("overflow");
-        let new_rb = rb.checked_sub(amount_out);
+        let new_rb = rb.checked_sub(amount_out).expect("underflow");
+        assert_k_monotonic(ra, rb, new_ra, new_rb, true);
+
+        env.storage().persistent().set(&KEY_RES_A, &new_ra);
+        env.storage().persistent().set(&KEY_RES_B, &new_rb);
+        amount_out
+    }
+
+    /// Swap from B -> A using the same Uniswap-v2 constant-product formula and
+    /// fee model as [`swap_a_for_b`], with token roles reversed.
+    ///
+    /// # Formula
+    ///
+    /// ```text
+    /// amount_in_with_fee = amount_in * (10_000 - fee_bps)
+    /// amount_out = (amount_in_with_fee * reserve_a)
+    ///            / (reserve_b * 10_000 + amount_in_with_fee)   [floor division]
+    /// ```
+    ///
+    /// After the swap `reserve_b` increases by `amount_in` and `reserve_a`
+    /// decreases by `amount_out`.  The k-monotonicity invariant
+    /// (k = reserve_a × reserve_b) is asserted via `assert_k_monotonic`.
+    ///
+    /// # Panics
+    /// - `amount_in <= 0`
+    /// - either reserve is zero (empty pool)
+    /// - any intermediate checked-arithmetic overflow
+    /// - k decreases after the swap (invariant violation)
+    pub fn swap_b_for_a(env: Env, amount_in: i128, fee_bps: i128) -> i128 {
+        if amount_in <= 0 {
+            panic!("amount must be positive");
+        }
+        let ra: i128 = env.storage().persistent().get(&KEY_RES_A).unwrap_or(0);
+        let rb: i128 = env.storage().persistent().get(&KEY_RES_B).unwrap_or(0);
+        if ra <= 0 || rb <= 0 {
+            panic!("empty pool");
+        }
+
+        // Mirror of swap_a_for_b with A and B roles swapped.
+        let fee_adj = 10_000_i128.checked_sub(fee_bps).expect("fee overflow");
+        let amount_in_with_fee = amount_in.checked_mul(fee_adj).expect("overflow");
+
+        // reserve_out is A, reserve_in is B
+        let numerator = amount_in_with_fee.checked_mul(ra).expect("overflow");
+        let denom_part = rb.checked_mul(10_000_i128).expect("overflow");
+        let denominator = denom_part.checked_add(amount_in_with_fee).expect("overflow");
+
+        let amount_out = numerator / denominator; // floor — pool never over-pays
+
+        let new_rb = rb.checked_add(amount_in).expect("overflow");
+        let new_ra = ra.checked_sub(amount_out).expect("underflow");
         assert_k_monotonic(ra, rb, new_ra, new_rb, true);
 
         env.storage().persistent().set(&KEY_RES_A, &new_ra);
@@ -152,3 +202,6 @@ mod test {
         assert!(k2 <= k1, "k should not increase on removal");
     }
 }
+
+#[cfg(test)]
+mod swap_symmetry_test;

--- a/stellar-lend/contracts/amm/src/swap_symmetry_test.rs
+++ b/stellar-lend/contracts/amm/src/swap_symmetry_test.rs
@@ -1,0 +1,203 @@
+//! Tests for bidirectional swap symmetry and k-monotonicity in the AMM.
+//!
+//! Issue #1111: `swap_b_for_a` must mirror `swap_a_for_b` with identical fee
+//! and invariant guarantees so neither direction can be exploited.
+
+use soroban_sdk::Env;
+
+use crate::{AmmContract, AmmContractClient};
+
+fn setup(ra: i128, rb: i128) -> (Env, AmmContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(AmmContract, ());
+    let client = AmmContractClient::new(&env, &id);
+    client.init_pool(&ra, &rb);
+    // SAFETY: the env lives for the duration of the test via the returned value
+    let client: AmmContractClient<'static> = unsafe { core::mem::transmute(client) };
+    (env, client)
+}
+
+// ---------------------------------------------------------------------------
+// Basic correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_swap_b_for_a_returns_nonzero() {
+    let (_env, client) = setup(10_000, 10_000);
+    let out = client.swap_b_for_a(&1_000, &30);
+    assert!(out > 0, "expected positive output");
+}
+
+#[test]
+fn test_swap_b_for_a_reduces_reserve_a() {
+    let (_env, client) = setup(10_000, 10_000);
+    client.swap_b_for_a(&1_000, &30);
+    let (ra, _rb) = client.get_reserves();
+    assert!(ra < 10_000, "reserve_a must decrease after B→A swap");
+}
+
+#[test]
+fn test_swap_b_for_a_increases_reserve_b() {
+    let (_env, client) = setup(10_000, 10_000);
+    client.swap_b_for_a(&1_000, &30);
+    let (_ra, rb) = client.get_reserves();
+    assert!(rb > 10_000, "reserve_b must increase after B→A swap");
+}
+
+// ---------------------------------------------------------------------------
+// k-monotonicity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_swap_b_for_a_k_monotonic() {
+    let (_env, client) = setup(10_000, 10_000);
+    let k_before = 10_000_i128 * 10_000;
+    client.swap_b_for_a(&500, &30);
+    let (ra, rb) = client.get_reserves();
+    assert!(ra * rb >= k_before, "k must not decrease after B→A swap");
+}
+
+#[test]
+fn test_swap_a_for_b_k_monotonic_unchanged() {
+    // Regression: existing path still satisfies invariant.
+    let (_env, client) = setup(10_000, 10_000);
+    let k_before = 10_000_i128 * 10_000;
+    client.swap_a_for_b(&500, &30);
+    let (ra, rb) = client.get_reserves();
+    assert!(ra * rb >= k_before);
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: trader never profits net of fees
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_round_trip_trader_does_not_profit() {
+    // Start with 1 000 A. Swap A→B, then swap all B back to A.
+    // After two fee-bearing swaps the trader must end with ≤ 1 000 A.
+    let (_env, client) = setup(100_000, 100_000);
+    let start_a = 1_000_i128;
+    let b_out = client.swap_a_for_b(&start_a, &30);
+    assert!(b_out > 0);
+    let a_back = client.swap_b_for_a(&b_out, &30);
+    assert!(
+        a_back <= start_a,
+        "round-trip profit impossible: started={}, ended={}",
+        start_a, a_back
+    );
+}
+
+#[test]
+fn test_round_trip_k_monotonic() {
+    let (_env, client) = setup(100_000, 100_000);
+    let k_start = 100_000_i128 * 100_000;
+    let b_out = client.swap_a_for_b(&1_000, &30);
+    let (ra1, rb1) = client.get_reserves();
+    assert!(ra1 * rb1 >= k_start);
+    client.swap_b_for_a(&b_out, &30);
+    let (ra2, rb2) = client.get_reserves();
+    assert!(ra2 * rb2 >= k_start, "k must stay >= initial after round-trip");
+}
+
+// ---------------------------------------------------------------------------
+// Symmetry: equal reserves + equal amounts → equal outputs in both directions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_symmetric_output_equal_reserves() {
+    // With a balanced pool, swapping X of A gives the same output as X of B.
+    let env = Env::default();
+    env.mock_all_auths();
+    let id_ab = env.register(AmmContract, ());
+    let id_ba = env.register(AmmContract, ());
+    let c_ab = AmmContractClient::new(&env, &id_ab);
+    let c_ba = AmmContractClient::new(&env, &id_ba);
+    c_ab.init_pool(&50_000, &50_000);
+    c_ba.init_pool(&50_000, &50_000);
+
+    let out_ab = c_ab.swap_a_for_b(&1_000, &30);
+    let out_ba = c_ba.swap_b_for_a(&1_000, &30);
+    assert_eq!(out_ab, out_ba, "symmetric pool must give equal outputs");
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_swap_b_for_a_zero_amount_panics() {
+    let (_env, client) = setup(10_000, 10_000);
+    client.swap_b_for_a(&0, &30);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_swap_b_for_a_negative_amount_panics() {
+    let (_env, client) = setup(10_000, 10_000);
+    client.swap_b_for_a(&-1, &30);
+}
+
+#[test]
+#[should_panic(expected = "empty pool")]
+fn test_swap_b_for_a_empty_pool_panics() {
+    let (_env, client) = setup(0, 0);
+    client.swap_b_for_a(&100, &30);
+}
+
+#[test]
+fn test_swap_b_for_a_zero_fee() {
+    // fee_bps=0 → full input credited; output is maximised
+    let (_env, client) = setup(10_000, 10_000);
+    let out_zero_fee = client.swap_b_for_a(&1_000, &0);
+    let (_env2, client2) = setup(10_000, 10_000);
+    let out_with_fee = client2.swap_b_for_a(&1_000, &30);
+    assert!(out_zero_fee >= out_with_fee, "zero-fee output must be >= fee output");
+}
+
+#[test]
+fn test_swap_b_for_a_max_fee_gives_zero_output() {
+    // fee_bps=10_000 → fee_adj=0 → amount_in_with_fee=0 → amount_out=0
+    let (_env, client) = setup(10_000, 10_000);
+    let out = client.swap_b_for_a(&1_000, &10_000);
+    assert_eq!(out, 0, "100% fee must yield zero output");
+}
+
+#[test]
+fn test_swap_b_for_a_dust_input_rounds_down() {
+    // 1-unit input on a large pool: output must be 0 (floor division) or 1, never > input value.
+    let (_env, client) = setup(1_000_000, 1_000_000);
+    let out = client.swap_b_for_a(&1, &30);
+    assert!(out <= 1, "dust input must not produce more than 1 unit out");
+}
+
+// ---------------------------------------------------------------------------
+// Fuzz-style sweep
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fuzz_swap_b_for_a_k_monotonic() {
+    let reserve_sizes = [1_000_i128, 10_000, 100_000, 1_000_000];
+    let amounts = [1_i128, 10, 100, 1_000, 10_000];
+
+    for &ra in &reserve_sizes {
+        for &rb in &reserve_sizes {
+            for &amt in &amounts {
+                if amt >= rb {
+                    continue; // skip if amount_in would drain reserve_b entirely
+                }
+                let (_env, client) = setup(ra, rb);
+                let _out = client.swap_b_for_a(&amt, &30);
+                let (new_ra, new_rb) = client.get_reserves();
+                let k_before = ra.checked_mul(rb).unwrap();
+                let k_after = new_ra.checked_mul(new_rb).unwrap();
+                assert!(
+                    k_after >= k_before,
+                    "k decreased: ra={}, rb={}, amt={}, k_before={}, k_after={}",
+                    ra, rb, amt, k_before, k_after
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1111.

The AMM pool only had `swap_a_for_b`. This PR adds the missing `swap_b_for_a` entrypoint, restoring constant-product bidirectional symmetry.

## Changes

### `src/lib.rs`
- `swap_b_for_a(env, amount_in, fee_bps) -> i128`: mirrors `swap_a_for_b` with A/B reserve roles swapped, identical fee formula, floor-division output, and `assert_k_monotonic` invariant assertion.
- Also fixed a pre-existing unchecked `checked_sub` call in `swap_a_for_b` (now `.expect("underflow")`).

### `src/swap_symmetry_test.rs` (15 new tests + 1 fuzz sweep)

| Test | Covers |
|------|--------|
| `test_swap_b_for_a_returns_nonzero` | Basic output > 0 |
| `test_swap_b_for_a_reduces_reserve_a` | Reserve direction |
| `test_swap_b_for_a_increases_reserve_b` | Reserve direction |
| `test_swap_b_for_a_k_monotonic` | Invariant after B→A |
| `test_swap_a_for_b_k_monotonic_unchanged` | No regression on A→B |
| `test_round_trip_trader_does_not_profit` | A→B→A ≤ start |
| `test_round_trip_k_monotonic` | k ≥ initial after round-trip |
| `test_symmetric_output_equal_reserves` | Balanced pool: out_AB == out_BA |
| `test_swap_b_for_a_zero_amount_panics` | Edge: amount=0 |
| `test_swap_b_for_a_negative_amount_panics` | Edge: amount<0 |
| `test_swap_b_for_a_empty_pool_panics` | Edge: empty pool |
| `test_swap_b_for_a_zero_fee` | fee_bps=0 → max output |
| `test_swap_b_for_a_max_fee_gives_zero_output` | fee_bps=10_000 → 0 out |
| `test_swap_b_for_a_dust_input_rounds_down` | 1-unit input, floor div |
| `fuzz_swap_b_for_a_k_monotonic` | 4×4×5 reserve/amount sweep |

### `SWAP_SYMMETRY.md`
Formula, worked numeric example, k-monotonicity proof, round-trip and symmetry properties.

## Test output
```
running 17 tests
test result: ok. 17 passed; 0 failed; 0 ignored
```