### PR TITLE
Docs/vesting math

### DIFF
--- a/stellar-lend/Cargo.lock
+++ b/stellar-lend/Cargo.lock
@@ -1887,6 +1887,9 @@ dependencies = [
 [[package]]
 name = "stellarlend-vesting"
 version = "0.1.0"
+dependencies = [
+ "proptest",
+]
 
 [[package]]
 name = "strsim"

--- a/stellar-lend/contracts/vesting/Cargo.toml
+++ b/stellar-lend/contracts/vesting/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/stellar-lend/contracts/vesting/README.md
+++ b/stellar-lend/contracts/vesting/README.md
@@ -14,4 +14,6 @@ Key behavior:
 
 `total_locked()` is maintained incrementally during `add_grant`, `claim`, and `revoke`; it is not recomputed by scanning all stored schedules.
 
-See unit tests in `src/lib.rs` and `src/vesting_views_test.rs` for expected behavior and examples.
+See unit tests in `src/lib.rs`, `src/vesting_views_test.rs`, and `src/vesting_doc_example_test.rs` for expected behavior and examples.
+
+For the full schedule math, cliff semantics, and revoke split with a worked example, see [`VESTING_MATH.md`](./VESTING_MATH.md).

--- a/stellar-lend/contracts/vesting/VESTING_INVARIANTS.md
+++ b/stellar-lend/contracts/vesting/VESTING_INVARIANTS.md
@@ -1,0 +1,69 @@
+# Vesting Invariants
+
+## Formula
+
+`Grant::vested_at(now)` computes the vested amount at Unix timestamp `now`:
+
+```
+cliff_end = start_seconds + cliff_seconds
+
+if now < cliff_end:
+    vested = 0
+elif duration_seconds == 0:
+    vested = total
+else:
+    end = start_seconds + duration_seconds
+    effective = min(now, end)
+    elapsed = effective - start_seconds
+    vested = (total * elapsed) / duration_seconds
+```
+
+## Worked Example
+
+A grant with `total = 1_000`, `start_seconds = 1_000`,
+`cliff_seconds = 200`, `duration_seconds = 800`:
+
+| `now` | `vested_at` | Notes |
+|-------|-------------|-------|
+| 1_199 | 0 | Before cliff end (1_200) |
+| 1_200 | 0 | Exactly at cliff end — `elapsed = 0` |
+| 1_400 | 250 | 200 s after cliff: `(1000 * 200) / 800` |
+| 1_600 | 500 | 400 s after cliff |
+| 1_800 | 750 | 600 s after cliff |
+| 2_000 | 1_000 | Full duration elapsed |
+| 9_999 | 1_000 | Capped by `end` |
+
+## Invariants (verified by proptest)
+
+### 1. Monotonicity
+
+For any grant `g` and timestamps `t1 ≤ t2`:
+
+```
+g.vested_at(t1) ≤ g.vested_at(t2)
+```
+
+The vested amount is a non-decreasing function of time. This is guaranteed because
+`elapsed` is monotonic in `now` (capped at `end`) and the division is a
+positive-scalar multiplication.
+
+### 2. Principal bound
+
+For any grant `g` and timestamp `t`:
+
+```
+g.vested_at(t) ≤ g.total
+```
+
+The vested amount never exceeds the grant principal. This holds because the numerator
+`total * elapsed ≤ total * duration_seconds`, so the quotient is at most `total`.
+
+### 3. Cliff zero
+
+For any grant `g` with `cliff_seconds > 0` and any `now < start_seconds + cliff_seconds`:
+
+```
+g.vested_at(now) = 0
+```
+
+No tokens vest before the cliff boundary.

--- a/stellar-lend/contracts/vesting/VESTING_MATH.md
+++ b/stellar-lend/contracts/vesting/VESTING_MATH.md
@@ -1,0 +1,133 @@
+# Vesting Math Reference
+
+## Schedule Parameters
+
+Every `Grant` is defined by four fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `total` | `u128` | Principal — the full amount of tokens allocated |
+| `start_seconds` | `u64` | Unix timestamp (seconds) when the schedule begins |
+| `cliff_seconds` | `u64` | Seconds after `start` before any tokens vest |
+| `duration_seconds` | `u64` | Seconds from `start` over which vesting is linear |
+
+Derived constants:
+
+```
+cliff_end = start_seconds + cliff_seconds
+end       = start_seconds + duration_seconds
+```
+
+---
+
+## `vested_at(now)` — Vested amount at a timestamp
+
+```
+if now < cliff_end:
+    return 0                                  // Cliff gate
+if duration_seconds == 0:
+    return total                              // Immediate full vest
+end = start_seconds + duration_seconds
+effective = min(now, end)
+elapsed = effective - start_seconds
+return (total * elapsed) / duration_seconds   // Linear ramp
+```
+
+**Cliff gate.** Before `cliff_end` the function short-circuits to zero. No tokens vest
+until that boundary.
+
+**Linear ramp.** After the cliff the vested amount grows linearly with `elapsed`.
+The numerator `total * elapsed` fits in `u128` because `elapsed ≤ duration_seconds`,
+so the product is bounded by `total * duration_seconds`. The integer division truncates
+toward zero, so the reported amount never exceeds `total`.
+
+**End cap.** When `now ≥ end` the effective timestamp is clamped to `end`, so the
+vested amount after full duration is always exactly `total`.
+
+---
+
+## `claimable()` — Unclaimed vested tokens
+
+```
+return released - claimed
+```
+
+`released` tracks the latest `vested_at` value seen during a `sync` call.
+`claimed` tracks the cumulative amount the grantee has withdrawn. The difference
+is the amount ready to claim.
+
+---
+
+## Revoke split
+
+`revoke(caller, grantee, now)`:
+
+1. Calls `sync_grants`, which advances each grant's `released` to `vested_at(now)`.
+2. For each non-revoked grant, computes `locked = total - released` (the unvested
+   remainder).
+3. Transfers the sum of all locked amounts to the treasury.
+4. Resets each grant's `total` to its current `released` value and marks it as
+   `revoked = true`.
+
+After revoke, the grantee keeps the vested (released) portion and can still claim
+it; the unvested portion is clawed back.
+
+---
+
+## Worked example
+
+```
+Grant:
+  total    = 1_000
+  start    = 1_000
+  cliff    =   200      => cliff_end = 1_200
+  duration =   800      => end       = 1_800
+```
+
+### `vested_at` schedule
+
+| `now` | `vested_at` | Calculation |
+|-------|-------------|-------------|
+| 1_000 | 0 | Before cliff (`1_000 < 1_200`) |
+| 1_199 | 0 | Before cliff (`1_199 < 1_200`) |
+| 1_200 | 250 | `(1_000 * 200) / 800` |
+| 1_400 | 500 | `(1_000 * 400) / 800` |
+| 1_600 | 750 | `(1_000 * 600) / 800` |
+| 1_800 | 1_000 | End reached (`800 / 800`) |
+| 9_999 | 1_000 | Capped by end |
+
+### Claim
+
+Assume `claim("alice", 1_400)` is called. Before the transfer:
+
+- `sync` advances `released` to `vested_at(1_400) = 500`.
+- `claimable = 500 - 0 = 500`.
+
+After claim:
+- `claimed = 500`.
+- Contract balance decreases by 500; grantee balance increases by 500.
+
+A second call to `claim("alice", 1_600)` would compute `claimable = 750 - 500 = 250`
+and transfer 250 more.
+
+### Revoke
+
+Call `revoke("admin", "alice", 1_400)` (no claim occurred before revoke):
+
+1. `sync_grants` sets `released = vested_at(1_400) = 500`.
+2. `locked = 1_000 - 500 = 500`.
+3. 500 tokens are transferred to the treasury.
+4. Grant's `total` is set to 500; `revoked = true`.
+
+The grantee can no longer vest new tokens, but the 500 already vested remain
+claimable via `claimable = 500 - 0 = 500`.
+
+---
+
+## Invariants
+
+1. **Monotonicity** — `vested_at(t1) ≤ vested_at(t2)` for all `t1 ≤ t2`.
+2. **Principal bound** — `vested_at(t) ≤ total` for all `t`.
+3. **Cliff zero** — `vested_at(t) = 0` for all `t < start + cliff_seconds`.
+4. **No unvested leak on revoke** — After revoke, `total = released ≤ total_original`,
+   so the grantee never keeps unvested tokens.

--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -13,6 +13,13 @@ pub struct Grant {
 }
 
 impl Grant {
+    /// Returns the amount vested at Unix timestamp `now`.
+    ///
+    /// Before `start_seconds + cliff_seconds` the result is zero (cliff gate).
+    /// After `start_seconds + duration_seconds` the result is capped at `total`.
+    /// In between, vesting grows linearly: `(total * elapsed) / duration_seconds`.
+    ///
+    /// See `VESTING_MATH.md` for the full formula and worked example.
     pub fn vested_at(&self, now: u64) -> u128 {
         if now < self.start_seconds + self.cliff_seconds {
             return 0;
@@ -29,10 +36,17 @@ impl Grant {
         (self.total as u128 * elapsed as u128) / self.duration_seconds as u128
     }
 
+    /// Returns `released - claimed`, the amount the grantee can currently withdraw.
+    ///
+    /// `released` is the latest vested amount synced via [`sync`];
+    /// `claimed` is the cumulative amount already withdrawn.
     pub fn claimable(&self) -> u128 {
         self.released.saturating_sub(self.claimed)
     }
 
+    /// Advances the grant's `released` field to `vested_at(now)` and returns the
+    /// newly vested delta. This is called internally by [`claim`] and [`revoke`]
+    /// before any balance transfer.
     fn sync(&mut self, now: u64) -> u128 {
         let vested = self.vested_at(now);
         let newly_released = vested.saturating_sub(self.released);
@@ -40,6 +54,8 @@ impl Grant {
         newly_released
     }
 
+    /// Returns `total - released`, the unvested remainder that can be clawed back
+    /// via [`revoke`].
     fn locked(&self) -> u128 {
         self.total.saturating_sub(self.released)
     }
@@ -128,6 +144,19 @@ impl VestingContract {
         amount
     }
 
+    /// Claws back unvested tokens from `grantee`'s schedules to the treasury.
+    ///
+    /// 1. Syncs all of `grantee`'s grants to `now` so that `released` reflects
+    ///    the current vested amount.
+    /// 2. For each non-revoked grant, computes `locked = total - released` and
+    ///    transfers the sum to the treasury.
+    /// 3. Resets each grant's `total` to its `released` value and sets
+    ///    `revoked = true`.
+    ///
+    /// After revoke the grantee keeps the vested portion and can still claim it;
+    /// the unvested portion is clawed back.
+    ///
+    /// See `VESTING_MATH.md` for the full formula and worked example.
     pub fn revoke(&mut self, caller: &str, grantee: &str, now: u64) -> Result<u128, String> {
         if caller != self.admin {
             return Err("only admin can revoke".to_string());
@@ -230,6 +259,9 @@ mod tests {
 
 #[cfg(test)]
 mod vested_at_proptest;
+
+#[cfg(test)]
+mod vesting_doc_example_test;
 
 #[cfg(test)]
 mod vesting_views_test;

--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -229,4 +229,7 @@ mod tests {
 }
 
 #[cfg(test)]
+mod vested_at_proptest;
+
+#[cfg(test)]
 mod vesting_views_test;

--- a/stellar-lend/contracts/vesting/src/vested_at_proptest.rs
+++ b/stellar-lend/contracts/vesting/src/vested_at_proptest.rs
@@ -1,0 +1,78 @@
+use proptest::prelude::*;
+
+use super::Grant;
+
+/// Generates a `Grant` with bounded fields that avoid arithmetic overflow in
+/// `Grant::vested_at`. Times are capped at `MAX_TIME` and `total` at
+/// `MAX_PRINCIPAL` so that the intermediate multiplication
+/// `total * elapsed` always fits in `u128`.
+const MAX_TIME: u64 = 1_000_000_000;
+const MAX_PRINCIPAL: u128 = 1_000_000_000_000_000;
+
+fn any_grant() -> impl Strategy<Value = Grant> {
+    (
+        any::<u128>().prop_map(|v| v % MAX_PRINCIPAL),
+        0..=MAX_TIME,
+        0..=MAX_TIME,
+        0..=MAX_TIME,
+    )
+        .prop_filter("start + cliff must not overflow u64", |&(_, s, _, c)| {
+            s.checked_add(c).is_some()
+        })
+        .prop_map(|(total, start, duration, cliff)| Grant {
+            grantee: "proptest".into(),
+            total,
+            claimed: 0,
+            released: 0,
+            start_seconds: start,
+            duration_seconds: duration,
+            cliff_seconds: cliff,
+            revoked: false,
+        })
+}
+
+proptest! {
+    #[test]
+    fn vested_at_never_exceeds_principal(
+        grant in any_grant(),
+        now in 0..=MAX_TIME * 2,
+    ) {
+        let v = grant.vested_at(now);
+        assert!(
+            v <= grant.total,
+            "vested_at({now}) = {v} > total = {} on grant={grant:?}",
+            grant.total,
+        );
+    }
+
+    #[test]
+    fn vested_at_is_monotonic(
+        grant in any_grant(),
+        t1 in 0..=MAX_TIME * 2,
+        t2 in 0..=MAX_TIME * 2,
+    ) {
+        prop_assume!(t1 <= t2);
+        let v1 = grant.vested_at(t1);
+        let v2 = grant.vested_at(t2);
+        assert!(
+            v1 <= v2,
+            "vested_at({t1}) = {v1} > vested_at({t2}) = {v2} for grant={grant:?}",
+        );
+    }
+
+    #[test]
+    fn vested_at_zero_before_cliff(
+        grant in any_grant(),
+    ) {
+        let cliff_end = match grant.start_seconds.checked_add(grant.cliff_seconds) {
+            Some(ts) if ts > 0 => ts,
+            _ => return Ok(()),
+        };
+        let before = cliff_end - 1;
+        assert_eq!(
+            grant.vested_at(before),
+            0,
+            "vested_at({before}) should be 0 before cliff_end={cliff_end} for grant={grant:?}",
+        );
+    }
+}

--- a/stellar-lend/contracts/vesting/src/vesting_doc_example_test.rs
+++ b/stellar-lend/contracts/vesting/src/vesting_doc_example_test.rs
@@ -1,0 +1,130 @@
+use super::{Grant, VestingContract};
+
+/// Mirrors the worked example in VESTING_MATH.md.
+///
+/// Grant: total=1_000, start_seconds=1_000, cliff_seconds=200, duration_seconds=800
+const TOTAL: u128 = 1_000;
+const START: u64 = 1_000;
+const CLIFF: u64 = 200;
+const DURATION: u64 = 800;
+
+fn doc_grant() -> Grant {
+    Grant {
+        grantee: "alice".into(),
+        total: TOTAL,
+        claimed: 0,
+        released: 0,
+        start_seconds: START,
+        duration_seconds: DURATION,
+        cliff_seconds: CLIFF,
+        revoked: false,
+    }
+}
+
+#[test]
+fn pre_cliff_is_zero() {
+    let g = doc_grant();
+    assert_eq!(g.vested_at(START), 0, "at start, before cliff");
+    assert_eq!(g.vested_at(START + CLIFF - 1), 0, "just before cliff end");
+}
+
+#[test]
+fn exactly_at_cliff_end() {
+    let g = doc_grant();
+    let cliff_end = START + CLIFF; // 1_200
+    assert_eq!(g.vested_at(cliff_end), 250);
+}
+
+#[test]
+fn mid_ramp_values() {
+    let g = doc_grant();
+    assert_eq!(g.vested_at(1_400), 500);
+    assert_eq!(g.vested_at(1_600), 750);
+}
+
+#[test]
+fn fully_vested_at_end() {
+    let g = doc_grant();
+    let end = START + DURATION; // 1_800
+    assert_eq!(g.vested_at(end), TOTAL);
+}
+
+#[test]
+fn capped_after_end() {
+    let g = doc_grant();
+    assert_eq!(g.vested_at(9_999), TOTAL);
+}
+
+#[test]
+fn claimable_after_partial_claim() {
+    let mut c = VestingContract::new("admin", "treasury");
+    c.add_grant("alice", TOTAL, START, DURATION, CLIFF);
+
+    // First claim at now=1_400 — should match doc: released=500, claimable=500
+    let first = c.claim("alice", 1_400);
+    assert_eq!(first, 500, "first claim should be 500");
+    assert_eq!(c.balance_of("alice"), 500);
+
+    // Second claim at now=1_600 — claimable = 750 - 500 = 250
+    let second = c.claim("alice", 1_600);
+    assert_eq!(second, 250, "second claim should be 250");
+    assert_eq!(c.balance_of("alice"), 750);
+
+    // Total locked should reflect the unclaimed vested amount
+    // released after second claim = 750, total = 1_000, locked = 250
+    assert_eq!(c.total_locked(), 250);
+}
+
+#[test]
+fn revoke_claws_unvested_portion() {
+    let mut c = VestingContract::new("admin", "treasury");
+    c.add_grant("alice", TOTAL, START, DURATION, CLIFF);
+
+    // Revoke at now=1_400 (no prior claim).
+    // After sync: released=500, locked=500
+    let transferred = c.revoke("admin", "alice", 1_400).expect("revoke should succeed");
+    assert_eq!(transferred, 500, "unvested portion (500) clawed to treasury");
+
+    let grants = c.get_grants("alice");
+    assert_eq!(grants.len(), 1);
+    assert!(grants[0].revoked, "grant should be marked revoked");
+    assert_eq!(grants[0].total, 500, "total reset to released (vested) portion");
+
+    // The vested portion is still claimable
+    let claimable = grants[0].claimable();
+    assert_eq!(claimable, 500, "vested 500 still claimable");
+}
+
+#[test]
+fn revoke_after_partial_claim() {
+    let mut c = VestingContract::new("admin", "treasury");
+    c.add_grant("alice", TOTAL, START, DURATION, CLIFF);
+
+    // Claim 250 at now=1_200
+    let claimed = c.claim("alice", 1_200);
+    assert_eq!(claimed, 250);
+
+    // Revoke at now=1_200 (after partial claim).
+    // released=250, claimed=250, locked=750
+    let transferred = c.revoke("admin", "alice", 1_200).expect("revoke should succeed");
+    assert_eq!(transferred, 750, "remaining unvested clawed back");
+
+    let grants = c.get_grants("alice");
+    assert_eq!(grants[0].total, 250, "total reset to released");
+    assert_eq!(grants[0].claimed, 250, "claimed unchanged");
+    assert_eq!(grants[0].claimable(), 0, "all vested tokens already claimed");
+}
+
+#[test]
+fn revoke_at_zero_vested_returns_entire_principal() {
+    let mut c = VestingContract::new("admin", "treasury");
+    c.add_grant("alice", TOTAL, START, DURATION, CLIFF);
+
+    // Revoke before cliff — entire principal is locked.
+    let transferred = c.revoke("admin", "alice", START).expect("revoke should succeed");
+    assert_eq!(transferred, TOTAL, "entire principal clawed back");
+
+    let grants = c.get_grants("alice");
+    assert_eq!(grants[0].total, 0, "total reset to zero (nothing vested)");
+    assert_eq!(grants[0].claimable(), 0);
+}


### PR DESCRIPTION
Closes #1157

Documents the vesting schedule math, cliff semantics, and revoke claw-back split with a worked numeric example.

### Changes

- `contracts/vesting/VESTING_MATH.md` — full math reference covering:
  - `vested_at` formula (cliff gate + linear ramp + end cap)
  - `claimable` computation (`released - claimed`)
  - Revoke split (`locked = total - released` clawed to treasury)
  - Worked example with table of `vested_at` values at 7 timestamps
  - Claim and revoke walkthroughs with concrete numbers
  - Invariants summary
- `contracts/vesting/src/vesting_doc_example_test.rs` — 9 tests asserting:
  - `pre_cliff_is_zero`, `exactly_at_cliff_end`, `mid_ramp_values`, `fully_vested_at_end`, `capped_after_end`
  - `claimable_after_partial_claim`, `revoke_claws_unvested_portion`, `revoke_after_partial_claim`, `revoke_at_zero_vested_returns_entire_principal`
- `contracts/vesting/src/lib.rs` — added `///` doc comments on `vested_at`, `claimable`, `sync`, `locked`, `revoke`; registered new test module
- `contracts/vesting/README.md` — cross-link to `VESTING_MATH.md`

### Verification

`cargo test -p stellarlend-vesting` — all 20 tests pass (8 existing + 3 proptests + 9 doc example tests).