### PR TITLE
Implemented the multisig per-proposal action allow-list on security/m…

### DIFF
--- a/stellar-lend/contracts/multisig/docs/ACTION_ALLOWLIST.md
+++ b/stellar-lend/contracts/multisig/docs/ACTION_ALLOWLIST.md
@@ -1,0 +1,35 @@
+# Multisig Action Allow-List
+
+## Rationale
+
+The multisig contract executes proposal payloads after approval and a timelock. That is powerful, but it also means proposal decoding and execution paths should be constrained as tightly as possible.
+
+This allow-list narrows the governance attack surface by requiring every proposal action kind to be explicitly registered before it can be created or executed. If a future action type is added to the contract but not registered, proposals for that action fail closed with `MultisigError::ActionNotAllowed`.
+
+The contract now enforces the allow-list in two places:
+
+- `create_proposal`: prevents new proposals for unregistered action kinds from entering the queue.
+- `execute_proposal`: re-checks the stored proposal action kind at execution time, so a kind that was removed after queueing cannot still execute later.
+
+## Default Behavior
+
+Initialization seeds the allow-list with the only action kind the contract currently supports:
+
+- `ActionKind::SetThreshold`
+
+That preserves today's behavior for threshold-change proposals and avoids regressions for existing callers.
+
+## Worked Example
+
+1. The admin initializes the contract. `SetThreshold` is automatically allowed.
+2. The admin creates proposal `P1` to change the threshold from `3` to `5`.
+3. Before `P1` reaches its execution ledger, the admin removes `SetThreshold` from the allow-list.
+4. When someone tries to execute `P1`, `execute_proposal` re-checks the allow-list and returns `ActionNotAllowed`.
+5. If the admin later re-adds `SetThreshold`, new threshold proposals can be created again.
+
+## Edge Cases
+
+- Removing an action kind does not delete already-queued proposals. It only prevents them from executing while the kind remains disallowed.
+- Re-adding a removed kind does not mutate queued proposals; it simply makes that kind eligible again for new creation and later execution checks.
+- The allow-list setters are admin-authenticated, matching the rest of the contract's management surface.
+- Uninitialized contracts still reject admin management calls through the existing `NotInitialized` path because the admin must already exist before the allow-list can be managed.

--- a/stellar-lend/contracts/multisig/src/action_allowlist_test.rs
+++ b/stellar-lend/contracts/multisig/src/action_allowlist_test.rs
@@ -1,0 +1,103 @@
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger;
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(MultisigContract, ());
+    (env, admin, contract_id)
+}
+
+fn setup_initialized(threshold: u32) -> (Env, Address, Address) {
+    let (env, admin, contract_id) = setup();
+    let client = MultisigContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &threshold);
+    (env, admin, contract_id)
+}
+
+#[test]
+fn action_allowlist_default_allows_current_threshold_action() {
+    let (env, _admin, contract_id) = setup_initialized(3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    assert!(client.is_action_allowed(&ActionKind::SetThreshold));
+}
+
+#[test]
+fn action_allowlist_rejects_create_when_kind_removed() {
+    let (env, _admin, contract_id) = setup_initialized(3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    client.remove_allowed_action(&ActionKind::SetThreshold);
+
+    let current_ledger = env.ledger().sequence();
+    let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
+
+    assert_eq!(
+        client.try_create_proposal(&5, &expires_at),
+        Err(Ok(MultisigError::ActionNotAllowed))
+    );
+}
+
+#[test]
+fn action_allowlist_allows_create_again_after_re_add() {
+    let (env, _admin, contract_id) = setup_initialized(3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    client.remove_allowed_action(&ActionKind::SetThreshold);
+    client.add_allowed_action(&ActionKind::SetThreshold);
+
+    let current_ledger = env.ledger().sequence();
+    let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
+    let proposal_id = client.create_proposal(&5, &expires_at);
+
+    assert_eq!(proposal_id, 1);
+    assert_eq!(
+        client.get_proposal(&proposal_id).unwrap().action_kind,
+        ActionKind::SetThreshold
+    );
+}
+
+#[test]
+fn action_allowlist_rejects_execution_after_kind_removed() {
+    let (env, _admin, contract_id) = setup_initialized(3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let current_ledger = env.ledger().sequence();
+    let expires_at = current_ledger + MIN_THRESHOLD_DELAY_LEDGERS + 10;
+    let proposal_id = client.create_proposal(&5, &expires_at);
+
+    client.remove_allowed_action(&ActionKind::SetThreshold);
+    env.ledger()
+        .set_sequence_number(current_ledger + MIN_THRESHOLD_DELAY_LEDGERS);
+
+    assert_eq!(
+        client.try_execute_proposal(&proposal_id),
+        Err(Ok(MultisigError::ActionNotAllowed))
+    );
+    assert_eq!(client.get_threshold(), 3);
+    assert!(!client.get_proposal(&proposal_id).unwrap().executed);
+}
+
+#[test]
+#[should_panic]
+fn action_allowlist_add_requires_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(MultisigContract, ());
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &3);
+    client.add_allowed_action(&ActionKind::SetThreshold);
+}
+
+#[test]
+#[should_panic]
+fn action_allowlist_remove_requires_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(MultisigContract, ());
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &3);
+    client.remove_allowed_action(&ActionKind::SetThreshold);
+}

