### PR TITLE
feat(oracle): expose get_pool_twap_price view over the AMM TWAP fallback

### DIFF
--- a/stellar-lend/contracts/hello-world/docs/interface_quick_reference.md
+++ b/stellar-lend/contracts/hello-world/docs/interface_quick_reference.md
@@ -1,0 +1,95 @@
+# Interface Quick Reference
+
+Read-only views exposed by the `hello-world` contract for integrators,
+liquidation bots, and monitoring tools. Each entry documents the formula
+and a worked example so a caller can sanity-check the value they get back
+without reading the implementation.
+
+## `get_pool_twap_price(asset, window_secs) -> Option<u128>`
+
+Source: [`oracle.rs`](../src/oracle.rs) (`get_pool_twap_price`), backed by
+[`amm_twap.rs`](../src/amm_twap.rs) (`get_twap`, `has_window_coverage`).
+Contract entrypoint: [`lib.rs`](../src/lib.rs).
+
+### What it's for
+
+The oracle module (`oracle.rs`) falls back to an AMM time-weighted average
+price (`amm_twap::get_twap`) whenever the primary price feed is stale or
+missing. Until this view existed, that fallback value was only visible
+*indirectly* — as whatever `get_price` happened to return — with no way to
+inspect it on its own. `get_pool_twap_price` exposes that same fallback
+value directly, so a monitor or liquidation bot can check "is the fallback
+price usable right now, and what is it?" without waiting for the primary
+feed to actually go stale first.
+
+### Formula
+
+For a pool tracking `asset` against its paired token, with cumulative
+price accumulator `P` (updated on every swap/liquidity event) and a window
+`[T − window_secs, T]`:
+
+```text
+twap = (P(T) − P(T − window_secs)) / window_secs
+```
+
+`P(T)` is the accumulator extrapolated to the current ledger timestamp;
+`P(T − window_secs)` is read from the nearest persisted snapshot at or
+before that point (or the earliest available history, if the window
+extends further back than any snapshot). The result is scaled by
+`amm_twap::PRICE_SCALE` (`1e18`) — divide by `1e18` to get the
+human-readable price of one unit of `asset` in terms of its paired token.
+
+This is **the same calculation** `oracle::get_price`'s fallback path uses
+internally (`try_twap_fallback` calls the identical `amm_twap::get_twap`
+function) — `get_pool_twap_price` does not reimplement or approximate it.
+
+### Sentinel behavior (`None`)
+
+Unlike the internal fallback path (which is allowed to hard-abort the
+transaction when data isn't available, since that's an acceptable
+fail-safe deep inside a settlement flow), this view **never panics**. It
+returns `None` whenever calling `get_twap` would otherwise be unsafe:
+
+| Condition | Result |
+|---|---|
+| No pool state recorded yet for `asset` | `None` |
+| Pool exists, but zero/insufficient elapsed history for the window | `None` |
+| `window_secs` below `amm_twap::MIN_WINDOW_SECS` (25s) | `None` |
+| Sufficient snapshot history covers the window | `Some(twap_value)` |
+
+Treat `None` as "not usable for this window right now" — not as a
+transient error worth retrying immediately.
+
+### Worked example
+
+A pool has been swapping for a while. At ledger time `T = 10_000`:
+
+- A snapshot at `t = 9_850` recorded `price0_cumulative = 100_000 × 1e18`.
+- The live accumulator, extrapolated to `T = 10_000`, reads
+  `price0_cumulative = 130_000 × 1e18`.
+
+Calling `get_pool_twap_price(asset, 150)` (a 150-second window, matching
+`oracle::TWAP_FALLBACK_WINDOW_SECS`):
+
+```text
+window_secs   = 150          (T - 150 = 9_850, exactly matches the snapshot)
+delta         = 130_000e18 − 100_000e18 = 30_000e18
+twap          = 30_000e18 / 150 = 200e18
+```
+
+Result: `Some(200_000_000_000_000_000_000)` → divide by `1e18` → **200**
+units of the paired token per unit of `asset`.
+
+If instead no snapshot existed within the requested window (e.g. the pool
+was created less than 150 seconds ago), the call returns `None` rather
+than panicking or returning a misleadingly-extrapolated number.
+
+### Notes for integrators
+
+- This is a pure read — it never writes to contract storage, unlike
+  `get_price`, which may cache the price it resolves.
+- The returned scale (`1e18`) intentionally matches the AMM's own
+  accumulator scale, **not** the protocol's 6-decimal internal price
+  format used elsewhere (e.g. `get_price`'s `i128` return). Rescale
+  yourself if you need to compare directly against `get_price`'s output:
+  divide by `(amm_twap::PRICE_SCALE / 1_000_000)` to match.

--- a/stellar-lend/contracts/hello-world/src/amm_twap.rs
+++ b/stellar-lend/contracts/hello-world/src/amm_twap.rs
@@ -320,3 +320,49 @@ fn find_snapshot_at_or_before(snaps: &Vec<TwapSnapshot>, target_ts: u64) -> Opti
 pub fn get_pool_state(env: &Env, asset: &Address) -> Option<TwapPoolState> {
     env.storage().persistent().get(&twap_state_key(asset))
 }
+
+/// Returns `true` if `get_twap(env, asset, window_secs)` would succeed
+/// (i.e. not panic) for the given window, without performing the actual
+/// TWAP calculation.
+///
+/// This mirrors every panic/assert precondition inside `get_twap` exactly,
+/// so callers that need a non-panicking sentinel (e.g. a read-only view
+/// intended for monitoring/integration, rather than a settlement path that
+/// is fine with hard-aborting) can check coverage first and only call
+/// `get_twap` when this returns `true`.
+pub fn has_window_coverage(env: &Env, asset: &Address, window_secs: u64) -> bool {
+    if window_secs < MIN_WINDOW_SECS {
+        return false;
+    }
+
+    let state_key = twap_state_key(asset);
+    let current_state: TwapPoolState = match env.storage().persistent().get(&state_key) {
+        Some(s) => s,
+        None => return false,
+    };
+
+    let now: u64 = env.ledger().timestamp();
+    let target_start = now.saturating_sub(window_secs);
+
+    let snaps_key = twap_snaps_key(asset);
+    let snaps: Vec<TwapSnapshot> = env
+        .storage()
+        .persistent()
+        .get(&snaps_key)
+        .unwrap_or_else(|| Vec::new(env));
+
+    match find_snapshot_at_or_before(&snaps, target_start) {
+        // Mirrors: assert!(actual_window > 0, "zero-length TWAP window");
+        Some(start_snap) => now.saturating_sub(start_snap.timestamp) > 0,
+        // Mirrors: assert!(actual_window >= MIN_WINDOW_SECS, "insufficient TWAP history ...");
+        // get_twap falls back to current_state.last_timestamp (not `now`) when
+        // there's no snapshot at all yet -- match that exactly.
+        None => {
+            let earliest_ts = snaps
+                .first()
+                .map(|s| s.timestamp)
+                .unwrap_or(current_state.last_timestamp);
+            now.saturating_sub(earliest_ts) >= MIN_WINDOW_SECS
+        }
+    }
+}

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -43,8 +43,17 @@ pub mod storage;
 pub mod types;
 pub mod withdraw;
 
+// Legacy test suite references oracle symbols (ExternalOracle,
+// get_price_with_fallback, set_oracle_config) that predate the current
+// oracle.rs API and no longer exist anywhere in this crate. It currently
+// fails to compile under `cargo test`. Excluded from compilation, mirroring
+// the precedent already set below for `mod tests;`. Rewriting it to match
+// the current oracle API is a separate task from issue #1128.
+// #[cfg(test)]
+// mod twap_tests;
+
 #[cfg(test)]
-mod twap_tests;
+mod twap_view_test;
 
 // Legacy test suite currently mismatches contract API and is excluded from CI compile.
 // #[cfg(test)]
@@ -746,6 +755,19 @@ impl HelloContract {
         fallback_oracle: Address,
     ) {
         oracle::set_fallback_oracle(&env, caller, asset, fallback_oracle).expect("Oracle error")
+    }
+
+    /// Read-only view: the AMM TWAP fallback price for `asset` over
+    /// `window_secs`, at the AMM accumulator's native scale (1e18 — see
+    /// `oracle::TWAP_PRICE_SCALE`). Calls the same `amm_twap::get_twap` path
+    /// the oracle's stale-primary fallback uses internally.
+    ///
+    /// Returns `None` (never panics/aborts) when no snapshot covers the
+    /// requested window — e.g. the pool is too new, has no TWAP history yet,
+    /// or `window_secs` is below the protocol minimum. Pure read; does not
+    /// mutate contract state.
+    pub fn get_pool_twap_price(env: Env, asset: Address, window_secs: u64) -> Option<u128> {
+        oracle::get_pool_twap_price(&env, &asset, window_secs)
     }
 
     // ============================================================================

--- a/stellar-lend/contracts/hello-world/src/oracle.rs
+++ b/stellar-lend/contracts/hello-world/src/oracle.rs
@@ -10,6 +10,11 @@
 //!    time-weighted average price from the on-chain AMM pool reserves.
 //! 4. **Configured fallback oracle**: legacy fallback oracle address support.
 //!
+//! `get_pool_twap_price` exposes step 3's underlying AMM TWAP value directly
+//! as a read-only view (returning `None` rather than panicking when the
+//! window isn't covered yet), so integrators/monitors can inspect the
+//! fallback without flying blind during a primary-feed outage.
+//!
 //! ## Safety
 //! - Price deviation between consecutive updates is bounded (default ±5%).
 //! - Staleness threshold defaults to 1 hour; configurable by admin.
@@ -444,6 +449,33 @@ fn try_twap_fallback(env: &Env, asset: &Address) -> Result<i128, OracleError> {
 
     cache_price(env, asset, price);
     Ok(price)
+}
+
+/// Read-only view exposing the same AMM TWAP fallback price that
+/// [`get_price`]'s resolution order would fall back to for `asset`, at the
+/// AMM accumulator's own native scale (`TWAP_PRICE_SCALE`, i.e. 1e18 — the
+/// same scale documented on `amm_twap::get_twap`). This is the *pre*-rescale
+/// value; `try_twap_fallback`'s further division to 6 decimals for the
+/// protocol's `i128` price format is intentionally not applied here, so
+/// integrators/monitors see exactly what the AMM accumulator reports.
+///
+/// Calls the identical `amm_twap::get_twap` code path `try_twap_fallback`
+/// uses internally — this is not a reimplementation.
+///
+/// Returns `None` (never panics) when no snapshot covers the requested
+/// `window_secs`: the pool has no recorded state yet, there isn't enough
+/// TWAP history for the window, or `window_secs` is below
+/// `amm_twap::MIN_WINDOW_SECS`. Integrators/monitors should treat `None` as
+/// "the fallback is not currently usable for this window" rather than
+/// retrying — it means the data genuinely isn't there yet.
+///
+/// Pure read: never mutates contract state (unlike `get_price`, which may
+/// cache the resolved price).
+pub fn get_pool_twap_price(env: &Env, asset: &Address, window_secs: u64) -> Option<u128> {
+    if !amm_twap::has_window_coverage(env, asset, window_secs) {
+        return None;
+    }
+    Some(amm_twap::get_twap(env, asset, window_secs))
 }
 
 /// Get price from the configured legacy fallback oracle feed.

--- a/stellar-lend/contracts/hello-world/src/twap_view_test.rs
+++ b/stellar-lend/contracts/hello-world/src/twap_view_test.rs
@@ -1,0 +1,225 @@
+/// twap_view_test.rs — Tests for `oracle::get_pool_twap_price`, the
+/// read-only view exposing the AMM TWAP fallback (issue #1128).
+///
+/// Coverage targets
+/// ───────────────
+/// ✓ No pool state at all for the asset → None
+/// ✓ Pool exists but no elapsed time / no snapshot yet → None
+/// ✓ window_secs below amm_twap::MIN_WINDOW_SECS → None
+/// ✓ Window exactly at the boundary covered by the earliest available data → Some
+/// ✓ Multiple snapshots, window selecting a specific one → Some, matches get_twap exactly
+/// ✓ Never panics for any combination of the above (the whole point of this view)
+/// ✓ Pure read: does not mutate has_window_coverage's own inputs across repeated calls
+
+#[cfg(test)]
+mod twap_view_tests {
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{testutils::Ledger, Address, Env};
+
+    use crate::amm_twap::{self, update_twap_accumulators, MIN_WINDOW_SECS, SNAPSHOT_INTERVAL_SECS};
+    use crate::oracle::get_pool_twap_price;
+
+    fn advance_time(env: &Env, secs: u64) {
+        let current = env.ledger().timestamp();
+        env.ledger().set_timestamp(current + secs);
+    }
+
+    fn mock_asset(env: &Env) -> Address {
+        Address::generate(env)
+    }
+
+    // -----------------------------------------------------------------------
+    // No data at all
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn returns_none_when_asset_has_no_pool_state() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let asset = mock_asset(&env);
+
+        // Never called update_twap_accumulators for this asset at all.
+        let result = get_pool_twap_price(&env, &asset, MIN_WINDOW_SECS);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pool exists, but no snapshot covers the window yet
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn returns_none_immediately_after_first_update_with_no_elapsed_time() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let asset = mock_asset(&env);
+
+        // First write: establishes pool state. Note that
+        // `maybe_write_snapshot` does record a snapshot here too (its
+        // "last snapshot" baseline is 0, so the first ever write always
+        // clears SNAPSHOT_INTERVAL_SECS) -- but that snapshot's timestamp
+        // is `now` itself, so it does not predate `now - window_secs` for
+        // any positive window, and therefore cannot cover one yet.
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000);
+
+        let result = get_pool_twap_price(&env, &asset, MIN_WINDOW_SECS);
+        assert_eq!(
+            result, None,
+            "the only snapshot so far is dated 'now', so no positive-length window is covered"
+        );
+    }
+
+    #[test]
+    fn returns_none_when_history_is_shorter_than_the_requested_window() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000);
+
+        // Only a few seconds of history -- far short of MIN_WINDOW_SECS.
+        advance_time(&env, 3);
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000);
+
+        let result = get_pool_twap_price(&env, &asset, MIN_WINDOW_SECS);
+        assert_eq!(result, None, "3s of history cannot cover a MIN_WINDOW_SECS window");
+    }
+
+    // -----------------------------------------------------------------------
+    // window_secs below the protocol minimum
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn returns_none_when_window_secs_is_below_min_window_secs() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000);
+        advance_time(&env, MIN_WINDOW_SECS * 3);
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000);
+
+        // Plenty of history exists, but the requested window itself is too small.
+        let result = get_pool_twap_price(&env, &asset, MIN_WINDOW_SECS - 1);
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Exact-window boundary: just enough history, via the "no snapshot
+    // before target_start, use earliest available" path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn returns_some_when_elapsed_history_exactly_meets_min_window_secs() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000);
+        // Advance exactly MIN_WINDOW_SECS and write again, so the pool's
+        // very first state is exactly MIN_WINDOW_SECS old -- the boundary
+        // case for the "no snapshot yet, use earliest history" path.
+        advance_time(&env, MIN_WINDOW_SECS);
+        update_twap_accumulators(&env, &asset, 1_500_000, 300_000);
+
+        let result = get_pool_twap_price(&env, &asset, MIN_WINDOW_SECS);
+        assert!(
+            result.is_some(),
+            "exactly MIN_WINDOW_SECS of elapsed history must be sufficient"
+        );
+
+        // Must be identical to calling get_twap directly -- this view calls
+        // the same path, not a reimplementation.
+        let direct = amm_twap::get_twap(&env, &asset, MIN_WINDOW_SECS);
+        assert_eq!(result.unwrap(), direct);
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple snapshots: window selects a specific historical snapshot
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn returns_some_matching_get_twap_exactly_with_multiple_snapshots() {
+        let env = Env::default();
+        env.ledger().set_timestamp(10_000);
+        let asset = mock_asset(&env);
+
+        // Seed enough snapshot history for a real windowed query: several
+        // updates spaced past SNAPSHOT_INTERVAL_SECS apart so each one gets
+        // persisted as its own snapshot.
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000); // price 0.2
+        advance_time(&env, SNAPSHOT_INTERVAL_SECS);
+        update_twap_accumulators(&env, &asset, 1_000_000, 250_000); // price 0.25
+        advance_time(&env, SNAPSHOT_INTERVAL_SECS);
+        update_twap_accumulators(&env, &asset, 1_000_000, 300_000); // price 0.3
+        advance_time(&env, SNAPSHOT_INTERVAL_SECS);
+        update_twap_accumulators(&env, &asset, 1_000_000, 350_000); // price 0.35
+        advance_time(&env, SNAPSHOT_INTERVAL_SECS);
+        update_twap_accumulators(&env, &asset, 1_000_000, 400_000); // price 0.4
+
+        let window = 2 * SNAPSHOT_INTERVAL_SECS;
+        let result = get_pool_twap_price(&env, &asset, window);
+        assert!(result.is_some(), "ample multi-snapshot history must cover this window");
+
+        let direct = amm_twap::get_twap(&env, &asset, window);
+        assert_eq!(
+            result.unwrap(),
+            direct,
+            "view must return exactly what get_twap computes for the same window"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Never panics, across a sweep of windows including ones that don't
+    // have coverage. This is the central guarantee this view exists for.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn never_panics_across_a_sweep_of_windows_with_and_without_coverage() {
+        let env = Env::default();
+        env.ledger().set_timestamp(50_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000);
+        advance_time(&env, SNAPSHOT_INTERVAL_SECS);
+        update_twap_accumulators(&env, &asset, 1_000_000, 220_000);
+        advance_time(&env, SNAPSHOT_INTERVAL_SECS);
+        update_twap_accumulators(&env, &asset, 1_000_000, 240_000);
+
+        // A mix of windows: too small, too large for available history, and
+        // comfortably covered. None of these should panic regardless of
+        // whether the result is Some or None.
+        for window in [
+            1,
+            MIN_WINDOW_SECS - 1,
+            MIN_WINDOW_SECS,
+            SNAPSHOT_INTERVAL_SECS,
+            10 * SNAPSHOT_INTERVAL_SECS,
+            10_000,
+        ] {
+            let _ = get_pool_twap_price(&env, &asset, window);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Purity: repeated calls with identical inputs return identical output
+    // and don't change subsequent results (no hidden state mutation).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repeated_calls_are_idempotent() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 200_000);
+        advance_time(&env, MIN_WINDOW_SECS);
+        update_twap_accumulators(&env, &asset, 1_000_000, 250_000);
+
+        let first = get_pool_twap_price(&env, &asset, MIN_WINDOW_SECS);
+        let second = get_pool_twap_price(&env, &asset, MIN_WINDOW_SECS);
+        let third = get_pool_twap_price(&env, &asset, MIN_WINDOW_SECS);
+
+        assert_eq!(first, second);
+        assert_eq!(second, third);
+    }
+}


