### PR TITLE
test(vesting): property-based monotonicity and principal-bound invari…

### DIFF
--- a/stellar-lend/Cargo.lock
+++ b/stellar-lend/Cargo.lock
@@ -1887,6 +1887,9 @@ dependencies = [
 [[package]]
 name = "stellarlend-vesting"
 version = "0.1.0"
+dependencies = [
+ "proptest",
+]
 
 [[package]]
 name = "strsim"

--- a/stellar-lend/contracts/vesting/Cargo.toml
+++ b/stellar-lend/contracts/vesting/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/stellar-lend/contracts/vesting/VESTING_INVARIANTS.md
+++ b/stellar-lend/contracts/vesting/VESTING_INVARIANTS.md
@@ -1,0 +1,69 @@
+# Vesting Invariants
+
+## Formula
+
+`Grant::vested_at(now)` computes the vested amount at Unix timestamp `now`:
+
+```
+cliff_end = start_seconds + cliff_seconds
+
+if now < cliff_end:
+    vested = 0
+elif duration_seconds == 0:
+    vested = total
+else:
+    end = start_seconds + duration_seconds
+    effective = min(now, end)
+    elapsed = effective - start_seconds
+    vested = (total * elapsed) / duration_seconds
+```
+
+## Worked Example
+
+A grant with `total = 1_000`, `start_seconds = 1_000`,
+`cliff_seconds = 200`, `duration_seconds = 800`:
+
+| `now` | `vested_at` | Notes |
+|-------|-------------|-------|
+| 1_199 | 0 | Before cliff end (1_200) |
+| 1_200 | 0 | Exactly at cliff end — `elapsed = 0` |
+| 1_400 | 250 | 200 s after cliff: `(1000 * 200) / 800` |
+| 1_600 | 500 | 400 s after cliff |
+| 1_800 | 750 | 600 s after cliff |
+| 2_000 | 1_000 | Full duration elapsed |
+| 9_999 | 1_000 | Capped by `end` |
+
+## Invariants (verified by proptest)
+
+### 1. Monotonicity
+
+For any grant `g` and timestamps `t1 ≤ t2`:
+
+```
+g.vested_at(t1) ≤ g.vested_at(t2)
+```
+
+The vested amount is a non-decreasing function of time. This is guaranteed because
+`elapsed` is monotonic in `now` (capped at `end`) and the division is a
+positive-scalar multiplication.
+
+### 2. Principal bound
+
+For any grant `g` and timestamp `t`:
+
+```
+g.vested_at(t) ≤ g.total
+```
+
+The vested amount never exceeds the grant principal. This holds because the numerator
+`total * elapsed ≤ total * duration_seconds`, so the quotient is at most `total`.
+
+### 3. Cliff zero
+
+For any grant `g` with `cliff_seconds > 0` and any `now < start_seconds + cliff_seconds`:
+
+```
+g.vested_at(now) = 0
+```
+
+No tokens vest before the cliff boundary.

--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -229,4 +229,7 @@ mod tests {
 }
 
 #[cfg(test)]
+mod vested_at_proptest;
+
+#[cfg(test)]
 mod vesting_views_test;

--- a/stellar-lend/contracts/vesting/src/vested_at_proptest.rs
+++ b/stellar-lend/contracts/vesting/src/vested_at_proptest.rs
@@ -1,0 +1,78 @@
+use proptest::prelude::*;
+
+use super::Grant;
+
+/// Generates a `Grant` with bounded fields that avoid arithmetic overflow in
+/// `Grant::vested_at`. Times are capped at `MAX_TIME` and `total` at
+/// `MAX_PRINCIPAL` so that the intermediate multiplication
+/// `total * elapsed` always fits in `u128`.
+const MAX_TIME: u64 = 1_000_000_000;
+const MAX_PRINCIPAL: u128 = 1_000_000_000_000_000;
+
+fn any_grant() -> impl Strategy<Value = Grant> {
+    (
+        any::<u128>().prop_map(|v| v % MAX_PRINCIPAL),
+        0..=MAX_TIME,
+        0..=MAX_TIME,
+        0..=MAX_TIME,
+    )
+        .prop_filter("start + cliff must not overflow u64", |&(_, s, _, c)| {
+            s.checked_add(c).is_some()
+        })
+        .prop_map(|(total, start, duration, cliff)| Grant {
+            grantee: "proptest".into(),
+            total,
+            claimed: 0,
+            released: 0,
+            start_seconds: start,
+            duration_seconds: duration,
+            cliff_seconds: cliff,
+            revoked: false,
+        })
+}
+
+proptest! {
+    #[test]
+    fn vested_at_never_exceeds_principal(
+        grant in any_grant(),
+        now in 0..=MAX_TIME * 2,
+    ) {
+        let v = grant.vested_at(now);
+        assert!(
+            v <= grant.total,
+            "vested_at({now}) = {v} > total = {} on grant={grant:?}",
+            grant.total,
+        );
+    }
+
+    #[test]
+    fn vested_at_is_monotonic(
+        grant in any_grant(),
+        t1 in 0..=MAX_TIME * 2,
+        t2 in 0..=MAX_TIME * 2,
+    ) {
+        prop_assume!(t1 <= t2);
+        let v1 = grant.vested_at(t1);
+        let v2 = grant.vested_at(t2);
+        assert!(
+            v1 <= v2,
+            "vested_at({t1}) = {v1} > vested_at({t2}) = {v2} for grant={grant:?}",
+        );
+    }
+
+    #[test]
+    fn vested_at_zero_before_cliff(
+        grant in any_grant(),
+    ) {
+        let cliff_end = match grant.start_seconds.checked_add(grant.cliff_seconds) {
+            Some(ts) if ts > 0 => ts,
+            _ => return Ok(()),
+        };
+        let before = cliff_end - 1;
+        assert_eq!(
+            grant.vested_at(before),
+            0,
+            "vested_at({before}) should be 0 before cliff_end={cliff_end} for grant={grant:?}",
+        );
+    }
+}


### PR DESCRIPTION
Closes #1133

Adds proptest coverage asserting three vesting invariants:

1. **Monotonicity** — `vested_at(t1) ≤ vested_at(t2)` for `t1 ≤ t2`
2. **Principal bound** — `vested_at(t) ≤ total` for all timestamps
3. **Cliff zero** — `vested_at(t) == 0` for `t < start + cliff`

### Changes

- `contracts/vesting/Cargo.toml` — add `proptest` dev-dependency
- `contracts/vesting/src/vested_at_proptest.rs` — three proptests covering random grants and timestamps with bounded values to avoid arithmetic overflow
- `contracts/vesting/src/lib.rs` — register new test module
- `contracts/vesting/VESTING_INVARIANTS.md` — documents the vesting formula, worked example, and each invariant

### Verification

`cargo test -p stellarlend-vesting` — all 11 tests pass (8 existing + 3 new proptests).