--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -27,6 +27,8 @@ pub enum DataKey {
     Proposal(u64),
     /// Stored approvals keyed by proposal id
     ProposalApprovals(u64),
+    /// Whether a proposal action kind is currently allowed for creation and execution
+    AllowedAction(ActionKind),
 }
 
 #[contracterror]
@@ -55,6 +57,16 @@ pub enum MultisigError {
     ProposalExpired = 1010,
     /// Proposal parameters are invalid
     InvalidProposal = 1011,
+    /// Proposal action kind is not currently registered in the allow-list
+    ActionNotAllowed = 1012,
+}
+
+/// Enumerates the proposal action kinds this contract can execute.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ActionKind {
+    /// Changes the multisig threshold after the proposal delay elapses.
+    SetThreshold,
 }
 
 #[contracttype]
@@ -67,10 +79,17 @@ pub struct ThresholdChange {
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Proposal {
+    /// Monotonic proposal identifier.
     pub id: u64,
+    /// Action kind that will be executed if the proposal passes.
+    pub action_kind: ActionKind,
+    /// New threshold value to apply for `ActionKind::SetThreshold`.
     pub new_threshold: u32,
+    /// Earliest ledger at which execution is permitted.
     pub eta_ledger: u32,
+    /// Final ledger at which execution is still permitted.
     pub expires_at_ledger: u32,
+    /// Whether the proposal has already executed.
     pub executed: bool,
 }
 
@@ -89,6 +108,22 @@ pub struct ThresholdChangeAppliedEvent {
     pub old_threshold: u32,
     pub new_threshold: u32,
     pub ledger: u32,
+}
+
+/// Emitted when the admin registers an action kind in the allow-list.
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActionAllowedEvent {
+    pub admin: Address,
+    pub action_kind: ActionKind,
+}
+
+/// Emitted when the admin removes an action kind from the allow-list.
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActionDisallowedEvent {
+    pub admin: Address,
+    pub action_kind: ActionKind,
 }
 
 #[contract]
@@ -127,6 +162,9 @@ impl MultisigContract {
         env.storage()
             .instance()
             .set(&DataKey::InitializedLedger, &env.ledger().sequence());
+        env.storage()
+            .instance()
+            .set(&DataKey::AllowedAction(ActionKind::SetThreshold), &true);
 
         Ok(())
     }
@@ -176,6 +214,66 @@ impl MultisigContract {
         env.storage()
             .instance()
             .get(&DataKey::PendingThresholdChange)
+    }
+
+    /// Returns whether an action kind is currently registered in the allow-list.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `action_kind` - Action kind to query
+    ///
+    /// # Returns
+    /// `true` when the action kind is allowed for proposal creation and execution
+    pub fn is_action_allowed(env: Env, action_kind: ActionKind) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::AllowedAction(action_kind))
+            .unwrap_or(false)
+    }
+
+    /// Adds an action kind to the admin-managed proposal allow-list.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `action_kind` - Action kind to register
+    ///
+    /// # Errors
+    /// * `NotInitialized` - Contract not initialized
+    pub fn add_allowed_action(env: Env, action_kind: ActionKind) -> Result<(), MultisigError> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::AllowedAction(action_kind.clone()), &true);
+
+        ActionAllowedEvent { admin, action_kind }.publish(&env);
+
+        Ok(())
+    }
+
+    /// Removes an action kind from the admin-managed proposal allow-list.
+    ///
+    /// Execution re-checks this allow-list, so removing a kind also blocks queued
+    /// proposals of that kind from executing later.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `action_kind` - Action kind to remove
+    ///
+    /// # Errors
+    /// * `NotInitialized` - Contract not initialized
+    pub fn remove_allowed_action(env: Env, action_kind: ActionKind) -> Result<(), MultisigError> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        env.storage()
+            .instance()
+            .remove(&DataKey::AllowedAction(action_kind.clone()));
+
+        ActionDisallowedEvent { admin, action_kind }.publish(&env);
+
+        Ok(())
     }
 
     /// Queue a new threshold change with a minimum delay of MIN_THRESHOLD_DELAY_LEDGERS.
