### PR TITLE
feat(amm): track per-side swap fee accrual with get_accrued_fees view

### DIFF
--- a/stellar-lend/contracts/amm/FEE_ACCOUNTING.md
+++ b/stellar-lend/contracts/amm/FEE_ACCOUNTING.md
@@ -1,0 +1,114 @@
+# AMM Swap Fee Accounting
+
+## Overview
+
+The StellarLend AMM tracks protocol swap fees as a first-class, queryable quantity
+instead of silently folding them into reserves. Every swap increments a per-side
+fee accumulator that can be read via `get_accrued_fees()`.
+
+## Storage Keys
+
+| Key             | Type     | Description                                              |
+|-----------------|----------|----------------------------------------------------------|
+| `KEY_FEE_A`     | `i128`   | Cumulative fees earned from `swap_a_for_b` (token A side) |
+| `KEY_FEE_B`     | `i128`   | Cumulative fees earned from `swap_b_for_a` (token B side) |
+
+Both keys use Soroban **persistent** storage so they survive contract
+instance upgrades and are visible to off-chain indexers.
+
+## Accrual Formula
+
+For each swap the fee is computed as:
+
+```text
+fee = amount_in * fee_bps / 10_000
+```
+
+- `amount_in` — the quantity of the input token supplied by the trader.
+- `fee_bps` — the protocol fee in basis points (0 ≤ fee_bps ≤ 9,999).
+- Division is **floor** (integer truncation), matching the Uniswap-v2
+  convention already used for swap outputs.
+
+### Direction Mapping
+
+| Swap direction | Input token | Accumulator updated |
+|----------------|-------------|---------------------|
+| `swap_a_for_b` | A           | `KEY_FEE_A`         |
+| `swap_b_for_a` | B           | `KEY_FEE_B`         |
+
+The fee portion of `amount_in` is kept by the pool and recorded in the
+corresponding accumulator. The swap output math is unchanged.
+
+## Monotonicity Guarantees
+
+1. **Non-decreasing:** Accumulators are only ever incremented; they are
+   never decremented.
+2. **Upper bound:** Because `fee_bps < 10,000` and division floors,
+   `fee ≤ amount_in * 9,999 / 10,000 < amount_in`. The accumulator for
+   any side therefore never exceeds the sum of `amount_in` values for
+   swaps on that side.
+3. **Overflow guard:** All arithmetic uses `checked_` operations. An
+   overflow in accumulator update will panic rather than silently wrap.
+
+## View: `get_accrued_fees(env) -> (i128, i128)`
+
+Returns the current accumulated fees as `(fee_a, fee_b)`.
+
+```rust
+let (fee_a, fee_b) = client.get_accrued_fees();
+```
+
+## Worked Example
+
+Start with a balanced pool: `reserve_a = 100,000`, `reserve_b = 100,000`.
+
+### Swap 1: A → B
+
+Trader swaps `1,000 A` with `fee_bps = 30`.
+
+```text
+fee = 1,000 * 30 / 10,000 = 3
+```
+
+After the swap:
+- `KEY_FEE_A = 3`
+- Reserves: `reserve_a = 101,000`, `reserve_b` decreased by `amount_out`.
+
+### Swap 2: B → A
+
+Trader swaps `500 B` with `fee_bps = 30`.
+
+```text
+fee = 500 * 30 / 10,000 = 1
+```
+
+After the swap:
+- `KEY_FEE_B = 1`
+- Reserves: `reserve_b` increased by `500`, `reserve_a` decreased by `amount_out`.
+
+### Read State
+
+```text
+get_accrued_fees() => (3, 1)
+```
+
+The protocol has earned 3 units of token A and 1 unit of token B in swap
+fees. These values are auditable and can be routed to a treasury via a
+future protocol-fee withdrawal endpoint.
+
+## Edge Cases
+
+| Scenario                      | Behavior                                     |
+|-------------------------------|----------------------------------------------|
+| `fee_bps = 0`                 | `fee = 0`; accumulator unchanged             |
+| `fee_bps = 9,999`             | `fee = amount_in * 9,999 / 10,000` (max fee) |
+| Multiple consecutive swaps    | Accumulator = sum of individual fees         |
+| `init_pool`                   | Both accumulators reset to `0`               |
+| `add_liquidity` / `remove_liquidity` | Accumulators unaffected (no swap fee) |
+
+## Interaction with Flash Swaps
+
+Flash swaps (`flash_swap_a_for_b` / `repay_flash_swap`) do **not** accrue
+fees into `KEY_FEE_A` / `KEY_FEE_B`. Fee accounting for flash swaps is
+deferred to a future extension; the current accumulator only tracks
+standard `swap_a_for_b` and `swap_b_for_a` calls.

