### PR TITLE
test/bridge-validatorset-proptest-and-twap-maxbuffer-perf

### DIFF
--- a/stellar-lend/contracts/bridge/VALIDATORSET_INVARIANTS.md
+++ b/stellar-lend/contracts/bridge/VALIDATORSET_INVARIANTS.md
@@ -1,0 +1,62 @@
+# ValidatorSet Invariants
+
+This note explains the safety invariants now covered by
+`src/validatorset_proptest.rs` for the bridge `ValidatorSet`.
+
+## Why these invariants matter
+
+`ValidatorSet::threshold`, `ValidatorSet::len`, and `ValidatorSet::contains_pk`
+feed directly into bridge quorum verification. If any of them drift from the
+effective validator membership, the bridge can become unsafe in either
+direction:
+
+- Too low a threshold weakens quorum safety.
+- Too high a threshold can deadlock validator rotation.
+- Inconsistent membership checks can accept or reject proofs incorrectly.
+
+The new properties keep those three methods aligned even when the raw stored
+validator list contains duplicates.
+
+## Invariants
+
+For every generated validator set:
+
+- If the set is non-empty, `1 <= threshold() <= len()`.
+- `contains_pk(pk)` is true if and only if `pk.to_bytes()` appears in
+  `to_bytes_vec()`.
+- Duplicate keys do not increase `len()` or `threshold()`.
+
+`len()` now means the number of unique validator public keys, not the raw byte
+vector length. That matches how quorum proofs are counted in
+`Bridge::verify_quorum_proof`, which already deduplicates signers before
+comparing them to the threshold.
+
+## Worked example
+
+Suppose a malformed validator list is stored as:
+
+```text
+[A, A, A, B]
+```
+
+Raw length is 4, but the effective validator membership is only `{A, B}`.
+
+- Unique `len()` = 2
+- `threshold()` = `(2 * 2) / 3 + 1 = 2`
+- `contains_pk(A)` = true
+- `contains_pk(B)` = true
+- `contains_pk(C)` = false
+
+Without deduplication, the threshold would have been computed from 4 entries and
+become 3, which is impossible to satisfy with only 2 distinct signers. The new
+behavior prevents that silent liveness failure.
+
+## Edge cases
+
+- Empty set: `threshold()` remains the arithmetic result `1`, but the bounded
+  threshold invariant is enforced only for non-empty sets.
+- Singleton set: `len() == 1` and `threshold() == 1`.
+- Large set: the supermajority formula remains `floor(2n / 3) + 1`, applied to
+  the unique validator count.
+- Duplicate-heavy set: `to_bytes_vec()` still preserves raw storage order and
+  duplicates for audit/debug visibility, while quorum math ignores repeats.