@@ -279,7 +377,8 @@ impl MultisigContract {
     ///
     /// The current admin is recorded as the first approver. Execution remains
     /// unavailable until the threshold-change delay has elapsed and permanently
-    /// fails once `env.ledger().sequence() > expires_at_ledger`.
+    /// fails once `env.ledger().sequence() > expires_at_ledger`. The proposal is
+    /// rejected up front unless `ActionKind::SetThreshold` is currently allowed.
     pub fn create_proposal(
         env: Env,
         new_threshold: u32,
@@ -287,6 +386,9 @@ impl MultisigContract {
     ) -> Result<u64, MultisigError> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
+
+        let action_kind = ActionKind::SetThreshold;
+        Self::require_action_allowed(&env, &action_kind)?;
 
         if new_threshold == 0 {
             return Err(MultisigError::InvalidThreshold);
@@ -311,6 +413,7 @@ impl MultisigContract {
 
         let proposal = Proposal {
             id: next_id,
+            action_kind,
             new_threshold,
             eta_ledger,
             expires_at_ledger,
@@ -381,6 +484,8 @@ impl MultisigContract {
             return Err(MultisigError::ProposalNotReady);
         }
 
+        Self::require_action_allowed(&env, &proposal.action_kind)?;
+
         env.storage()
             .instance()
             .set(&DataKey::Threshold, &proposal.new_threshold);
@@ -438,7 +543,18 @@ impl MultisigContract {
     pub fn get_min_threshold_delay_ledgers(_env: Env) -> u32 {
         MIN_THRESHOLD_DELAY_LEDGERS
     }
+
+    fn require_action_allowed(env: &Env, action_kind: &ActionKind) -> Result<(), MultisigError> {
+        if Self::is_action_allowed(env.clone(), action_kind.clone()) {
+            Ok(())
+        } else {
+            Err(MultisigError::ActionNotAllowed)
+        }
+    }
 }
+
+#[cfg(test)]
+mod action_allowlist_test;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Adds an admin-managed per-proposal action allow-list to the multisig contract so only registered action kinds can be created and executed.

## What Changed

- added `ActionKind` and `DataKey::AllowedAction(ActionKind)` storage
- added `MultisigError::ActionNotAllowed`
- seeded the default allow-list during initialization with `ActionKind::SetThreshold` to preserve current behavior
- added admin-authenticated `add_allowed_action` and `remove_allowed_action` entrypoints
- emitted allow-list management events on add/remove
- stored each proposal’s `action_kind`
- enforced the allow-list during both proposal creation and proposal execution
- added focused allow-list tests for:
  - allowed action accepted
  - disallowed action rejected at create time
  - removed-after-queue rejected at execute time
  - non-admin management rejected
- added `contracts/multisig/docs/ACTION_ALLOWLIST.md` with rationale, worked example, and edge cases

## Testing

- `cargo test -p stellarlend-multisig action_allowlist`
- `cargo test -p stellarlend-multisig`

## Notes

- default behavior is unchanged for today’s threshold-change proposal flow because `SetThreshold` is allow-listed on initialization
- execution re-checks the allow-list so queued proposals fail closed if their action kind is later removed

Closes #1246