### PR TITLE
feat: add revoke_approval to multisig contract with tests and docs

### DIFF
--- a/stellar-lend/contracts/multisig/docs/REVOKE_APPROVAL.md
+++ b/stellar-lend/contracts/multisig/docs/REVOKE_APPROVAL.md
@@ -1,0 +1,28 @@
+# Revoke approval
+
+## Rationale
+
+The multisig contract now lets a signer remove their approval from an open proposal before it is executed. This makes the approval flow reversible when a signer changes their mind, notices a mistake, or wants to avoid contributing to a proposal that should not proceed.
+
+The revoke path is intentionally strict:
+
+- it only works for proposals that still exist and are not already executed;
+- it rejects revocation attempts for approvals that were never recorded;
+- it preserves the existing quorum semantics, so execution still depends on the current valid approvals and the current threshold.
+
+## Worked example
+
+1. A proposal is created with threshold 2.
+2. Signer A approves the proposal.
+3. Signer B approves the proposal as well.
+4. Signer B calls `revoke_approval`.
+5. The approval list is updated so only Signer A remains, and the proposal can no longer satisfy quorum until another valid approval is added.
+
+This allows a signer to withdraw support before the proposal reaches execution, while still keeping the approval history auditable through the stored approval list and the emitted `ApprovalRevoked` event.
+
+## Edge cases
+
+- Revoking a non-existent approval returns `ApprovalNotFound` instead of silently succeeding.
+- Revoking from an executed proposal returns `ProposalAlreadyExecuted`.
+- Revoking from an expired proposal returns `ProposalExpired`.
+- Revoking an approval can reduce the effective approval count below the live threshold, which prevents execution until quorum is restored.

--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -64,14 +64,16 @@ pub enum MultisigError {
     InvalidProposal = 1011,
     /// Caller has already approved this proposal (duplicate approval)
     AlreadyApproved = 1012,
+    /// Approval does not exist for the requested signer on the proposal
+    ApprovalNotFound = 1013,
     /// Caller is not a registered signer
-    NotASigner = 1013,
+    NotASigner = 1014,
     /// Quorum has not been reached (too few current-signer approvals)
-    InsufficientApprovals = 1014,
+    InsufficientApprovals = 1015,
     /// No pending signer-set change is queued
-    NoQueuedSignersChange = 1015,
+    NoQueuedSignersChange = 1016,
     /// Signer-set change delay period not yet elapsed
-    SignersDelayNotElapsed = 1016,
+    SignersDelayNotElapsed = 1017,
 }
 
 #[contracttype]
