### PR TITLE
feat: add get_rate_smoothing_state view to lending with tests and docs

### DIFF
--- a/docs/interface_quick_reference.md
+++ b/docs/interface_quick_reference.md
@@ -55,6 +55,7 @@
 | `get_position` | `(user: Address)` | `PositionSummary { collateral: i128, debt: i128, health_factor: i128 }` |
 | `get_debt_position` | `(user: Address)` | `DebtPosition { principal: i128, last_update: u64 }` |
 | `get_min_borrow` | `()` | `i128` |
+| `get_rate_smoothing_state` | `()` | `RateSmoothingState { schema_version: u32, current_rate_bps: i128, last_target_rate_bps: i128, last_update_ledger: u32 }` |
 | `get_health_factor` | `(user: Address)` | `i128` |
 | `get_protocol_metrics` | `()` | `ProtocolMetrics { total_borrow: i128, total_supply: i128, utilization_bps: i128, ledger: u32 }` |
 
@@ -156,6 +157,17 @@ pub struct ProtocolMetrics {
     pub total_supply: i128,
     pub utilization_bps: i128,
     pub ledger: u32,
+}
+```
+
+### `RateSmoothingState`
+
+```rust
+pub struct RateSmoothingState {
+    pub schema_version: u32,
+    pub current_rate_bps: i128,
+    pub last_target_rate_bps: i128,
+    pub last_update_ledger: u32,
 }
 ```
 

--- a/stellar-lend/contracts/lending/RATE_SMOOTHING_STATE.md
+++ b/stellar-lend/contracts/lending/RATE_SMOOTHING_STATE.md
@@ -1,0 +1,67 @@
+# Rate Smoothing State View
+
+## Rationale
+
+The lending rate model persists the effective smoothed borrow rate and the
+ledger where it was last updated. Liquidation bots and indexers also need the
+last target rate that produced the stored smoothing state so they can explain
+rate movement without replaying utilization and rate parameters off-chain.
+
+`get_rate_smoothing_state()` exposes the stored state directly:
+
+```text
+RateSmoothingState {
+  schema_version: 1,
+  current_rate_bps,
+  last_target_rate_bps,
+  last_update_ledger,
+}
+```
+
+The view is observability-only. It does not call the borrow-rate calculator, it
+does not update the per-ledger cache, and it does not recompute utilization.
+
+## Worked Example
+
+Assume these rate parameters:
+
+- `max_rate_change_per_ledger_bps = 50`
+- `hysteresis_bps = 0`
+- floor and ceiling leave the example rates unclamped
+
+At ledger `100`, `update_and_get_rate(env, 1_700, params)` initializes the
+smoothing state. Because this is the first update, the smoothed rate is the
+target:
+
+```text
+current_rate_bps = 1_700
+last_target_rate_bps = 1_700
+last_update_ledger = 100
+```
+
+At ledger `101`, utilization pushes the target to `2_700`. Smoothing allows a
+single-ledger move of only `50 bps`, so the persisted effective rate becomes
+`1_750` while the target is recorded as `2_700`:
+
+```text
+current_rate_bps = 1_750
+last_target_rate_bps = 2_700
+last_update_ledger = 101
+```
+
+`get_rate_smoothing_state()` returns those persisted values exactly. It does
+not derive a fresh target from current deposits/debt and therefore cannot drift
+from the state written by `update_and_get_rate`.
+
+## Edge Cases
+
+- **Uninitialized state:** returns `schema_version = 1` and zero for all rate
+  and ledger fields.
+- **Same-ledger reads:** repeated calls return the same values and do not
+  mutate storage.
+- **Clamped updates:** `current_rate_bps` is the final clamped smoothed rate
+  persisted under `RateModelKey::LastRate`; `last_target_rate_bps` remains the
+  target argument passed to `update_and_get_rate`.
+- **Indexer compatibility:** the response is versioned. Future breaking schema
+  changes should introduce a new version or a new view rather than changing the
+  meaning of the version `1` fields.

--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -78,6 +78,7 @@ The table below reflects the **shipping** surface of `src/lib.rs` as of this bra
 | `get_position` | `(env, user: Address) → PositionSummary` | `{ collateral: i128, debt: i128, health_factor: i128 }` | Returns collateral balance, effective debt (principal + accrued interest), and health factor (`col * 8000 / debt`; `100_000_000` when debt is zero). Extends TTL on read. |
 | `get_debt_position` | `(env, user: Address) → DebtPosition` | `{ principal: i128, last_update: u64 }` | Raw debt state; useful for debugging or off-chain interest simulation. Extends TTL on read. |
 | `get_min_borrow` | `(env) → i128` | `i128` | Returns the current minimum borrow amount (default `0`). |
+| `get_rate_smoothing_state` | `(env) → RateSmoothingState` | `{ schema_version: u32, current_rate_bps: i128, last_target_rate_bps: i128, last_update_ledger: u32 }` | Returns the persisted borrow-rate smoothing state without recomputing rates or mutating storage. |
 | `get_health_factor` | `(env, user: Address) → i128` | `i128` | Convenience health-factor view using the same liquidation threshold scale; returns the no-debt sentinel when debt is zero. |
 | `get_protocol_metrics` | `(env) → ProtocolMetrics` | `{ total_borrow: i128, total_supply: i128, utilization_bps: i128, ledger: u32 }` | Returns aggregate borrow/supply utilization and the current ledger sequence. |
 

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -81,6 +81,8 @@ mod rate_cache_test;
 #[cfg(test)]
 mod rate_hysteresis_test;
 #[cfg(test)]
+mod rate_smoothing_state_test;
+#[cfg(test)]
 mod repay_debt_floor_test;
 #[cfg(test)]
 mod repay_overpay_test;
@@ -353,6 +355,25 @@ pub struct ProtocolMetrics {
     pub ledger: u32,
 }
 
+/// Versioned read model for borrow-rate smoothing state persisted by the rate model.
+///
+/// This struct is intentionally append-only for indexer stability. The
+/// `schema_version` field lets downstream decoders reject unknown future
+/// versions instead of guessing at field semantics.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RateSmoothingState {
+    /// Schema version for this view response. Version 1 contains the persisted
+    /// smoothed rate, last target rate, and last-update ledger.
+    pub schema_version: u32,
+    /// Last effective borrow rate persisted under `RateModelKey::LastRate`.
+    pub current_rate_bps: i128,
+    /// Last target rate persisted under `RateModelKey::LastTargetRate`.
+    pub last_target_rate_bps: i128,
+    /// Last ledger sequence persisted under `RateModelKey::LastRateLedger`.
+    pub last_update_ledger: u32,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PositionSummary {
@@ -441,6 +462,33 @@ impl LendingContract {
             .persistent()
             .get(&DataKey::BadDebt)
             .unwrap_or(0i128)
+    }
+
+    /// Return the persisted borrow-rate smoothing state without recomputing rates.
+    ///
+    /// This view is intentionally read-only: it does not call `current_borrow_rate`,
+    /// does not write cache entries, and does not mutate rate-model storage. When
+    /// smoothing has never been initialized, all numeric state fields return `0`
+    /// with `schema_version = 1`.
+    pub fn get_rate_smoothing_state(env: Env) -> RateSmoothingState {
+        RateSmoothingState {
+            schema_version: SCHEMA_VERSION_V1,
+            current_rate_bps: env
+                .storage()
+                .instance()
+                .get(&rate_model::RateModelKey::LastRate)
+                .unwrap_or(0),
+            last_target_rate_bps: env
+                .storage()
+                .instance()
+                .get(&rate_model::RateModelKey::LastTargetRate)
+                .unwrap_or(0),
+            last_update_ledger: env
+                .storage()
+                .instance()
+                .get(&rate_model::RateModelKey::LastRateLedger)
+                .unwrap_or(0),
+        }
     }
 
     /// Set the configured oracle pubkey used to verify signed price updates.

--- a/stellar-lend/contracts/lending/src/rate_model.rs
+++ b/stellar-lend/contracts/lending/src/rate_model.rs
@@ -65,6 +65,7 @@ pub fn compute_borrow_rate(utilization_bps: i128, params: &RateParams) -> i128 {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RateModelKey {
     LastRate,
+    LastTargetRate,
     LastRateLedger,
 }
 
@@ -158,6 +159,9 @@ pub fn update_and_get_rate(env: &Env, target_rate: i128, params: &RateParams) ->
     env.storage()
         .instance()
         .set(&RateModelKey::LastRate, &clamped_rate);
+    env.storage()
+        .instance()
+        .set(&RateModelKey::LastTargetRate, &target_rate);
     env.storage()
         .instance()
         .set(&RateModelKey::LastRateLedger, &current_ledger);

--- a/stellar-lend/contracts/lending/src/rate_smoothing_state_test.rs
+++ b/stellar-lend/contracts/lending/src/rate_smoothing_state_test.rs
@@ -1,0 +1,109 @@
+#![cfg(test)]
+
+use crate::rate_model::{update_and_get_rate, RateParams};
+use crate::{LendingContract, LendingContractClient, RateSmoothingState};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_sequence_number(100);
+
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, client, id)
+}
+
+fn smoothing_params() -> RateParams {
+    let mut params = RateParams::default();
+    params.max_rate_change_per_ledger_bps = 50;
+    params.hysteresis_bps = 0;
+    params
+}
+
+#[test]
+fn rate_smoothing_state_defaults_when_uninitialized() {
+    let (_env, client, _id) = setup();
+
+    assert_eq!(
+        client.get_rate_smoothing_state(),
+        RateSmoothingState {
+            schema_version: 1,
+            current_rate_bps: 0,
+            last_target_rate_bps: 0,
+            last_update_ledger: 0,
+        }
+    );
+}
+
+#[test]
+fn rate_smoothing_state_matches_single_persisted_update() {
+    let (env, client, id) = setup();
+    let params = smoothing_params();
+
+    env.as_contract(&id, || {
+        assert_eq!(update_and_get_rate(&env, 1_700, &params), 1_700);
+    });
+
+    assert_eq!(
+        client.get_rate_smoothing_state(),
+        RateSmoothingState {
+            schema_version: 1,
+            current_rate_bps: 1_700,
+            last_target_rate_bps: 1_700,
+            last_update_ledger: 100,
+        }
+    );
+}
+
+#[test]
+fn rate_smoothing_state_tracks_several_updates_without_recomputation() {
+    let (env, client, id) = setup();
+    let params = smoothing_params();
+
+    env.as_contract(&id, || {
+        assert_eq!(update_and_get_rate(&env, 1_700, &params), 1_700);
+    });
+
+    env.ledger().set_sequence_number(101);
+    env.as_contract(&id, || {
+        assert_eq!(update_and_get_rate(&env, 2_700, &params), 1_750);
+    });
+
+    env.ledger().set_sequence_number(111);
+    env.as_contract(&id, || {
+        assert_eq!(update_and_get_rate(&env, 900, &params), 1_250);
+    });
+
+    assert_eq!(
+        client.get_rate_smoothing_state(),
+        RateSmoothingState {
+            schema_version: 1,
+            current_rate_bps: 1_250,
+            last_target_rate_bps: 900,
+            last_update_ledger: 111,
+        }
+    );
+}
+
+#[test]
+fn rate_smoothing_state_schema_is_stable_for_indexers() {
+    let (_env, client, _id) = setup();
+    let state = client.get_rate_smoothing_state();
+
+    assert_eq!(state.schema_version, 1);
+    let RateSmoothingState {
+        schema_version,
+        current_rate_bps,
+        last_target_rate_bps,
+        last_update_ledger,
+    } = state;
+    assert_eq!(schema_version, 1);
+    assert_eq!(current_rate_bps, 0);
+    assert_eq!(last_target_rate_bps, 0);
+    assert_eq!(last_update_ledger, 0);
+}


### PR DESCRIPTION
 PR description:

  ## Summary



  Adds a read-only `get_rate_smoothing_state` view for the lending contract so indexers and liquidation bots can read the persisted borrow-rate
  smoothing state directly.

  ## Changes

  - Added versioned `RateSmoothingState` return struct.
  - Added `get_rate_smoothing_state(env)` view exposing current rate, last target rate, last-update ledger, and schema version.
  - Reads the exact values persisted by `update_and_get_rate` under `RateModelKey`.
  - Returns zero defaults when smoothing state is uninitialized.
  - Added focused tests and documentation.

  Closes #1203 