### PR TITLE
Closes  #1027 Make liquidate read close factor and incentive from storage instead of inline const literals

### DIFF
--- a/docs/risk_params.md
+++ b/docs/risk_params.md
@@ -12,8 +12,9 @@ This document provides a consolidated view of all protocol risk parameters, incl
 | **Debt Ceiling** | Maximum total protocol debt allowed across all users | **1 trillion** | > 0 | `set_debt_ceiling(ceiling)` | Limits protocol exposure and blast radius if price oracle fails |
 | **Deposit Cap** | Maximum total protocol deposits allowed across all users | **1 trillion** | > 0 | `set_deposit_cap(cap)` | Limits protocol exposure to asset concentration risk |
 | **Minimum Collateral Ratio** | Minimum ratio of collateral to total debt required for a borrow to succeed, in basis points | **15 000 bps (150 %)** | > 0 | `set_collateral_ratio(admin, ratio)` | Prevents under-collateralised borrowing and protects protocol solvency |
-| Close Factor | Maximum portion of a borrow position that can be liquidated in a single transaction | Defined in code | 0% – 100% | Admin-controlled setter | Prevents full liquidation at once, reducing market shock and cascading failures |
-| Liquidation Threshold | Collateral ratio below which a position becomes eligible for liquidation | Defined in code | Protocol-defined bounds | Admin-controlled setter | Ensures positions remain sufficiently collateralized and protects lenders |
+| Close Factor | Maximum portion of a borrower's debt that can be repaid in a single `liquidate` call, in basis points | **5 000 bps (50 %)** | `(0, 10 000]` | `set_close_factor_bps(close_factor_bps)` | Prevents full liquidation at once, reducing market shock and cascading failures |
+| Liquidation Incentive | Bonus collateral, on top of the repaid debt, paid to the liquidator, in basis points | **1 000 bps (10 %)** | `[0, 5 000]` | `set_liquidation_incentive_bps(incentive_bps)` | Rewards liquidators for clearing bad debt while capping the bonus so it can't be misconfigured into an outsized collateral seizure |
+| Liquidation Threshold | Collateral ratio below which a position becomes eligible for liquidation, in basis points | **8 000 bps (80 %)** | Fixed (`LIQUIDATION_THRESHOLD_BPS` constant) | Not governable — recompile-only | Ensures positions remain sufficiently collateralized and protects lenders |
 | Reserve Factor | Percentage of interest allocated to protocol reserves | Defined in code | 0% – 100% | Admin-controlled setter | Builds reserves for protocol stability and risk mitigation |
 | Supply Cap | Maximum total supply allowed for a specific asset | Defined in code | ≥ 0 | Admin-controlled setter | Limits exposure to any single asset and reduces systemic risk |
 | Borrow Cap | Maximum total borrow allowed for a specific asset | Defined in code | ≥ 0 | Admin-controlled setter | Prevents excessive leverage and liquidity stress |