### PR DESCRIPTION
Adds a read-only view that surfaces the same AMM TWAP fallback price oracle::get_price falls back to when the primary feed is stale, so integrators/liquidation bots/monitors can inspect it directly instead of flying blind during a primary-feed outage (#1128).

- amm_twap::has_window_coverage(env, asset, window_secs) -> bool: a new pure-read helper that mirrors every panic/assert precondition inside amm_twap::get_twap exactly (window_secs >= MIN_WINDOW_SECS, pool state exists, snapshot/history covers the window), without performing the actual TWAP calculation. Soroban contracts can't catch a panic (catch_unwind isn't available / a panic aborts the whole transaction), so this is the only correct way to guarantee a caller never hits get_twap's panic paths while still calling that exact function for the happy-path value.
- oracle::get_pool_twap_price(env, asset, window_secs) -> Option<u128>: checks has_window_coverage first; if true, calls amm_twap::get_twap (now guaranteed not to panic) and returns Some(value) at the AMM's native scale (TWAP_PRICE_SCALE, 1e18) -- the same path try_twap_fallback uses internally, not a reimplementation. Returns None otherwise. Never mutates state.
- lib.rs: new `get_pool_twap_price` contract entrypoint delegating to the above, following the exact pattern of the existing oracle entrypoints (get_price, set_fallback_oracle, etc.).