--- a/stellar-lend/contracts/amm/src/fee_accrual_test.rs
+++ b/stellar-lend/contracts/amm/src/fee_accrual_test.rs
@@ -1,0 +1,254 @@
+//! Tests for AMM swap fee accrual accounting.
+//!
+//! Verifies that `swap_a_for_b` and `swap_b_for_a` correctly accumulate
+//! protocol fees into per-side counters accessible via `get_accrued_fees`.
+//!
+//! # Invariants tested
+//!
+//! | Invariant                                             | Test function                         |
+//! |-------------------------------------------------------|---------------------------------------|
+//! | Fee = `amount_in * fee_bps / 10_000` (floor)          | `test_fee_formula_a`, `test_fee_formula_b` |
+//! | `get_accrued_fees` starts at `(0, 0)` after init      | `test_initial_fees_zero`              |
+//! | Accumulator is monotonic non-decreasing               | `test_fee_accumulator_monotonic`      |
+//! | Accrued fee never exceeds cumulative `amount_in`      | `test_fee_never_exceeds_amount_in`    |
+//! | Zero-fee swaps leave accumulator unchanged            | `test_zero_fee_swap`                  |
+//! | Multiple swaps accumulate correctly                   | `test_multiple_swaps_accrue`          |
+//! | A→B swaps increment only `fee_a`                      | `test_swap_a_only_increments_fee_a`   |
+//! | B→A swaps increment only `fee_b`                      | `test_swap_b_only_increments_fee_b`   |
+//! | Large fee_bps (9_999) handled safely                  | `test_max_fee_bps`                    |
+//! | Fee accumulator survives add/remove liquidity          | `test_liquidity_ops_preserve_fees`    |
+
+#![cfg(test)]
+
+use crate::{AmmContract, AmmContractClient};
+use soroban_sdk::Env;
+
+fn setup_pool(ra: i128, rb: i128) -> (Env, AmmContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(AmmContract, ());
+    let client = AmmContractClient::new(&env, &id);
+    client.init_pool(&ra, &rb);
+    // SAFETY: env outlives the returned client via the tuple
+    let client: AmmContractClient<'static> = unsafe { core::mem::transmute(client) };
+    (env, client)
+}
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initial_fees_zero() {
+    let (env, client) = setup_pool(10_000, 10_000);
+    let (fee_a, fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_a, 0, "fee_a must start at zero");
+    assert_eq!(fee_b, 0, "fee_b must start at zero");
+}
+
+// ---------------------------------------------------------------------------
+// Fee formula verification
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fee_formula_a() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    let amount_in: i128 = 1_000;
+    let fee_bps: i128 = 30;
+    let expected_fee = amount_in * fee_bps / 10_000;
+
+    client.swap_a_for_b(&amount_in, &fee_bps);
+    let (fee_a, _fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_a, expected_fee, "fee_a must equal amount_in * fee_bps / 10_000");
+}
+
+#[test]
+fn test_fee_formula_b() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    let amount_in: i128 = 1_000;
+    let fee_bps: i128 = 30;
+    let expected_fee = amount_in * fee_bps / 10_000;
+
+    client.swap_b_for_a(&amount_in, &fee_bps);
+    let (_fee_a, fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_b, expected_fee, "fee_b must equal amount_in * fee_bps / 10_000");
+}
+
+// ---------------------------------------------------------------------------
+// Monotonicity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fee_accumulator_monotonic() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    let (mut prev_a, mut prev_b) = client.get_accrued_fees();
+
+    for &amt in &[100_i128, 200, 300, 400] {
+        client.swap_a_for_b(&amt, &30);
+        let (fa, fb) = client.get_accrued_fees();
+        assert!(fa >= prev_a, "fee_a must be monotonic (prev={}, curr={})", prev_a, fa);
+        assert!(fb >= prev_b, "fee_b must be monotonic (prev={}, curr={})", prev_b, fb);
+        prev_a = fa;
+        prev_b = fb;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fee never exceeds amount_in
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fee_never_exceeds_amount_in() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    let amount_in: i128 = 5_000;
+    let fee_bps: i128 = 9_999;
+    let fee = amount_in * fee_bps / 10_000;
+    assert!(fee <= amount_in, "fee must not exceed amount_in");
+
+    client.swap_a_for_b(&amount_in, &fee_bps);
+    let (fee_a, _) = client.get_accrued_fees();
+    assert!(fee_a <= amount_in, "accrued fee_a must not exceed the swap's amount_in");
+}
+
+// ---------------------------------------------------------------------------
+// Zero-fee edge case
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_zero_fee_swap() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    client.swap_a_for_b(&1_000, &0);
+    let (fee_a, _fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_a, 0, "zero fee_bps must yield zero accrued fee");
+
+    client.swap_b_for_a(&1_000, &0);
+    let (_fa, fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_b, 0, "zero fee_bps must yield zero accrued fee");
+}
+
+// ---------------------------------------------------------------------------
+// Multiple swaps accumulate correctly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_multiple_swaps_accrue() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+
+    let amounts_a = [100_i128, 200, 300];
+    let amounts_b = [150_i128, 250, 350];
+    let fee_bps: i128 = 30;
+
+    let expected_fee_a: i128 = amounts_a.iter().map(|&a| a * fee_bps / 10_000).sum();
+    let expected_fee_b: i128 = amounts_b.iter().map(|&b| b * fee_bps / 10_000).sum();
+
+    for &amt in &amounts_a {
+        client.swap_a_for_b(&amt, &fee_bps);
+    }
+    for &amt in &amounts_b {
+        client.swap_b_for_a(&amt, &fee_bps);
+    }
+
+    let (fee_a, fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_a, expected_fee_a, "fee_a must accumulate across all A→B swaps");
+    assert_eq!(fee_b, expected_fee_b, "fee_b must accumulate across all B→A swaps");
+}
+
+// ---------------------------------------------------------------------------
+// Direction isolation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_swap_a_only_increments_fee_a() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    client.swap_a_for_b(&1_000, &30);
+    let (fee_a, fee_b) = client.get_accrued_fees();
+    assert!(fee_a > 0, "fee_a must increase after A→B swap");
+    assert_eq!(fee_b, 0, "fee_b must stay zero after A→B swap");
+}
+
+#[test]
+fn test_swap_b_only_increments_fee_b() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    client.swap_b_for_a(&1_000, &30);
+    let (fee_a, fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_a, 0, "fee_a must stay zero after B→A swap");
+    assert!(fee_b > 0, "fee_b must increase after B→A swap");
+}
+
+// ---------------------------------------------------------------------------
+// Max fee_bps edge case
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_max_fee_bps() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    let amount_in: i128 = 1_000;
+    let fee_bps: i128 = 9_999;
+    let expected_fee = amount_in * fee_bps / 10_000;
+
+    client.swap_a_for_b(&amount_in, &fee_bps);
+    let (fee_a, _) = client.get_accrued_fees();
+    assert_eq!(fee_a, expected_fee, "max fee_bps must compute correctly");
+}
+
+// ---------------------------------------------------------------------------
+// Liquidity ops preserve fee accumulators
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_liquidity_ops_preserve_fees() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    client.swap_a_for_b(&500, &30);
+    let (fee_a_before, _) = client.get_accrued_fees();
+
+    client.add_liquidity(&100, &200);
+    let (fa_after_add, _) = client.get_accrued_fees();
+    assert_eq!(fa_after_add, fee_a_before, "add_liquidity must not alter fee_a");
+
+    client.remove_liquidity(&50, &100);
+    let (fa_after_rem, _) = client.get_accrued_fees();
+    assert_eq!(fa_after_rem, fee_a_before, "remove_liquidity must not alter fee_a");
+}
+
+// ---------------------------------------------------------------------------
+// Re-init resets accumulators
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_reinit_resets_fees() {
+    let (_env, client) = setup_pool(10_000, 10_000);
+    client.swap_a_for_b(&500, &30);
+    assert!(client.get_accrued_fees().0 > 0, "fee_a should be positive after swap");
+
+    client.init_pool(&20_000, &20_000);
+    let (fee_a, fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_a, 0, "re-init must reset fee_a");
+    assert_eq!(fee_b, 0, "re-init must reset fee_b");
+}
+
+// ---------------------------------------------------------------------------
+// Analytical fee verification across sequence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_analytical_fee_sequence() {
+    let (_env, client) = setup_pool(100_000, 100_000);
+    let fee_bps: i128 = 50;
+
+    let swaps_a = [1_000_i128, 2_000, 3_000, 4_000, 5_000];
+    let swaps_b = [500_i128, 1_500, 2_500];
+
+    let expected_fee_a: i128 = swaps_a.iter().map(|&a| a * fee_bps / 10_000).sum();
+    let expected_fee_b: i128 = swaps_b.iter().map(|&b| b * fee_bps / 10_000).sum();
+
+    for &amt in &swaps_a {
+        client.swap_a_for_b(&amt, &fee_bps);
+    }
+    for &amt in &swaps_b {
+        client.swap_b_for_a(&amt, &fee_bps);
+    }
+
+    let (fee_a, fee_b) = client.get_accrued_fees();
+    assert_eq!(fee_a, expected_fee_a, "fee_a must match analytical sum");
+    assert_eq!(fee_b, expected_fee_b, "fee_b must match analytical sum");
+}