@@ -58,6 +59,37 @@ where `col_ratio` is stored under the `"col_ratio"` instance-storage key (defaul
 - `TotalDeposits` = sum of all user collateral balances
 - Both totals are updated atomically with per-user state changes
 - Overflow/underflow is prevented via checked arithmetic; operations fail with `LendingError::Overflow`
+
+### Governable Liquidation Parameters (Close Factor & Liquidation Incentive)
+
+`LendingContract::liquidate` (`stellar-lend/contracts/lending/src/lib.rs`) sources its
+close-factor cap and liquidation incentive from governed storage instead of from inline
+`const` literals, so they can be retuned by the admin without a contract upgrade. The
+liquidation threshold remains the fixed `LIQUIDATION_THRESHOLD_BPS` constant — it is not
+governable.
+
+| Parameter | Storage key | Default | Bounds | Setter | Getter |
+|-----------|-------------|---------|--------|--------|--------|
+| Close factor | `DataKey::CloseFactorBps` (instance) | `DEFAULT_CLOSE_FACTOR_BPS` = 5 000 bps (50 %) | `(0, 10 000]` | `set_close_factor_bps(close_factor_bps)` | `get_close_factor_bps()` |
+| Liquidation incentive | `DataKey::LiquidationIncentiveBps` (instance) | `DEFAULT_LIQUIDATION_INCENTIVE_BPS` = 1 000 bps (10 %) | `[0, MAX_LIQUIDATION_INCENTIVE_BPS]` (`MAX_LIQUIDATION_INCENTIVE_BPS` = 5 000 bps / 50 %) | `set_liquidation_incentive_bps(incentive_bps)` | `get_liquidation_incentive_bps()` |
+
+**Behaviour:**
+- Both setters call `assert_admin`; a non-admin caller's `liquidate`-affecting setter call
+  fails with the host's auth error (`require_auth` rejection).
+- `set_close_factor_bps` rejects `close_factor_bps <= 0` or `close_factor_bps > 10000` with
+  `LendingError::InvalidCloseFactorBps` (code 7001). Storage is left unchanged on rejection.
+- `set_liquidation_incentive_bps` rejects values outside `[0, MAX_LIQUIDATION_INCENTIVE_BPS]`
+  with `LendingError::InvalidLiquidationIncentiveBps` (code 7002).
+- Until an admin calls a setter, the corresponding getter — and `liquidate` itself —
+  fall back to the default literal, so behaviour is unchanged for deployments that never
+  configure an override (the same 50 % close factor / 10 % incentive as before this change).
+- `liquidate`'s rounding policy is unaffected: `max_repay = debt × close_factor_bps ÷ 10000`
+  and `seized = repay × (10000 + incentive_bps) ÷ 10000` both still floor via
+  `math::checked_mul_div_floor`.
+
+**Source:** `stellar-lend/contracts/lending/src/liquidation_params_test.rs` covers default
+fallthrough, boundary acceptance, out-of-range rejection, unauthorised-caller rejection, and
+that `liquidate` actually reads the overridden values end to end.
 
 ## Implementation Notes
 

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -71,6 +71,8 @@ mod mul_div_proptest;
 #[cfg(test)]
 mod liquidation_branch_test;
 #[cfg(test)]
+mod liquidation_params_test;
+#[cfg(test)]
 mod liquidation_sequence_invariant_test;
 #[cfg(test)]
 mod max_borrow_proptest;
@@ -124,8 +126,18 @@ const DEFAULT_DEPOSIT_CAP: i128 = 1_000_000_000_000;
 pub(crate) const HEALTH_FACTOR_SCALE: i128 = 10_000;
 const HEALTH_FACTOR_NO_DEBT: i128 = 100_000_000;
 pub const LIQUIDATION_THRESHOLD_BPS: i128 = 8000;
-/// Maximum fraction of debt that can be repaid in a single liquidation call (50 %).
-pub const CLOSE_FACTOR: i128 = 5000;
+/// Default close-factor cap (basis points) applied by `liquidate` when
+/// `DataKey::CloseFactorBps` has not been configured via
+/// [`LendingContract::set_close_factor_bps`]. 5000 bps = 50 %.
+pub const DEFAULT_CLOSE_FACTOR_BPS: i128 = 5000;
+/// Default liquidation incentive (basis points) applied by `liquidate` when
+/// `DataKey::LiquidationIncentiveBps` has not been configured via
+/// [`LendingContract::set_liquidation_incentive_bps`]. 1000 bps = 10 %.
+pub const DEFAULT_LIQUIDATION_INCENTIVE_BPS: i128 = 1000;
+/// Upper bound accepted by [`LendingContract::set_liquidation_incentive_bps`].
+/// Caps the liquidation bonus at 50 % so a misconfigured value cannot seize
+/// an outsized share of a borrower's collateral on top of the repaid debt.
+pub const MAX_LIQUIDATION_INCENTIVE_BPS: i128 = 5000;
 const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
 const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
@@ -192,6 +204,18 @@ pub enum DataKey {
     IsolationDebt(Address),
     /// Ring-buffered protocol utilization samples, stored oldest-first.
     UtilizationHistory,
+    /// Governed close-factor cap (basis points) consulted by `liquidate` to
+    /// limit the maximum portion of a borrower's debt repayable in a single
+    /// call. Bounds: `(0, 10000]`. Defaults to [`DEFAULT_CLOSE_FACTOR_BPS`]
+    /// when unset. Configured via
+    /// [`LendingContract::set_close_factor_bps`].
+    CloseFactorBps,
+    /// Governed liquidation incentive (basis points) consulted by `liquidate`
+    /// to compute the bonus collateral seized on top of the repaid debt.
+    /// Bounds: `[0, MAX_LIQUIDATION_INCENTIVE_BPS]`. Defaults to
+    /// [`DEFAULT_LIQUIDATION_INCENTIVE_BPS`] when unset. Configured via
+    /// [`LendingContract::set_liquidation_incentive_bps`].
+    LiquidationIncentiveBps,
 }
 
 #[contractevent]
@@ -338,6 +362,11 @@ pub enum LendingError {
     NoBadDebt = 6001,
     /// `write_off_bad_debt` called with `amount` greater than recorded bad debt.
     WriteOffExceedsBadDebt = 6002,
+    /// `set_close_factor_bps` called with a value outside `(0, 10000]`.
+    InvalidCloseFactorBps = 7001,
+    /// `set_liquidation_incentive_bps` called with a value outside
+    /// `[0, MAX_LIQUIDATION_INCENTIVE_BPS]`.
+    InvalidLiquidationIncentiveBps = 7002,
 }
 
 /// Per-asset isolation-mode configuration stored under `DataKey::AssetIsolation`.
@@ -1273,31 +1302,39 @@ impl LendingContract {
     /// the whole liquidation atomically.
     ///
     /// Anyone may call `liquidate` on a position whose health factor is below
-    /// the liquidation threshold (`< 1.0`).  The caller repays up to 50 % of
-    /// the borrower's debt and receives an equivalent amount of the borrower's
-    /// collateral plus a 10 % liquidation incentive.  The incentive is minted
-    /// from the borrower's collateral, not from the protocol.
+    /// the liquidation threshold (`< 1.0`).  The caller repays up to the
+    /// governed close-factor share of the borrower's debt (default 50 %) and
+    /// receives an equivalent amount of the borrower's collateral plus the
+    /// governed liquidation incentive (default 10 %).  The incentive is
+    /// minted from the borrower's collateral, not from the protocol.
+    ///
+    /// The close factor and incentive are governable risk parameters — see
+    /// [`Self::get_close_factor_bps`] / [`Self::set_close_factor_bps`] and
+    /// [`Self::get_liquidation_incentive_bps`] /
+    /// [`Self::set_liquidation_incentive_bps`] — and the liquidation
+    /// threshold is the top-level [`LIQUIDATION_THRESHOLD_BPS`] constant.
     ///
     /// # Rounding policy (all divisions favour protocol solvency)
     ///
     /// | Division                     | Rounding | Rationale |
     /// |------------------------------|----------|-----------|
     /// | `hf = col × THRESHOLD ÷ debt` | floor    | Lower HF → position looks more underwater → earlier liquidation |
-    /// | `max_repay = debt × 5000 ÷ 10000` | floor | Smaller cap → less debt extinguished per call → more rounds remain |
-    /// | `seized = repay × 11000 ÷ 10000`  | floor | Liquidator receives *less* collateral than the exact 10 % bonus |
+    /// | `max_repay = debt × close_factor_bps ÷ 10000` | floor | Smaller cap → less debt extinguished per call → more rounds remain |
+    /// | `seized = repay × (10000 + incentive_bps) ÷ 10000`  | floor | Liquidator receives *less* collateral than the exact bonus |
     ///
     /// All three use [`math::checked_mul_div_floor`] so every truncation
     /// transfers the sub-unit remainder to the protocol / remaining borrowers.
     /// # Storage read budget
     ///
-    /// This function is expected to perform at most **7** storage reads on the hot path:
+    /// This function is expected to perform at most **8** storage reads on the hot path:
     /// 1. Flash active flag (instance storage)
     /// 2. Collateral amount (persistent storage)
     /// 3. Debt position (persistent storage via `load_debt`)
     /// 4. Bad debt (persistent storage, only when shortfall occurs)
     /// 5. Optional oracle price reads (instance storage) – enforced by `require_fresh_valuation_prices`
-    /// 6. Parameter lookups (instance storage) – if any future extensions add them.
-    /// 7. Additional reads for temporary storage used internally.
+    /// 6. Close-factor parameter lookup (instance storage)
+    /// 7. Liquidation-incentive parameter lookup (instance storage)
+    /// 8. Additional reads for temporary storage used internally.
     ///
     /// The implementation aims to batch redundant reads where possible and avoids
     /// re‑loading the same entry multiple times.
@@ -1349,11 +1386,10 @@ impl LendingContract {
             }
 
             // Health-factor computation: floor rounding.
-            // collateral * 8000 / debt — rounding down makes HF slightly lower,
-            // making the position look *more* underwater than it really is,
-            // which is conservative (triggers liquidation slightly earlier).
-            const LIQUIDATION_THRESHOLD: i128 = 8000;
-            let hf = math::checked_mul_div_floor(collateral, LIQUIDATION_THRESHOLD, debt)
+            // collateral * LIQUIDATION_THRESHOLD_BPS / debt — rounding down makes HF
+            // slightly lower, making the position look *more* underwater than it
+            // really is, which is conservative (triggers liquidation slightly earlier).
+            let hf = math::checked_mul_div_floor(collateral, LIQUIDATION_THRESHOLD_BPS, debt)
                 .map_err(|_| LendingError::Overflow)?;
 
             if hf >= 10000 {
@@ -1361,10 +1397,13 @@ impl LendingContract {
             }
 
             // Close-factor cap: floor rounding.
-            // debt * CLOSE_FACTOR / BPS_DENOM — rounding down means the liquidator can extinguish
-            // *at most* 50 % of debt, and possibly slightly less.  This is conservative:
-            // the protocol retains more liquidation opportunities.
-            let max_repay = math::checked_mul_div_floor(debt, CLOSE_FACTOR, BPS_DENOM)
+            // debt * close_factor_bps / 10000 — rounding down means the liquidator can
+            // extinguish *at most* the governed share of debt (default 50 %), and
+            // possibly slightly less. This is conservative: the protocol retains more
+            // liquidation opportunities. `close_factor_bps` is a governed risk
+            // parameter; see [`Self::set_close_factor_bps`].
+            let close_factor_bps = Self::close_factor_bps_config(&env);
+            let max_repay = math::checked_mul_div_floor(debt, close_factor_bps, BPS_DENOM)
                 .map_err(|_| LendingError::Overflow)?;
             let actual_repay = if amount > max_repay {
                 max_repay
@@ -1378,13 +1417,14 @@ impl LendingContract {
             }
 
             // Liquidation incentive: floor rounding.
-            // actual_repay * 11000 / 10000 — rounding down means the liquidator
-            // receives *less* collateral than the exact 10 % bonus.  The sub-unit
+            // actual_repay * (10000 + incentive_bps) / 10000 — rounding down means the
+            // liquidator receives *less* collateral than the exact bonus. The sub-unit
             // remainder stays with the borrower (or protocol), preventing value
-            // extraction via repeated dust-sized liquidations.
-            const INCENTIVE_BPS: i128 = 1000;
+            // extraction via repeated dust-sized liquidations. `incentive_bps` is a
+            // governed risk parameter; see [`Self::set_liquidation_incentive_bps`].
+            let incentive_bps = Self::liquidation_incentive_bps_config(&env);
             let seized_collateral =
-                math::checked_mul_div_floor(actual_repay, BPS_DENOM + INCENTIVE_BPS, BPS_DENOM)
+                math::checked_mul_div_floor(actual_repay, BPS_DENOM + incentive_bps, BPS_DENOM)
                     .map_err(|_| LendingError::Overflow)?;
 
             // Clamp: never seize more than the borrower's available collateral.
@@ -1463,6 +1503,87 @@ impl LendingContract {
 
             Ok(actual_repay)
         })
+    }
+
+    /// Read the governed close-factor cap (basis points) consulted by
+    /// `liquidate`, defaulting to [`DEFAULT_CLOSE_FACTOR_BPS`] when unset.
+    fn close_factor_bps_config(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::CloseFactorBps)
+            .unwrap_or(DEFAULT_CLOSE_FACTOR_BPS)
+    }
+
+    /// Read the governed liquidation incentive (basis points) consulted by
+    /// `liquidate`, defaulting to [`DEFAULT_LIQUIDATION_INCENTIVE_BPS`] when
+    /// unset.
+    fn liquidation_incentive_bps_config(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::LiquidationIncentiveBps)
+            .unwrap_or(DEFAULT_LIQUIDATION_INCENTIVE_BPS)
+    }
+
+    /// Return the effective close-factor cap (basis points) used by
+    /// `liquidate` — the maximum portion of a borrower's debt that may be
+    /// repaid in a single liquidation call.
+    ///
+    /// Defaults to [`DEFAULT_CLOSE_FACTOR_BPS`] (5000 = 50 %) until an admin
+    /// configures an override via [`Self::set_close_factor_bps`].
+    pub fn get_close_factor_bps(env: Env) -> i128 {
+        Self::close_factor_bps_config(&env)
+    }
+
+    /// Set the close-factor cap in basis points (admin-only).
+    ///
+    /// The close factor bounds the maximum share of a borrower's debt that a
+    /// single `liquidate` call may extinguish. Must be in `(0, 10000]`
+    /// (greater than 0 %, at most 100 %).
+    ///
+    /// # Errors
+    /// - [`LendingError::InvalidCloseFactorBps`] if `close_factor_bps <= 0`
+    ///   or `close_factor_bps > 10000`.
+    pub fn set_close_factor_bps(env: Env, close_factor_bps: i128) -> Result<(), LendingError> {
+        assert_admin(&env);
+        if close_factor_bps <= 0 || close_factor_bps > BPS_DENOM {
+            return Err(LendingError::InvalidCloseFactorBps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::CloseFactorBps, &close_factor_bps);
+        Ok(())
+    }
+
+    /// Return the effective liquidation incentive (basis points) used by
+    /// `liquidate` — the bonus, on top of the repaid debt, paid to the
+    /// liquidator in seized collateral.
+    ///
+    /// Defaults to [`DEFAULT_LIQUIDATION_INCENTIVE_BPS`] (1000 = 10 %) until
+    /// an admin configures an override via
+    /// [`Self::set_liquidation_incentive_bps`].
+    pub fn get_liquidation_incentive_bps(env: Env) -> i128 {
+        Self::liquidation_incentive_bps_config(&env)
+    }
+
+    /// Set the liquidation incentive in basis points (admin-only).
+    ///
+    /// Must be in `[0, MAX_LIQUIDATION_INCENTIVE_BPS]` (0 % to 50 %).
+    ///
+    /// # Errors
+    /// - [`LendingError::InvalidLiquidationIncentiveBps`] if
+    ///   `incentive_bps < 0` or `incentive_bps > MAX_LIQUIDATION_INCENTIVE_BPS`.
+    pub fn set_liquidation_incentive_bps(
+        env: Env,
+        incentive_bps: i128,
+    ) -> Result<(), LendingError> {
+        assert_admin(&env);
+        if !(0..=MAX_LIQUIDATION_INCENTIVE_BPS).contains(&incentive_bps) {
+            return Err(LendingError::InvalidLiquidationIncentiveBps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::LiquidationIncentiveBps, &incentive_bps);
+        Ok(())
     }
 
     pub fn repay(env: Env, user: Address, amount: i128) -> Result<i128, LendingError> {

--- a/stellar-lend/contracts/lending/src/liquidation_params_test.rs
+++ b/stellar-lend/contracts/lending/src/liquidation_params_test.rs
@@ -1,0 +1,313 @@
+//! Tests for the governable close-factor and liquidation-incentive risk
+//! parameters introduced for issue #1027.
+//!
+//! `LendingContract::liquidate` previously hard-coded `CLOSE_FACTOR = 5000`
+//! and `INCENTIVE_BPS = 1000` as inline `const` literals, and duplicated the
+//! top-level `LIQUIDATION_THRESHOLD_BPS` constant as a local `8000` literal.
+//! These tests cover the new `DataKey::CloseFactorBps` /
+//! `DataKey::LiquidationIncentiveBps` storage, their admin-gated setters and
+//! bounds, the public getters (including default fallthrough when unset),
+//! and that `liquidate` actually sources its close-factor cap and incentive
+//! from the governed values rather than from recompiled constants.
+
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+use crate::{
+    debt::DebtPosition, DataKey, LendingContract, LendingContractClient, LendingError,
+    DEFAULT_CLOSE_FACTOR_BPS, DEFAULT_LIQUIDATION_INCENTIVE_BPS, MAX_LIQUIDATION_INCENTIVE_BPS,
+};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, cid, admin)
+}
+
+/// Seed a borrower's `(collateral, debt)` position directly into storage.
+///
+/// This bypasses `deposit`/`borrow` (which independently enforce their own
+/// solvency gate at borrow time) so a liquidatable position can be set up
+/// directly, mirroring the approach already used by
+/// `liquidate_close_factor_test.rs`.
+fn seed_position(env: &Env, cid: &Address, borrower: &Address, collateral: i128, debt: i128) {
+    let now = env.ledger().timestamp();
+    env.as_contract(cid, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(borrower.clone()), &collateral);
+        env.storage().persistent().set(
+            &DataKey::Debt(borrower.clone()),
+            &DebtPosition {
+                principal: debt,
+                last_update: now,
+            },
+        );
+    });
+}
+
+// ─── Default fallthrough ──────────────────────────────────────────────────
+
+#[test]
+fn close_factor_bps_defaults_when_unset() {
+    let (_env, client, ..) = setup();
+    assert_eq!(client.get_close_factor_bps(), DEFAULT_CLOSE_FACTOR_BPS);
+    assert_eq!(DEFAULT_CLOSE_FACTOR_BPS, 5_000);
+}
+
+#[test]
+fn liquidation_incentive_bps_defaults_when_unset() {
+    let (_env, client, ..) = setup();
+    assert_eq!(
+        client.get_liquidation_incentive_bps(),
+        DEFAULT_LIQUIDATION_INCENTIVE_BPS
+    );
+    assert_eq!(DEFAULT_LIQUIDATION_INCENTIVE_BPS, 1_000);
+}
+
+// ─── Setters: boundary acceptance ─────────────────────────────────────────
+
+#[test]
+fn set_close_factor_bps_accepts_lower_boundary() {
+    let (_env, client, ..) = setup();
+    client.set_close_factor_bps(&1);
+    assert_eq!(client.get_close_factor_bps(), 1);
+}
+
+#[test]
+fn set_close_factor_bps_accepts_upper_boundary() {
+    let (_env, client, ..) = setup();
+    client.set_close_factor_bps(&10_000);
+    assert_eq!(client.get_close_factor_bps(), 10_000);
+}
+
+#[test]
+fn set_liquidation_incentive_bps_accepts_lower_boundary() {
+    let (_env, client, ..) = setup();
+    client.set_liquidation_incentive_bps(&0);
+    assert_eq!(client.get_liquidation_incentive_bps(), 0);
+}
+
+#[test]
+fn set_liquidation_incentive_bps_accepts_upper_boundary() {
+    let (_env, client, ..) = setup();
+    client.set_liquidation_incentive_bps(&MAX_LIQUIDATION_INCENTIVE_BPS);
+    assert_eq!(
+        client.get_liquidation_incentive_bps(),
+        MAX_LIQUIDATION_INCENTIVE_BPS
+    );
+}
+
+// ─── Setters: out-of-range rejection ───────────────────────────────────────
+
+#[test]
+fn set_close_factor_bps_rejects_zero() {
+    let (_env, client, ..) = setup();
+    let res = client.try_set_close_factor_bps(&0);
+    assert!(matches!(res, Err(Ok(LendingError::InvalidCloseFactorBps))));
+    // Rejected calls must not mutate storage.
+    assert_eq!(client.get_close_factor_bps(), DEFAULT_CLOSE_FACTOR_BPS);
+}
+
+#[test]
+fn set_close_factor_bps_rejects_negative() {
+    let (_env, client, ..) = setup();
+    let res = client.try_set_close_factor_bps(&-1);
+    assert!(matches!(res, Err(Ok(LendingError::InvalidCloseFactorBps))));
+}
+
+#[test]
+fn set_close_factor_bps_rejects_above_10000() {
+    let (_env, client, ..) = setup();
+    let res = client.try_set_close_factor_bps(&10_001);
+    assert!(matches!(res, Err(Ok(LendingError::InvalidCloseFactorBps))));
+    assert_eq!(client.get_close_factor_bps(), DEFAULT_CLOSE_FACTOR_BPS);
+}
+
+#[test]
+fn set_liquidation_incentive_bps_rejects_negative() {
+    let (_env, client, ..) = setup();
+    let res = client.try_set_liquidation_incentive_bps(&-1);
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InvalidLiquidationIncentiveBps))
+    ));
+    assert_eq!(
+        client.get_liquidation_incentive_bps(),
+        DEFAULT_LIQUIDATION_INCENTIVE_BPS
+    );
+}
+
+#[test]
+fn set_liquidation_incentive_bps_rejects_above_max() {
+    let (_env, client, ..) = setup();
+    let above_max = MAX_LIQUIDATION_INCENTIVE_BPS + 1;
+    let res = client.try_set_liquidation_incentive_bps(&above_max);
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InvalidLiquidationIncentiveBps))
+    ));
+}
+
+// ─── Setters: unauthorised caller rejection ────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn set_close_factor_bps_rejects_unauthorised_caller() {
+    let env = Env::default();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &cid,
+            fn_name: "set_close_factor_bps",
+            args: (7_000i128,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_close_factor_bps(&7_000);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn set_liquidation_incentive_bps_rejects_unauthorised_caller() {
+    let env = Env::default();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &cid,
+            fn_name: "set_liquidation_incentive_bps",
+            args: (2_000i128,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_liquidation_incentive_bps(&2_000);
+}
+
+// ─── `liquidate` sources the governed values ───────────────────────────────
+
+/// Drive `liquidate` and unwrap to the repaid amount, failing with a
+/// descriptive message on any other branch (mirrors the matcher in
+/// `liquidate_close_factor_test.rs::run_case`).
+fn expect_repaid(
+    liquidator: &Address,
+    borrower: &Address,
+    debt_asset: &Address,
+    collateral_asset: &Address,
+    amount: i128,
+    client: &LendingContractClient<'static>,
+) -> i128 {
+    match client.try_liquidate(liquidator, borrower, debt_asset, collateral_asset, &amount) {
+        Ok(Ok(repaid)) => repaid,
+        Ok(Err(conv)) => panic!("return-value conversion error: {conv:?}"),
+        Err(Ok(err)) => panic!("liquidate returned typed error: {err:?}"),
+        Err(Err(invoke)) => panic!("liquidate trapped (host error): {invoke:?}"),
+    }
+}
+
+/// With no admin override, `liquidate` must behave exactly as it did when
+/// the close factor / incentive were inline `const` literals — pinning the
+/// same scenario already covered by `liquidate_close_factor_test.rs`.
+#[test]
+fn liquidate_uses_default_close_factor_and_incentive_when_unset() {
+    let (env, client, cid, _admin) = setup();
+    assert_eq!(client.get_close_factor_bps(), 5_000);
+    assert_eq!(client.get_liquidation_incentive_bps(), 1_000);
+
+    let liquidator = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let debt_asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+    seed_position(&env, &cid, &borrower, 100, 200);
+
+    // max_repay = 200 * 5000 / 10000 = 100 (default close factor)
+    let repaid = expect_repaid(
+        &liquidator,
+        &borrower,
+        &debt_asset,
+        &collateral_asset,
+        100,
+        &client,
+    );
+    assert_eq!(repaid, 100);
+}
+
+/// Raising the close-factor cap to 100% allows a single `liquidate` call to
+/// extinguish the *entire* debt, instead of being capped at 50%.
+#[test]
+fn liquidate_honours_governed_close_factor_override() {
+    let (env, client, cid, _admin) = setup();
+    client.set_close_factor_bps(&10_000);
+
+    let liquidator = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let debt_asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+    // hf = 900 * 8000 / 800 = 9000 < 10000 -> unhealthy.
+    seed_position(&env, &cid, &borrower, 900, 800);
+
+    // max_repay = 800 * 10000 / 10000 = 800 (100% close factor) -> full repay.
+    let repaid = expect_repaid(
+        &liquidator,
+        &borrower,
+        &debt_asset,
+        &collateral_asset,
+        800,
+        &client,
+    );
+    assert_eq!(repaid, 800);
+
+    let pos = client.get_position(&borrower);
+    assert_eq!(pos.debt, 0);
+    // seized = 800 * (10000 + 1000) / 10000 = 880 (default incentive, no clamp).
+    assert_eq!(pos.collateral, 900 - 880);
+}
+
+/// Zeroing out the liquidation incentive means the liquidator receives
+/// exactly the repaid amount in collateral, with no bonus on top.
+#[test]
+fn liquidate_honours_governed_incentive_override() {
+    let (env, client, cid, _admin) = setup();
+    client.set_liquidation_incentive_bps(&0);
+
+    let liquidator = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let debt_asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+    // hf = 200 * 8000 / 200 = 8000 < 10000 -> unhealthy.
+    seed_position(&env, &cid, &borrower, 200, 200);
+
+    // max_repay = 200 * 5000 / 10000 = 100 (default close factor).
+    let repaid = expect_repaid(
+        &liquidator,
+        &borrower,
+        &debt_asset,
+        &collateral_asset,
+        100,
+        &client,
+    );
+    assert_eq!(repaid, 100);
+
+    let pos = client.get_position(&borrower);
+    // seized = 100 * (10000 + 0) / 10000 = 100 -> no bonus collateral seized.
+    assert_eq!(pos.collateral, 200 - 100);
+}

--- a/stellar-lend/contracts/lending/tests/liquidation_mechanics_test.rs
+++ b/stellar-lend/contracts/lending/tests/liquidation_mechanics_test.rs
@@ -4,7 +4,7 @@
 mod tests {
     use stellar_lend_common::BPS_DENOM;
     use stellarlend_lending::math;
-    use stellarlend_lending::{CLOSE_FACTOR, LIQUIDATION_THRESHOLD_BPS};
+    use stellarlend_lending::{DEFAULT_CLOSE_FACTOR_BPS, LIQUIDATION_THRESHOLD_BPS};
 
     // Helper to compute seized collateral based on actual repay
     fn compute_seized(actual_repay: i128) -> i128 {
@@ -25,7 +25,8 @@ mod tests {
         assert!(hf < 10_000);
 
         // Close factor cap
-        let max_repay = math::checked_mul_div_floor(debt, CLOSE_FACTOR, BPS_DENOM).unwrap();
+        let max_repay =
+            math::checked_mul_div_floor(debt, DEFAULT_CLOSE_FACTOR_BPS, BPS_DENOM).unwrap();
         assert_eq!(max_repay, 5_000);
         let actual_repay = std::cmp::min(requested, max_repay);
         assert_eq!(actual_repay, 5_000);
@@ -49,7 +50,8 @@ mod tests {
         assert!(hf < 10_000);
 
         // Close factor cap
-        let max_repay = math::checked_mul_div_floor(debt, CLOSE_FACTOR, BPS_DENOM).unwrap();
+        let max_repay =
+            math::checked_mul_div_floor(debt, DEFAULT_CLOSE_FACTOR_BPS, BPS_DENOM).unwrap();
         assert_eq!(max_repay, 6_000);
         let actual_repay = std::cmp::min(requested, max_repay);
         assert_eq!(actual_repay, 6_000);


### PR DESCRIPTION
Closes #1027 Make liquidate read close factor and incentive from storage instead of inline const literals

`LendingContract::liquidate` hard-coded `LIQUIDATION_THRESHOLD = 8000`, `CLOSE_FACTOR = 5000`, and `INCENTIVE_BPS = 1000` as inline `const` literals, duplicating the top-level `LIQUIDATION_THRESHOLD_BPS` constant and making the risk parameters untunable without a contract upgrade.

- Moves the close factor and liquidation incentive into governed instance storage (`DataKey::CloseFactorBps`, `DataKey::LiquidationIncentiveBps`).
- Adds admin-gated setters `set_close_factor_bps` (bounds `(0, 10000]`) and `set_liquidation_incentive_bps` (bounds `[0, MAX_LIQUIDATION_INCENTIVE_BPS]`, capped at 50%), each with a dedicated typed error (`InvalidCloseFactorBps`, `InvalidLiquidationIncentiveBps`).
- Adds public getters `get_close_factor_bps` / `get_liquidation_incentive_bps` that default to the original literals (5000 / 1000 bps) when unset, so behaviour is unchanged for deployments that never configure an override.
- `liquidate` now reuses the top-level `LIQUIDATION_THRESHOLD_BPS` constant directly instead of a local `8000` literal, removing the single-source-of-truth duplication called out in the issue.
- No change to the liquidation math itself — only to where the three parameters are sourced from.
- Updates `docs/risk_params.md` with the new parameters' storage keys, defaults, bounds, and setters/getters.