Also: discovered (and worked around) a pre-existing problem while verifying this -- `twap_tests.rs` imports oracle symbols (ExternalOracle, get_price_with_fallback, set_oracle_config) that don't exist anywhere in the current codebase; it predates a refactor of oracle.rs and currently fails to compile under `cargo test`. The maintainers already have a precedent for exactly this situation (a different legacy test module is commented out with an explanatory note a few lines below it in lib.rs) -- I followed that same convention for twap_tests.rs rather than rewriting unrelated legacy test code, which is out of scope for this issue. Flagging prominently for reviewer awareness; a proper rewrite of twap_tests.rs against the current oracle API is a separate task.

Tests: new stellar-lend/contracts/hello-world/src/twap_view_test.rs. Covers: no pool state at all, pool exists but window not yet covered (including the case where update_twap_accumulators's first call writes an immediate same-timestamp snapshot -- traced through the existing maybe_write_snapshot logic by hand to confirm this still correctly yields None), window_secs below MIN_WINDOW_SECS, exact-boundary window coverage, multiple snapshots (result asserted identical to calling get_twap directly, since this view must call -- not reimplement -- the same path), a sweep of windows confirming no panics, and idempotency across repeated calls.

Docs: new docs/interface_quick_reference.md with the TWAP formula and a fully worked numeric example, per the issue's documentation requirement.

Note on verification: I could not get a working build/test run in my environment. The workspace's committed Cargo.lock requires a newer Cargo than was available (lock file version 4), and regenerating one hits a transitive dependency (zeroize_derive, pulled in via ed25519-dalek's dependency on zeroize) that requires edition2024, which the available toolchain doesn't support either. I deliberately reverted all local Cargo.lock changes so none of that toolchain-pinning leaked into this diff -- the committed Cargo.lock is untouched. Correctness here rests on hand-tracing every test against the actual amm_twap.rs state machine (documented in code comments/commit message above), not a passing CI run. Please run
`cargo test -p hello-world twap` yourself before merging.

Closes #1128

## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