--- a/stellar-lend/contracts/amm/src/lib.rs
+++ b/stellar-lend/contracts/amm/src/lib.rs
@@ -7,6 +7,8 @@ pub mod liquidity_math;
 mod sqrt_precision_test;
 #[cfg(test)]
 mod flash_swap_test;
+#[cfg(test)]
+mod fee_accrual_test;
 
 use soroban_sdk::{contract, contractimpl, Address, Bytes, Env};
 
@@ -41,6 +43,21 @@ const KEY_RES_B: (&str, &str) = ("pool", "b");
 const KEY_FLASH_ACTIVE: (&str, &str) = ("pool", "flash_active");
 const KEY_K_BEFORE: (&str, &str) = ("pool", "flash_k_before");
 
+// Per-side swap fee accumulators.
+//
+// `KEY_FEE_A` tracks the total protocol fees earned from swaps where
+// token A is the input (i.e. `swap_a_for_b`).  Each call increments it
+// by `amount_in * fee_bps / 10_000`.
+//
+// `KEY_FEE_B` tracks the total protocol fees earned from swaps where
+// token B is the input (i.e. `swap_b_for_a`).
+//
+// Both accumulators are monotonic non-decreasing and never exceed the
+// cumulative `amount_in` for their respective side because the fee
+// formula uses floor division with `fee_bps < 10_000`.
+const KEY_FEE_A: (&str, &str) = ("pool", "fee_a");
+const KEY_FEE_B: (&str, &str) = ("pool", "fee_b");
+
 #[contract]
 pub struct AmmContract;
 
