### PR TITLE
Describe your changes

### DIFF
--- a/stellar-lend/contracts/hello-world/src/cross_asset.rs
+++ b/stellar-lend/contracts/hello-world/src/cross_asset.rs
@@ -390,6 +390,24 @@ pub fn update_asset_price(
     Ok(())
 }
 
+/// Return seconds since the asset price was last updated.
+///
+/// Returns `Ok(None)` when the asset exists but no price update timestamp
+/// has been recorded yet.
+pub fn get_asset_price_age(
+    env: &Env,
+    asset: Option<Address>,
+) -> Result<Option<u64>, CrossAssetError> {
+    let key = asset_key(asset);
+    let cfg = load_config(env, &key)?;
+
+    if cfg.last_price_update == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(env.ledger().timestamp().saturating_sub(cfg.last_price_update)))
+}
+
 /// Return the configuration for a given asset.
 pub fn get_asset_config_by_address(
     env: &Env,


### PR DESCRIPTION
**Title**

feat(cross-asset): expose per-asset price age getter

**Description**

## Summary

* Added a read-only getter for per-asset price age.
* Exposed the getter through `lib.rs`.
* Added the necessary updates to support querying the age of the latest asset price.

## Type of change

* [ ] Bug fix
* [x] New feature / functionality
* [ ] Refactor (no functional change)
* [ ] Documentation only
* [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

### Functional tests

* [ ] New public functions have success-path and failure-path tests
* [ ] All new error codes are reachable through a test
* [ ] Zero/negative/boundary values tested for numeric inputs

### Notes

* Added a read-only API for retrieving the age of an asset's latest price update.
* No existing public API behavior was intentionally changed.
  

Closes #1153 