### PR TITLE
test: add AMM flash-swap atomicity integration test with docs (#1227)

### DIFF
--- a/stellar-lend/contracts/amm/FLASH_SWAP_ATOMICITY.md
+++ b/stellar-lend/contracts/amm/FLASH_SWAP_ATOMICITY.md
@@ -1,0 +1,157 @@
+# Flash-Swap Atomicity
+
+> **Scope** `stellar-lend/contracts/amm` — the `flash_swap_a_for_b` /
+> `repay_flash_swap` pair and the `FlashActive` reentrancy guard.
+
+---
+
+## Rationale
+
+A flash swap lets a caller receive asset B from the pool *before* paying asset
+A back, as long as the constant-product invariant `k = reserve_a × reserve_b`
+is non-decreasing by the end of the same transaction.
+
+The atomicity guarantee is: **either the borrower repays enough to keep k
+non-decreasing, or every storage change — including the optimistic debit — is
+reverted as if the swap never happened.**
+
+Without this guarantee an under-paying borrower could drain reserve B while
+leaving reserve A unchanged, breaking the invariant that protects liquidity
+providers.
+
+---
+
+## How it works
+
+```text
+Multi-operation transaction
+───────────────────────────────────────────────────────────────
+Op 1  AMM.flash_swap_a_for_b(amount_out, fee_bps)
+        • Checks FlashActive == false (reentrancy guard)
+        • Sets FlashActive = true
+        • Snapshots k_before = reserve_a × reserve_b
+        • Debits reserve_b by amount_out (optimistic transfer)
+        • Returns amount_out to caller
+
+Op 2  <arbitrary caller logic — use the received asset B>
+
+Op 3  AMM.repay_flash_swap(amount_in)
+        • Checks FlashActive == true
+        • Credits reserve_a by amount_in
+        • Verifies: (reserve_a + amount_in) × reserve_b_after ≥ k_before
+          → if this fails: PANIC → Soroban rolls back Ops 1-3 entirely
+        • Sets FlashActive = false
+
+───────────────────────────────────────────────────────────────
+```
+
+Soroban executes all operations in a transaction atomically: if any operation
+panics, every storage write in the entire transaction is rolled back.  That
+includes Op 1's optimistic debit, so a failed repay leaves the pool in exactly
+the same state it was in before the flash swap started.
+
+> **Why two entry-points instead of a callback?**  Soroban 25.3.1 forbids a
+> contract from invoking itself from inside a callback (*Contract re-entry is
+> not allowed*).  The two-entry-point design is the idiomatic Soroban pattern
+> for flash loans and flash swaps.
+
+---
+
+## Minimum repayment formula
+
+Given pool state `(reserve_a, reserve_b)` before the flash swap and a
+requested `amount_out`:
+
+```text
+amount_in_min = ⌈ reserve_a × amount_out / (reserve_b − amount_out) ⌉
+```
+
+This is computed by `inverse_swap_in(ra, rb, amount_out, fee_bps)` in
+`src/lib.rs`.  The fee parameter is accepted for API symmetry with the forward
+swap, but the verify-k check is fee-independent — it only enforces
+k-monotonicity, not the swap-formula fee curve.
+
+---
+
+## Worked example
+
+Pool state: `reserve_a = 1 000`, `reserve_b = 1 000`, `k = 1 000 000`.
+
+Caller requests `amount_out = 200` (units of B).
+
+**Op 1 — flash_swap_a_for_b(200, fee_bps=30)**
+
+```
+k_before = 1 000 × 1 000 = 1 000 000
+reserve_b_after_debit = 1 000 − 200 = 800
+FlashActive = true
+```
+
+**Minimum repayment**
+
+```
+amount_in_min = ⌈ 1 000 × 200 / (1 000 − 200) ⌉
+              = ⌈ 200 000 / 800 ⌉
+              = ⌈ 250.0 ⌉
+              = 250
+```
+
+**Op 3a — repay_flash_swap(250)  [correct]**
+
+```
+k_after = (1 000 + 250) × 800 = 1 250 × 800 = 1 000 000 ≥ k_before ✓
+FlashActive = false
+```
+
+**Op 3b — repay_flash_swap(249)  [under-repay]**
+
+```
+k_after = (1 000 + 249) × 800 = 1 249 × 800 = 999 200 < k_before ✗
+→ PANIC "Invariant violation: k decreased during flash-swap repayment"
+→ Soroban rolls back; reserves restored to (1 000, 1 000); FlashActive = false
+```
+
+---
+
+## Reentrancy guard
+
+`FlashActive` is an instance-storage boolean that gates every
+state-mutating entrypoint while a flash swap is in flight:
+
+| Attempted call while `FlashActive == true` | Result                  |
+|--------------------------------------------|-------------------------|
+| `flash_swap_a_for_b` (nested)              | `ReentrantFlashSwap`    |
+| `add_liquidity`                            | `ReentrantFlashSwap`    |
+| `remove_liquidity`                         | `ReentrantFlashSwap`    |
+| `swap_a_for_b` / `swap_b_for_a`            | `ReentrantFlashSwap`    |
+| `repay_flash_swap`                         | allowed (clears flag)   |
+| `get_reserves` / `is_flash_active`         | always allowed (reads)  |
+
+---
+
+## Edge cases
+
+| Scenario | Behaviour |
+|---|---|
+| `amount_out == reserve_b` (full drain) | Rejected: `Insufficient reserves: amount_out would drain reserve_b` |
+| `amount_out <= 0` | Rejected: `amount_out must be positive` |
+| `fee_bps` outside `[0, 9999]` | Rejected: `invalid fee_bps` |
+| `amount_in <= 0` passed to `repay_flash_swap` | Rejected: `amount_in must be positive` |
+| `repay_flash_swap` called without prior flash | Rejected: `no flash swap in progress` |
+| Over-repay (surplus `amount_in`) | k grows strictly; surplus stays in pool (protocol revenue) |
+| `fee_bps == 0` | Minimum repayment reduces to `ra × amount_out / (rb − amount_out)` (no fee surcharge) |
+
+---
+
+## Test coverage (`flash_swap_atomicity_test.rs`)
+
+| Test | Scenario |
+|---|---|
+| `test_correct_repay_clears_flag_and_k_ok` | Correct repay via `SwapCallbackStub` → k ≥ k_before, flag cleared |
+| `test_under_repay_reverts_k_violation` | Under-repay (1 stroop short) → panic with invariant message |
+| `test_under_repay_reserves_unchanged` | `try_` captures under-repay error; reserves fully restored |
+| `test_under_repay_flag_cleared_on_rollback` | `is_flash_active` false after rolled-back swap |
+| `test_reentrant_flash_rejected` | `ReentrantCallbackStub` triggers nested flash → `ReentrantFlashSwap` |
+
+Additional coverage lives in `flash_swap_test.rs` (input validation, fee
+variants, consecutive swaps, params payload).

--- a/stellar-lend/contracts/amm/src/flash_swap_atomicity_test.rs
+++ b/stellar-lend/contracts/amm/src/flash_swap_atomicity_test.rs
@@ -1,0 +1,186 @@
+//! Integration tests for AMM flash-swap **atomicity** — the "repay or
+//! revert" guarantee described in issue #1227.
+//!
+//! # Design
+//!
+//! Soroban 25.3.1 forbids a contract from invoking itself from inside a
+//! callback (`Contract re-entry is not allowed`).  The flash-swap is
+//! therefore structured as two separate entry-points dispatched via
+//! Soroban's multi-operation transaction model:
+//!
+//! ```text
+//! Op 1: AMM.flash_swap_a_for_b(amount_out, fee_bps)   ← optimistic debit
+//! Op 2: <arbitrary user logic>
+//! Op 3: AMM.repay_flash_swap(amount_in)               ← verify-k
+//! ```
+//!
+//! In the test environment we replicate this by routing both ops through
+//! a single stub **callback contract** invocation so Soroban's
+//! atomic-rollback guarantee covers both sides.
+//!
+//! # Test matrix
+//!
+//! | Test                                         | Scenario                                     |
+//! |----------------------------------------------|----------------------------------------------|
+//! | `test_correct_repay_clears_flag_and_k_ok`    | Correct repay → k non-decreasing, flag clear |
+//! | `test_under_repay_reverts_k_violation`       | Under-repay → panic, reserves unchanged      |
+//! | `test_under_repay_reserves_unchanged`        | Under-repay rollback leaves reserves exact   |
+//! | `test_under_repay_flag_cleared_on_rollback`  | `is_flash_active` false after rollback       |
+//! | `test_reentrant_flash_rejected`              | Re-entrant flash during active one → reject  |
+
+#![cfg(test)]
+
+use crate::{inverse_swap_in, AmmContract, AmmContractClient};
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Bytes, Env};
+
+const FEE_BPS: i128 = 30;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn setup_pool(ra: i128, rb: i128) -> (Env, soroban_sdk::Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(AmmContract, ());
+    AmmContractClient::new(&env, &id).init_pool(&ra, &rb);
+    (env, id)
+}
+
+// ---------------------------------------------------------------------------
+// Stub callback contracts
+// ---------------------------------------------------------------------------
+
+/// Callback stub that performs both halves of the flash swap atomically so
+/// Soroban's rollback covers both the debit (Op 1) and the repay (Op 3).
+///
+/// `amount_in` controls what is sent back:
+/// - Pass the **exact** inverse-formula value for a correct repay.
+/// - Pass a value 1 stroop short for an under-repay (triggers k-violation).
+#[contract]
+pub struct SwapCallbackStub;
+
+#[contractimpl]
+impl SwapCallbackStub {
+    /// Initiate flash swap + repay in one atomic host invocation.
+    pub fn execute(
+        env: Env,
+        amm: soroban_sdk::Address,
+        amount_out: i128,
+        amount_in: i128,
+    ) {
+        let client = AmmContractClient::new(&env, &amm);
+        client.flash_swap_a_for_b(&amount_out, &FEE_BPS_VAL, &Bytes::new(&env));
+        client.repay_flash_swap(&amount_in);
+    }
+}
+
+// `contractimpl` cannot capture module-level constants directly.
+const FEE_BPS_VAL: i128 = 30;
+
+/// Callback stub that attempts a **re-entrant** flash swap inside the same
+/// AMM while a flash is already in flight.
+#[contract]
+pub struct ReentrantCallbackStub;
+
+#[contractimpl]
+impl ReentrantCallbackStub {
+    /// Starts a flash swap then immediately tries a nested one (must panic).
+    pub fn execute(env: Env, amm: soroban_sdk::Address, amount_out: i128) {
+        let client = AmmContractClient::new(&env, &amm);
+        // Step 1: open the flash swap — arms the guard.
+        client.flash_swap_a_for_b(&amount_out, &FEE_BPS_VAL, &Bytes::new(&env));
+        // Step 2: attempt a nested flash swap — must be rejected by the guard.
+        client.flash_swap_a_for_b(&1_i128, &FEE_BPS_VAL, &Bytes::new(&env));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Correct repay: `is_flash_active` is cleared and k is non-decreasing.
+#[test]
+fn test_correct_repay_clears_flag_and_k_ok() {
+    let (env, amm_id) = setup_pool(1_000, 1_000);
+    let amm = AmmContractClient::new(&env, &amm_id);
+
+    let amount_out: i128 = 200;
+    let amount_in = inverse_swap_in(1_000, 1_000, amount_out, FEE_BPS);
+
+    let stub_id = env.register(SwapCallbackStub, ());
+    SwapCallbackStubClient::new(&env, &stub_id)
+        .execute(&amm_id, &amount_out, &amount_in);
+
+    let (ra, rb) = amm.get_reserves();
+    let k_after = ra.checked_mul(rb).unwrap();
+    assert!(k_after >= 1_000_i128 * 1_000, "k must be non-decreasing");
+    assert!(!amm.is_flash_active(), "FlashActive must be cleared");
+}
+
+/// Under-repay must panic with the k-violation message.
+#[test]
+#[should_panic(expected = "Invariant violation: k decreased during flash-swap repayment")]
+fn test_under_repay_reverts_k_violation() {
+    let (env, amm_id) = setup_pool(1_000, 1_000);
+
+    let amount_out: i128 = 200;
+    let exact_in = inverse_swap_in(1_000, 1_000, amount_out, FEE_BPS);
+    let under_in = exact_in - 1;
+
+    let stub_id = env.register(SwapCallbackStub, ());
+    SwapCallbackStubClient::new(&env, &stub_id)
+        .execute(&amm_id, &amount_out, &under_in);
+}
+
+/// Under-repay via `try_` captures the error and confirms reserves are fully
+/// rolled back to their pre-flash state.
+#[test]
+fn test_under_repay_reserves_unchanged() {
+    let (env, amm_id) = setup_pool(1_000, 1_000);
+    let amm = AmmContractClient::new(&env, &amm_id);
+
+    let amount_out: i128 = 200;
+    let exact_in = inverse_swap_in(1_000, 1_000, amount_out, FEE_BPS);
+    let under_in = exact_in - 1;
+
+    let stub_id = env.register(SwapCallbackStub, ());
+    let res = SwapCallbackStubClient::new(&env, &stub_id)
+        .try_execute(&amm_id, &amount_out, &under_in);
+    assert!(res.is_err(), "under-repay must fail");
+
+    let (ra, rb) = amm.get_reserves();
+    assert_eq!(ra, 1_000, "reserve_a must be rolled back");
+    assert_eq!(rb, 1_000, "reserve_b must be rolled back");
+}
+
+/// After a rolled-back under-repay, `is_flash_active` must be false (the
+/// entire transaction — including the flag set — was reverted).
+#[test]
+fn test_under_repay_flag_cleared_on_rollback() {
+    let (env, amm_id) = setup_pool(1_000, 1_000);
+    let amm = AmmContractClient::new(&env, &amm_id);
+
+    let amount_out: i128 = 200;
+    let exact_in = inverse_swap_in(1_000, 1_000, amount_out, FEE_BPS);
+
+    let stub_id = env.register(SwapCallbackStub, ());
+    let _ = SwapCallbackStubClient::new(&env, &stub_id)
+        .try_execute(&amm_id, &amount_out, &(exact_in - 1));
+
+    assert!(
+        !amm.is_flash_active(),
+        "FlashActive must be false after rolled-back flash swap"
+    );
+}
+
+/// A re-entrant flash swap while `FlashActive` is true must be rejected with
+/// `ReentrantFlashSwap`.
+#[test]
+#[should_panic(expected = "ReentrantFlashSwap")]
+fn test_reentrant_flash_rejected() {
+    let (env, amm_id) = setup_pool(1_000, 1_000);
+
+    let stub_id = env.register(ReentrantCallbackStub, ());
+    ReentrantCallbackStubClient::new(&env, &stub_id).execute(&amm_id, &100_i128);
+}

--- a/stellar-lend/contracts/amm/src/lib.rs
+++ b/stellar-lend/contracts/amm/src/lib.rs
@@ -6,6 +6,8 @@ pub mod math;
 #[cfg(test)]
 mod flash_swap_test;
 #[cfg(test)]
+mod flash_swap_atomicity_test;
+#[cfg(test)]
 mod fee_accrual_test;
 #[cfg(test)]
 mod mint_shares_proptest;


### PR DESCRIPTION
## Summary

Implements issue #1227.

### Changes
- **`stellar-lend/contracts/amm/src/flash_swap_atomicity_test.rs`** — five integration tests covering every requirement from the issue:
  - `test_correct_repay_clears_flag_and_k_ok` — correct repay leaves k non-decreasing and clears `FlashActive`
  - `test_under_repay_reverts_k_violation` — under-repay panics with k-violation message
  - `test_under_repay_reserves_unchanged` — `try_execute` confirms reserves fully rolled back on under-repay
  - `test_under_repay_flag_cleared_on_rollback` — `is_flash_active` is false after rollback
  - `test_reentrant_flash_rejected` — re-entrant flash swap during active one panics with `ReentrantFlashSwap`

  Two stub callback contracts (`SwapCallbackStub`, `ReentrantCallbackStub`) route both halves of the flash swap through a single host invocation, matching the atomicity of a production multi-op transaction.

- **`stellar-lend/contracts/amm/src/lib.rs`** — registers the new `flash_swap_atomicity_test` module.

- **`stellar-lend/contracts/amm/FLASH_SWAP_ATOMICITY.md`** — rationale, two-entry-point design, worked example (correct repay + under-repay), reentrancy guard table, edge-case notes, test matrix.

### Testing
All five new tests exercise the stub callback pattern. No regressions to existing tests.

Closes #1227