@@ -51,10 +68,14 @@ impl AmmContract {
     /// Gated by the `FlashActive` reentrancy guard so that a flash swap
     /// initiated on a stale pool cannot be silently clobbered by a
     /// follow-up `init_pool` from the same transaction.
+    ///
+    /// Resets both fee accumulators to zero.
     pub fn init_pool(env: Env, a: i128, b: i128) {
         Self::assert_no_active_flash_swap(&env);
         env.storage().persistent().set(&KEY_RES_A, &a);
         env.storage().persistent().set(&KEY_RES_B, &b);
+        env.storage().persistent().set(&KEY_FEE_A, &0_i128);
+        env.storage().persistent().set(&KEY_FEE_B, &0_i128);
     }
 
     fn assert_no_active_flash_swap(env: &Env) {
@@ -112,6 +133,8 @@ impl AmmContract {
             panic!("empty pool");
         }
 
+        let fee = compute_fee(amount_in, fee_bps);
+
         // Uniswap v2 style: amount_in_with_fee = amount_in * (10000 - fee_bps)
         let fee_adj = 10_000_i128.checked_sub(fee_bps).expect("fee overflow");
         let amount_in_with_fee = amount_in.checked_mul(fee_adj).expect("overflow");
@@ -130,8 +153,16 @@ impl AmmContract {
         let new_rb = rb.checked_sub(amount_out).expect("underflow");
         assert_k_monotonic(ra, rb, new_ra, new_rb, true);
 
+        let accrued_fee_a: i128 = env
+            .storage()
+            .persistent()
+            .get(&KEY_FEE_A)
+            .unwrap_or(0);
+        let new_fee_a = accrued_fee_a.checked_add(fee).expect("fee_a overflow");
+
         env.storage().persistent().set(&KEY_RES_A, &new_ra);
         env.storage().persistent().set(&KEY_RES_B, &new_rb);
+        env.storage().persistent().set(&KEY_FEE_A, &new_fee_a);
         amount_out
     }
 
@@ -165,6 +196,8 @@ impl AmmContract {
             panic!("empty pool");
         }
 
+        let fee = compute_fee(amount_in, fee_bps);
+
         // Mirror of swap_a_for_b with A and B roles swapped.
         let fee_adj = 10_000_i128.checked_sub(fee_bps).expect("fee overflow");
         let amount_in_with_fee = amount_in.checked_mul(fee_adj).expect("overflow");
@@ -180,8 +213,16 @@ impl AmmContract {
         let new_ra = ra.checked_sub(amount_out).expect("underflow");
         assert_k_monotonic(ra, rb, new_ra, new_rb, true);
 
+        let accrued_fee_b: i128 = env
+            .storage()
+            .persistent()
+            .get(&KEY_FEE_B)
+            .unwrap_or(0);
+        let new_fee_b = accrued_fee_b.checked_add(fee).expect("fee_b overflow");
+
         env.storage().persistent().set(&KEY_RES_A, &new_ra);
         env.storage().persistent().set(&KEY_RES_B, &new_rb);
+        env.storage().persistent().set(&KEY_FEE_B, &new_fee_b);
         amount_out
     }
 
@@ -349,6 +390,29 @@ impl AmmContract {
             .get(&KEY_FLASH_ACTIVE)
             .unwrap_or(false)
     }
+
+    /// Read the total accrued swap fees per side.
+    ///
+    /// Returns `(fee_a, fee_b)` where:
+    /// - `fee_a` is the sum of fees charged on every `swap_a_for_b` call,
+    /// - `fee_b` is the sum of fees charged on every `swap_b_for_a` call.
+    ///
+    /// Each fee is computed as `amount_in * fee_bps / 10_000` (floor
+    /// division) at the time of the swap and accumulated into a
+    /// monotonic, persisted counter.
+    pub fn get_accrued_fees(env: Env) -> (i128, i128) {
+        let fee_a: i128 = env
+            .storage()
+            .persistent()
+            .get(&KEY_FEE_A)
+            .unwrap_or(0);
+        let fee_b: i128 = env
+            .storage()
+            .persistent()
+            .get(&KEY_FEE_B)
+            .unwrap_or(0);
+        (fee_a, fee_b)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -378,6 +442,18 @@ fn assert_k_monotonic(
             );
         }
     }
+}
+
+/// Compute the swap fee from `amount_in` and `fee_bps` using the Uniswap-v2
+/// convention:
+///
+/// ```text
+/// fee = amount_in * fee_bps / 10_000
+/// ```
+///
+/// Uses checked arithmetic; panics on overflow.
+fn compute_fee(amount_in: i128, fee_bps: i128) -> i128 {
+    amount_in.checked_mul(fee_bps).expect("fee overflow") / 10_000
 }
 
 /// Inverse of the verify-k condition: returns the **minimum** `amount_in`


### PR DESCRIPTION
## Summary
Implements explicit, persisted fee accrual accounting for AMM swaps (issue #1112).

## Changes
- **lib.rs**: Added  and  persistent accumulators and  view
- **fee_accrual_test.rs**: Added 11 comprehensive tests covering formula verification, monotonicity, zero-fee, max-fee, multiple swaps, direction isolation, liquidity ops, and re-init
- **FEE_ACCOUNTING.md**: Added documentation with accrual formula and worked example

## Fee Formula
```
fee = amount_in * fee_bps / 10_000
```
- `swap_a_for_b` accrues to `KEY_FEE_A`
- `swap_b_for_a` accrues to `KEY_FEE_B`

## Invariants
- Accumulators are monotonic non-decreasing
- Fee never exceeds `amount_in` (floor division with `fee_bps < 10_000`)
- All arithmetic uses checked operations
- Swap output math is unchanged

## Test Plan
- `fee_accrual_test.rs` covers all edge cases specified in the issue  closes #1112 