--- a/stellar-lend/contracts/bridge/src/epoch_monotonicity_proptest.rs
+++ b/stellar-lend/contracts/bridge/src/epoch_monotonicity_proptest.rs
@@ -293,7 +293,11 @@ mod tests {
                 // P1: epoch must never decrease.
                 prop_assert!(
                     epoch_after >= prev_epoch,
-                    "step {step} ({attempt:?}): epoch regressed from {prev_epoch} to {epoch_after}"
+                    "step {} ({:?}): epoch regressed from {} to {}",
+                    step,
+                    attempt,
+                    prev_epoch,
+                    epoch_after
                 );
 
                 if succeeded {
@@ -301,8 +305,12 @@ mod tests {
                     prop_assert_eq!(
                         epoch_after,
                         epoch_before + 1,
-                        "step {step} ({attempt:?}): successful rotation must advance epoch by 1 \
-                         (was {epoch_before}, now {epoch_after})"
+                        "step {} ({:?}): successful rotation must advance epoch by 1 \
+                         (was {}, now {})",
+                        step,
+                        attempt,
+                        epoch_before,
+                        epoch_after
                     );
                     success_count += 1;
                     round += 1;
@@ -311,8 +319,12 @@ mod tests {
                     prop_assert_eq!(
                         epoch_after,
                         epoch_before,
-                        "step {step} ({attempt:?}): rejected rotation must not change epoch \
-                         (was {epoch_before}, now {epoch_after})"
+                        "step {} ({:?}): rejected rotation must not change epoch \
+                         (was {}, now {})",
+                        step,
+                        attempt,
+                        epoch_before,
+                        epoch_after
                     );
                 }
 
@@ -323,8 +335,9 @@ mod tests {
             prop_assert_eq!(
                 bridge.epoch,
                 success_count,
-                "final epoch {epoch} must equal success count {success_count}",
-                epoch = bridge.epoch
+                "final epoch {} must equal success count {}",
+                bridge.epoch,
+                success_count
             );
         }
 
@@ -356,7 +369,9 @@ mod tests {
             let large_epoch = bridge.epoch;
             prop_assert_eq!(
                 large_epoch, warm_up_rounds as u64,
-                "after {warm_up_rounds} warm-up rotations epoch must be {warm_up_rounds}"
+                "after {} warm-up rotations epoch must be {}",
+                warm_up_rounds,
+                warm_up_rounds
             );
 
             // Phase 2: apply random fault attempts and verify invariants.
@@ -375,7 +390,11 @@ mod tests {
                 // P1
                 prop_assert!(
                     epoch_after >= prev_epoch,
-                    "large-epoch step {step} ({attempt:?}): epoch regressed {prev_epoch}→{epoch_after}"
+                    "large-epoch step {} ({:?}): epoch regressed {}→{}",
+                    step,
+                    attempt,
+                    prev_epoch,
+                    epoch_after
                 );
 
                 if succeeded {
@@ -383,7 +402,10 @@ mod tests {
                     prop_assert_eq!(
                         epoch_after,
                         epoch_before + 1,
-                        "large-epoch step {step}: success must advance by 1 ({epoch_before}→{epoch_after})"
+                        "large-epoch step {}: success must advance by 1 ({}→{})",
+                        step,
+                        epoch_before,
+                        epoch_after
                     );
                     round += 1;
                 } else {
@@ -391,7 +413,10 @@ mod tests {
                     prop_assert_eq!(
                         epoch_after,
                         epoch_before,
-                        "large-epoch step {step}: rejection must not change epoch ({epoch_before}→{epoch_after})"
+                        "large-epoch step {}: rejection must not change epoch ({}→{})",
+                        step,
+                        epoch_before,
+                        epoch_after
                     );
                 }
 
@@ -460,7 +485,8 @@ mod tests {
                     prop_assert_eq!(
                         bridge.epoch,
                         epoch_before_fault + 1,
-                        "interleaved step {step} fault succeeded: epoch must be +1"
+                        "interleaved step {} fault succeeded: epoch must be +1",
+                        step
                     );
                     total_successes += 1;
                     round += 1;
@@ -469,7 +495,8 @@ mod tests {
                     prop_assert_eq!(
                         bridge.epoch,
                         epoch_before_fault,
-                        "interleaved step {step} fault rejected: epoch must be unchanged"
+                        "interleaved step {} fault rejected: epoch must be unchanged",
+                        step
                     );
                 }
 
@@ -496,7 +523,8 @@ mod tests {
                 prop_assert_eq!(
                     bridge.epoch,
                     epoch_before_valid + 1,
-                    "interleaved step {step} valid rotation must advance epoch by 1"
+                    "interleaved step {} valid rotation must advance epoch by 1",
+                    step
                 );
                 total_successes += 1;
                 round += 1;
@@ -506,8 +534,9 @@ mod tests {
             prop_assert_eq!(
                 bridge.epoch,
                 total_successes,
-                "final epoch {epoch} must equal total successes {total_successes}",
-                epoch = bridge.epoch
+                "final epoch {} must equal total successes {}",
+                bridge.epoch,
+                total_successes
             );
         }
     }

--- a/stellar-lend/contracts/bridge/src/lib.rs
+++ b/stellar-lend/contracts/bridge/src/lib.rs
@@ -11,21 +11,37 @@ pub struct ValidatorSet {
 }
 
 impl ValidatorSet {
+    /// Returns the effective validator count used for quorum decisions.
+    ///
+    /// Duplicate byte-encoded keys collapse to a single logical validator so a
+    /// malformed set cannot silently raise the quorum threshold by repeating the
+    /// same public key multiple times.
     pub fn len(&self) -> usize {
-        self.validators.len()
+        self.validators
+            .iter()
+            .map(|validator| validator.as_slice())
+            .collect::<HashSet<_>>()
+            .len()
     }
 
+    /// Returns the strict supermajority quorum threshold for this set.
+    ///
+    /// The threshold is computed from the deduplicated validator count exposed
+    /// by [`ValidatorSet::len`], so repeated keys never inflate the required
+    /// number of unique signatures.
     pub fn threshold(&self) -> usize {
         // Supermajority: > 2/3 of validators
         let n = self.len();
         (n * 2) / 3 + 1
     }
 
+    /// Returns `true` when `pk` is present anywhere in the raw validator list.
     pub fn contains_pk(&self, pk: &PublicKey) -> bool {
         let b = pk.to_bytes();
         self.validators.iter().any(|v| v.as_slice() == b.as_ref())
     }
 
+    /// Returns the raw byte-encoded validator list in storage order.
     pub fn to_bytes_vec(&self) -> Vec<Vec<u8>> {
         self.validators.clone()
     }
@@ -210,6 +226,9 @@ mod inbound_cap_test;
 
 #[cfg(test)]
 mod epoch_monotonicity_proptest;
+
+#[cfg(test)]
+mod validatorset_proptest;
 
 #[cfg(test)]
 mod tests {

--- a/stellar-lend/contracts/bridge/src/validatorset_proptest.rs
+++ b/stellar-lend/contracts/bridge/src/validatorset_proptest.rs
@@ -1,0 +1,162 @@
+//! validatorset_proptest.rs — Property-based tests for `ValidatorSet` quorum invariants.
+//!
+//! # Proven properties
+//!
+//! 1. For every non-empty validator set, `threshold()` stays in `[1, len()]`.
+//! 2. `contains_pk(pk)` is true exactly when `pk.to_bytes()` appears in
+//!    `to_bytes_vec()`.
+//! 3. Repeating the same validator key does not increase the effective
+//!    validator count or quorum threshold.
+
+#[cfg(test)]
+mod tests {
+    use crate::ValidatorSet;
+    use ed25519_dalek::{Keypair, PublicKey, SecretKey};
+    use proptest::prelude::*;
+    use std::collections::HashSet;
+
+    const MAX_SEED_SPACE: u8 = 40;
+    const MAX_VALIDATORS_PER_CASE: usize = 32;
+
+    /// Builds a deterministic keypair from a single-byte seed so proptest cases
+    /// are reproducible while still spanning many distinct validator keys.
+    fn deterministic_keypair(seed: u8) -> Keypair {
+        let mut secret_bytes = [0u8; 32];
+        secret_bytes[0] = seed.wrapping_add(1);
+        for (index, byte) in secret_bytes.iter_mut().enumerate().skip(1) {
+            *byte = seed
+                .wrapping_mul(13)
+                .wrapping_add((index as u8).wrapping_mul(17));
+        }
+
+        let secret = SecretKey::from_bytes(&secret_bytes).expect("seed must form a secret key");
+        let public: PublicKey = (&secret).into();
+
+        let mut keypair_bytes = [0u8; 64];
+        keypair_bytes[..32].copy_from_slice(&secret_bytes);
+        keypair_bytes[32..].copy_from_slice(public.as_bytes());
+
+        Keypair::from_bytes(&keypair_bytes).expect("deterministic keypair must be valid")
+    }
+
+    /// Converts a seed list into the raw byte representation expected by
+    /// `ValidatorSet`, preserving duplicates and order.
+    fn validator_bytes_from_seeds(seeds: &[u8]) -> Vec<Vec<u8>> {
+        seeds.iter()
+            .map(|seed| deterministic_keypair(*seed).public.to_bytes().to_vec())
+            .collect()
+    }
+
+    /// Returns the unique validator count represented by `seeds`.
+    fn unique_validator_count(seeds: &[u8]) -> usize {
+        validator_bytes_from_seeds(seeds)
+            .into_iter()
+            .collect::<HashSet<_>>()
+            .len()
+    }
+
+    /// Supermajority threshold helper used to validate the contract logic.
+    fn supermajority_threshold(unique_len: usize) -> usize {
+        (unique_len * 2) / 3 + 1
+    }
+
+    fn validator_set_strategy() -> impl Strategy<Value = Vec<u8>> {
+        prop::collection::vec(0..MAX_SEED_SPACE, 0..=MAX_VALIDATORS_PER_CASE)
+    }
+
+    proptest! {
+        /// Non-empty sets always require at least one and at most all unique validators.
+        #[test]
+        fn threshold_stays_within_non_empty_bounds(seeds in validator_set_strategy()) {
+            let validator_set = ValidatorSet {
+                validators: validator_bytes_from_seeds(&seeds),
+            };
+            let unique_len = validator_set.len();
+
+            if unique_len == 0 {
+                prop_assert_eq!(validator_set.threshold(), 1);
+            } else {
+                prop_assert!(validator_set.threshold() >= 1);
+                prop_assert!(validator_set.threshold() <= unique_len);
+            }
+        }
+
+        /// Membership checks stay aligned with the raw encoded validator list.
+        #[test]
+        fn contains_pk_matches_to_bytes_vec(
+            seeds in validator_set_strategy(),
+            probe_seed in 0..MAX_SEED_SPACE
+        ) {
+            let raw_validators = validator_bytes_from_seeds(&seeds);
+            let validator_set = ValidatorSet {
+                validators: raw_validators.clone(),
+            };
+
+            let probe = deterministic_keypair(probe_seed).public;
+            let probe_bytes = probe.to_bytes().to_vec();
+            let expected_membership = raw_validators.iter().any(|validator| validator == &probe_bytes);
+
+            prop_assert_eq!(validator_set.contains_pk(&probe), expected_membership);
+            prop_assert_eq!(
+                validator_set.to_bytes_vec().iter().any(|validator| validator == &probe_bytes),
+                expected_membership
+            );
+        }
+
+        /// Duplicate validator keys do not increase effective quorum size.
+        #[test]
+        fn duplicate_keys_do_not_inflate_threshold(seeds in validator_set_strategy()) {
+            let validator_set = ValidatorSet {
+                validators: validator_bytes_from_seeds(&seeds),
+            };
+            let unique_len = unique_validator_count(&seeds);
+
+            prop_assert_eq!(validator_set.len(), unique_len);
+            prop_assert_eq!(validator_set.threshold(), supermajority_threshold(unique_len));
+            prop_assert!(validator_set.threshold() <= validator_set.len().max(1));
+
+            if unique_len < seeds.len() {
+                let raw_threshold = supermajority_threshold(seeds.len());
+                prop_assert!(validator_set.threshold() <= raw_threshold);
+            }
+        }
+    }
+
+    /// A singleton validator set still requires exactly one signature.
+    #[test]
+    fn singleton_set_has_threshold_one() {
+        let validators = validator_bytes_from_seeds(&[7]);
+        let validator_set = ValidatorSet { validators };
+
+        assert_eq!(validator_set.len(), 1);
+        assert_eq!(validator_set.threshold(), 1);
+    }
+
+    /// Large sets keep threshold bounded by the number of unique validators.
+    #[test]
+    fn large_set_threshold_matches_unique_supermajority() {
+        let seeds: Vec<u8> = (0..MAX_VALIDATORS_PER_CASE as u8).collect();
+        let validator_set = ValidatorSet {
+            validators: validator_bytes_from_seeds(&seeds),
+        };
+
+        assert_eq!(validator_set.len(), MAX_VALIDATORS_PER_CASE);
+        assert_eq!(
+            validator_set.threshold(),
+            supermajority_threshold(MAX_VALIDATORS_PER_CASE)
+        );
+    }
+
+    /// Repeated keys are preserved in the raw byte view but ignored for quorum math.
+    #[test]
+    fn duplicate_keys_preserve_raw_bytes_without_raising_threshold() {
+        let validators = validator_bytes_from_seeds(&[1, 1, 1, 2]);
+        let validator_set = ValidatorSet {
+            validators: validators.clone(),
+        };
+
+        assert_eq!(validator_set.to_bytes_vec(), validators);
+        assert_eq!(validator_set.len(), 2);
+        assert_eq!(validator_set.threshold(), 2);
+    }
+}

--- a/stellar-lend/contracts/hello-world/docs/TWAP_MAXBUFFER_PERF.md
+++ b/stellar-lend/contracts/hello-world/docs/TWAP_MAXBUFFER_PERF.md
@@ -1,0 +1,78 @@
+# TWAP Max-Buffer Lookup Budget
+
+This document records the lookup-cost bound for `get_twap` when the snapshot
+buffer is at maximum occupancy.
+
+## Why this matters
+
+`get_twap` serves a TWAP window by:
+
+1. Extrapolating the current cumulative price to `now`.
+2. Finding the latest snapshot at or before `target_start = now - window_secs`.
+3. Dividing the cumulative delta by the elapsed time.
+
+The expensive part is step 2 when the snapshot ring is full. We want a concrete,
+reviewable bound for that worst case without changing the returned TWAP value.
+
+## Buffer shape under test
+
+The max-buffer tests fill the ring to:
+
+```text
+MAX_SNAPSHOTS = 1,440
+SNAPSHOT_INTERVAL_SECS = 60
+```
+
+That represents a fully occupied 24-hour snapshot history.
+
+## Measured lookup budget
+
+`find_snapshot_at_or_before` already uses binary search. For a full ring of
+1,440 snapshots, the worst-case comparison count is:
+
+```text
+ceil(log2(1440)) = 11
+```
+
+The new `twap_maxbuffer_perf_test.rs` assertions lock that budget in:
+
+- Short window lookup: `<= 11` comparisons
+- Long window lookup: `<= 11` comparisons
+- Mid-gap lookup: `<= 11` comparisons
+
+This gives a stable, deterministic performance bound that is much less brittle
+than wall-clock benchmarking in unit tests.
+
+## Worked example
+
+Assume the ring contains snapshots at:
+
+```text
+60, 120, 180, ... , 86,400
+```
+
+If `target_start = 95`, the correct anchor is the `60` second snapshot.
+The binary search does not walk linearly through the vector. Instead, it narrows
+the search interval until it returns the latest snapshot whose timestamp is
+`<= 95`, which is `60`.
+
+The same logic applies near the tail of the buffer for short windows and near
+the head of the buffer for long windows. In all cases the lookup cost remains
+bounded by 11 comparisons for 1,440 entries.
+
+## Edge cases covered
+
+- Full buffer with a short query window near the newest snapshots
+- Full buffer with a long query window near the oldest retained snapshots
+- Target timestamp between two snapshots
+- TWAP value unchanged at a stable 1:1 price while the ring is full
+
+## What this does not change
+
+- Snapshot write cadence
+- Eviction policy
+- TWAP math
+- Returned prices
+
+The only implementation addition is internal instrumentation that counts binary
+search comparisons in tests, so reviewers can enforce the cost bound directly.

--- a/stellar-lend/contracts/hello-world/src/amm_twap.rs
+++ b/stellar-lend/contracts/hello-world/src/amm_twap.rs
@@ -413,9 +413,21 @@ pub fn get_twap(env: &Env, asset: &Address, window_secs: u64) -> u128 {
 /// # Complexity
 /// O(log n) comparisons via binary search, where n ≤ [`MAX_SNAPSHOTS`].
 fn find_snapshot_at_or_before(snaps: &Vec<TwapSnapshot>, target_ts: u64) -> Option<TwapSnapshot> {
+    find_snapshot_at_or_before_with_steps(snaps, target_ts).0
+}
+
+/// Binary-search implementation shared by `get_twap` and the max-buffer tests.
+///
+/// The returned comparison count lets tests enforce a hard upper bound on the
+/// full-buffer lookup cost without changing any externally observable TWAP
+/// behavior.
+fn find_snapshot_at_or_before_with_steps(
+    snaps: &Vec<TwapSnapshot>,
+    target_ts: u64,
+) -> (Option<TwapSnapshot>, u32) {
     let len = snaps.len();
     if len == 0 {
-        return None;
+        return (None, 0);
     }
 
     // Binary search: maintain an invariant window [lo, hi).
@@ -423,10 +435,12 @@ fn find_snapshot_at_or_before(snaps: &Vec<TwapSnapshot>, target_ts: u64) -> Opti
     let mut lo: u32 = 0;
     let mut hi: u32 = len;
     let mut result: Option<TwapSnapshot> = None;
+    let mut comparisons: u32 = 0;
 
     while lo < hi {
         let mid = lo + (hi - lo) / 2;
         let snap: TwapSnapshot = snaps.get(mid).unwrap();
+        comparisons = comparisons.saturating_add(1);
         if snap.timestamp <= target_ts {
             // mid is a valid candidate; try to find a later one.
             result = Some(snap);
@@ -437,7 +451,17 @@ fn find_snapshot_at_or_before(snaps: &Vec<TwapSnapshot>, target_ts: u64) -> Opti
         }
     }
 
-    result
+    (result, comparisons)
+}
+
+/// Returns the snapshot lookup result and comparison count used by the
+/// `find_snapshot_at_or_before` binary search.
+#[cfg(test)]
+pub(crate) fn snapshot_search_metrics_for_test(
+    snaps: &Vec<TwapSnapshot>,
+    target_ts: u64,
+) -> (Option<TwapSnapshot>, u32) {
+    find_snapshot_at_or_before_with_steps(snaps, target_ts)
 }
 
 // ---------------------------------------------------------------------------

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -71,6 +71,8 @@ mod cross_asset_decimals_test;
 mod rate_clamp_test;
 #[cfg(test)]
 mod twap_view_test;
+#[cfg(test)]
+mod twap_maxbuffer_perf_test;
 
 // Legacy test suite currently mismatches contract API and is excluded from CI compile.
 // #[cfg(test)]

--- a/stellar-lend/contracts/hello-world/src/twap_maxbuffer_perf_test.rs
+++ b/stellar-lend/contracts/hello-world/src/twap_maxbuffer_perf_test.rs
@@ -1,0 +1,140 @@
+/// twap_maxbuffer_perf_test.rs — Full-buffer lookup budget tests for `get_twap`.
+///
+/// Coverage matrix
+/// ───────────────
+/// ✓ Snapshot ring filled to `MAX_SNAPSHOTS`
+/// ✓ Short-window lookup remains within binary-search budget
+/// ✓ Long-window lookup remains within binary-search budget
+/// ✓ Lookup returns the bounding snapshot at or before the target timestamp
+/// ✓ TWAP values remain unchanged under maximum buffer occupancy
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{testutils::Ledger, Address, Env};
+
+    use crate::amm_twap::{
+        get_snapshots, get_twap, snapshot_search_metrics_for_test, update_twap_accumulators,
+        MAX_SNAPSHOTS, MIN_WINDOW_SECS, PRICE_SCALE, SNAPSHOT_INTERVAL_SECS,
+    };
+
+    const LOOKUP_COMPARISON_BUDGET: u32 = 11;
+
+    /// Advances the mock ledger by `secs` seconds.
+    fn advance(env: &Env, secs: u64) {
+        let now = env.ledger().timestamp();
+        env.ledger().set_timestamp(now + secs);
+    }
+
+    /// Fills the snapshot ring to exactly `MAX_SNAPSHOTS` entries at a stable 1:1 price.
+    fn fill_snapshot_ring(env: &Env, asset: &Address) {
+        env.ledger().set_timestamp(0);
+        update_twap_accumulators(env, asset, 1_000_000, 1_000_000);
+
+        for _ in 0..MAX_SNAPSHOTS {
+            advance(env, SNAPSHOT_INTERVAL_SECS);
+            update_twap_accumulators(env, asset, 1_000_000, 1_000_000);
+        }
+    }
+
+    /// Returns the expected worst-case comparison count for a binary search over `len` items.
+    fn binary_search_budget(len: u32) -> u32 {
+        let mut budget = 0u32;
+        let mut span = len;
+        while span > 0 {
+            budget += 1;
+            span /= 2;
+        }
+        budget
+    }
+
+    /// On a full ring, a near-tail lookup stays within the logarithmic budget and returns
+    /// the latest snapshot at or before the requested window start.
+    #[test]
+    fn full_buffer_short_window_lookup_stays_within_budget() {
+        let env = Env::default();
+        let asset = Address::generate(&env);
+        fill_snapshot_ring(&env, &asset);
+
+        let snaps = get_snapshots(&env, &asset);
+        assert_eq!(snaps.len(), MAX_SNAPSHOTS);
+
+        let now = env.ledger().timestamp();
+        let short_window = MIN_WINDOW_SECS * 2;
+        let target_start = now.saturating_sub(short_window);
+
+        let (start_snap, comparisons) = snapshot_search_metrics_for_test(&snaps, target_start);
+        let start_snap = start_snap.expect("full ring should have a bounding snapshot");
+
+        assert!(
+            comparisons <= LOOKUP_COMPARISON_BUDGET,
+            "expected <= {LOOKUP_COMPARISON_BUDGET} comparisons, got {comparisons}"
+        );
+        assert_eq!(
+            comparisons,
+            binary_search_budget(MAX_SNAPSHOTS),
+            "full-ring lookup should stay on the binary-search budget line"
+        );
+        assert!(start_snap.timestamp <= target_start);
+
+        let next_timestamp = start_snap.timestamp + SNAPSHOT_INTERVAL_SECS;
+        assert!(
+            next_timestamp > target_start || next_timestamp > now,
+            "returned snapshot must be the last one at or before target_start"
+        );
+
+        assert_eq!(get_twap(&env, &asset, short_window), PRICE_SCALE);
+    }
+
+    /// On a full ring, a long-window lookup near the head still stays within the same budget
+    /// and keeps the TWAP value unchanged.
+    #[test]
+    fn full_buffer_long_window_lookup_stays_within_budget() {
+        let env = Env::default();
+        let asset = Address::generate(&env);
+        fill_snapshot_ring(&env, &asset);
+
+        let snaps = get_snapshots(&env, &asset);
+        let now = env.ledger().timestamp();
+        let long_window = SNAPSHOT_INTERVAL_SECS * (MAX_SNAPSHOTS as u64 - 1);
+        let target_start = now.saturating_sub(long_window);
+
+        let (start_snap, comparisons) = snapshot_search_metrics_for_test(&snaps, target_start);
+        let start_snap = start_snap.expect("full ring should have a long-window anchor");
+
+        assert!(
+            comparisons <= LOOKUP_COMPARISON_BUDGET,
+            "expected <= {LOOKUP_COMPARISON_BUDGET} comparisons, got {comparisons}"
+        );
+        assert_eq!(comparisons, binary_search_budget(MAX_SNAPSHOTS));
+        assert!(start_snap.timestamp <= target_start);
+        assert_eq!(start_snap.timestamp, SNAPSHOT_INTERVAL_SECS);
+
+        assert_eq!(get_twap(&env, &asset, long_window), PRICE_SCALE);
+    }
+
+    /// Targets that fall between two snapshots resolve immediately to the lower bound and do not
+    /// degenerate into a linear walk across the buffer.
+    #[test]
+    fn lookup_short_circuits_to_the_bounding_snapshot() {
+        let env = Env::default();
+        let asset = Address::generate(&env);
+        fill_snapshot_ring(&env, &asset);
+
+        let snaps = get_snapshots(&env, &asset);
+        let target_start = 95;
+
+        let (start_snap, comparisons) = snapshot_search_metrics_for_test(&snaps, target_start);
+        let start_snap = start_snap.expect("expected a bounding snapshot");
+
+        assert_eq!(start_snap.timestamp, 60);
+        assert!(
+            comparisons < MAX_SNAPSHOTS,
+            "lookup should remain sublinear, got {comparisons} comparisons for {} snapshots",
+            MAX_SNAPSHOTS
+        );
+        assert!(
+            comparisons <= LOOKUP_COMPARISON_BUDGET,
+            "comparison count should stay within the documented budget"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds property coverage for bridge `ValidatorSet` quorum invariants and documents/bounds full-buffer TWAP lookup cost under maximum snapshot occupancy.

### Bridge
- make `ValidatorSet::len()` count unique validator public keys
- ensure duplicate keys do not inflate quorum threshold
- add proptests covering:
  - `1 <= threshold() <= len()` for non-empty sets
  - `contains_pk()` consistency with `to_bytes_vec()`
  - duplicate-key quorum behavior
- add `VALIDATORSET_INVARIANTS.md` with rationale, worked example, and edge cases

### Hello World TWAP
- add full-buffer lookup budget coverage for `get_twap`
- instrument snapshot binary search in tests to count comparisons
- assert short-window and long-window lookups stay within the documented full-buffer budget
- confirm bounding-snapshot resolution remains correct
- confirm TWAP values are unchanged
- add `TWAP_MAXBUFFER_PERF.md` with rationale, worked example, and edge cases

## Testing
- `cargo +stable test validatorset_proptest`
- attempted `cargo +stable test -p hello-world twap_maxbuffer_perf` but blocked by unrelated pre-existing compile failures in `hello-world`

Closes #1230
Closes #1255