@@ -141,6 +143,14 @@ pub struct SignersChangeAppliedEvent {
 pub struct SignersChangeCancelledEvent {
     pub admin: Address,
     pub ledger: u32,
+}
+
+/// Emitted when a signer revokes a previous approval from an open proposal.
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApprovalRevokedEvent {
+    pub proposal_id: u64,
+    pub signer: Address,
 }
 
 #[contract]
@@ -686,6 +696,75 @@ impl MultisigContract {
         Ok(())
     }
 
+    /// Revoke a previously recorded approval from an open proposal.
+    ///
+    /// This is only valid for proposals that are still open, meaning the proposal
+    /// must exist, remain unexecuted, and have not expired. Revoking an approval
+    /// removes the signer from the stored approval list and emits an event for
+    /// off-chain tracking. A revocation that targets a missing approval is a typed
+    /// error rather than a silent no-op.
+    pub fn revoke_approval(env: Env, signer: Address, id: u64) -> Result<(), MultisigError> {
+        signer.require_auth();
+
+        let _admin = Self::get_admin(env.clone())?;
+
+        let proposal: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(id))
+            .ok_or(MultisigError::ProposalNotFound)?;
+
+        if proposal.executed {
+            return Err(MultisigError::ProposalAlreadyExecuted);
+        }
+
+        let current_ledger = env.ledger().sequence();
+        if current_ledger > proposal.expires_at_ledger {
+            return Err(MultisigError::ProposalExpired);
+        }
+
+        let is_valid_signer = if let Some(signers) = Self::get_signers(env.clone()) {
+            signers.contains(&signer)
+        } else {
+            signer == _admin
+        };
+        if !is_valid_signer {
+            return Err(MultisigError::NotASigner);
+        }
+
+        let mut approvals: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalApprovals(id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut removed = false;
+        let mut filtered = Vec::new(&env);
+        for approval in approvals.iter() {
+            if approval == signer {
+                removed = true;
+                continue;
+            }
+            filtered.push_back(approval);
+        }
+
+        if !removed {
+            return Err(MultisigError::ApprovalNotFound);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalApprovals(id), &filtered);
+
+        ApprovalRevokedEvent {
+            proposal_id: id,
+            signer: signer.clone(),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
     /// Execute a stored proposal if quorum is met, it is still fresh, and its
     /// delay has elapsed.
     ///
@@ -828,6 +907,9 @@ mod quorum_edge_test;
 
 #[cfg(test)]
 mod signer_cooldown_test;
+
+#[cfg(test)]
+mod revoke_approval_test;
 
 #[cfg(test)]
 mod tests {

--- a/stellar-lend/contracts/multisig/src/revoke_approval_test.rs
+++ b/stellar-lend/contracts/multisig/src/revoke_approval_test.rs
@@ -1,0 +1,133 @@
+#[cfg(test)]
+mod revoke_approval_tests {
+    use crate::{
+        MultisigContract, MultisigContractClient, MultisigError, MIN_THRESHOLD_DELAY_LEDGERS,
+    };
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Address, Env, Vec};
+
+    fn setup_with_signers(threshold: u32, signer_count: usize) -> (Env, Address, Address, Vec<Address>) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let contract_id = env.register_contract(None, MultisigContract);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &threshold);
+
+        let mut signers = Vec::new(&env);
+        for _ in 0..signer_count {
+            signers.push_back(Address::generate(&env));
+        }
+        client.set_signers(&signers);
+
+        (env, admin, contract_id, signers)
+    }
+
+    #[test]
+    fn test_revoke_approval_removes_signer_and_reduces_quorum() {
+        let (env, _admin, contract_id, signers) = setup_with_signers(2, 2);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let signer_a = signers.get(0).unwrap();
+        let signer_b = signers.get(1).unwrap();
+
+        let current_ledger = env.ledger().sequence();
+        let proposal_id = client.create_proposal(&3, &(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 100));
+
+        client.approve_proposal(&signer_a, &proposal_id);
+        client.approve_proposal(&signer_b, &proposal_id);
+
+        client.revoke_approval(&signer_b, &proposal_id);
+
+        let approvals = client.get_proposal_approvals(&proposal_id).unwrap();
+        assert!(!approvals.contains(&signer_b));
+        assert_eq!(approvals.iter().filter(|a| *a == signer_a).count(), 1);
+
+        env.ledger()
+            .set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 1);
+        assert_eq!(
+            client.try_execute_proposal(&proposal_id),
+            Err(Ok(MultisigError::InsufficientApprovals))
+        );
+    }
+
+    #[test]
+    fn test_revoke_nonexistent_approval_returns_error() {
+        let (env, _admin, contract_id, signers) = setup_with_signers(1, 1);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let signer_a = signers.get(0).unwrap();
+        let current_ledger = env.ledger().sequence();
+        let proposal_id = client.create_proposal(&2, &(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 100));
+
+        assert_eq!(
+            client.try_revoke_approval(&signer_a, &proposal_id),
+            Err(Ok(MultisigError::ApprovalNotFound))
+        );
+    }
+
+    #[test]
+    fn test_revoke_by_non_approver_is_rejected() {
+        let (env, _admin, contract_id, signers) = setup_with_signers(1, 2);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let signer_a = signers.get(0).unwrap();
+        let signer_b = signers.get(1).unwrap();
+        let current_ledger = env.ledger().sequence();
+        let proposal_id = client.create_proposal(&2, &(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 100));
+
+        client.approve_proposal(&signer_a, &proposal_id);
+
+        assert_eq!(
+            client.try_revoke_approval(&signer_b, &proposal_id),
+            Err(Ok(MultisigError::ApprovalNotFound))
+        );
+    }
+
+    #[test]
+    fn test_revoke_on_expired_or_executed_proposal_is_rejected() {
+        let (env, _admin, contract_id, signers) = setup_with_signers(1, 1);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let signer_a = signers.get(0).unwrap();
+        let current_ledger = env.ledger().sequence();
+        let proposal_id = client.create_proposal(&2, &(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10));
+        client.approve_proposal(&signer_a, &proposal_id);
+
+        env.ledger()
+            .set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 20);
+        assert_eq!(
+            client.try_revoke_approval(&signer_a, &proposal_id),
+            Err(Ok(MultisigError::ProposalExpired))
+        );
+
+        let proposal_id_2 = client.create_proposal(&2, &(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 100));
+        client.approve_proposal(&signer_a, &proposal_id_2);
+        client.execute_proposal(&proposal_id_2);
+        assert_eq!(
+            client.try_revoke_approval(&signer_a, &proposal_id_2),
+            Err(Ok(MultisigError::ProposalAlreadyExecuted))
+        );
+    }
+
+    #[test]
+    fn test_revoke_then_reapprove_restores_quorum() {
+        let (env, _admin, contract_id, signers) = setup_with_signers(2, 2);
+        let client = MultisigContractClient::new(&env, &contract_id);
+
+        let signer_a = signers.get(0).unwrap();
+        let signer_b = signers.get(1).unwrap();
+        let current_ledger = env.ledger().sequence();
+        let proposal_id = client.create_proposal(&2, &(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 100));
+
+        client.approve_proposal(&signer_a, &proposal_id);
+        client.approve_proposal(&signer_b, &proposal_id);
+        client.revoke_approval(&signer_b, &proposal_id);
+        client.approve_proposal(&signer_b, &proposal_id);
+
+        let approvals = client.get_proposal_approvals(&proposal_id).unwrap();
+        assert!(approvals.contains(&signer_b));
+    }
+}


### PR DESCRIPTION
Close #1211 
## Summary
<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
