### PR TITLE
feat: add per-asset borrow cap to cross_asset borrow with tests and docs

### DIFF
--- a/stellar-lend/contracts/lending/CROSS_ASSET_BORROW_CAP.md
+++ b/stellar-lend/contracts/lending/CROSS_ASSET_BORROW_CAP.md
@@ -1,0 +1,44 @@
+# Cross-Asset Borrow Cap
+
+Rationale
+
+A per-asset protocol borrow cap limits the total outstanding principal denominated
+in a given asset. This bounds single-asset concentration risk (e.g., too much
+of one borrowed asset outstanding) and complements existing per-asset debt
+ceilings and the aggregate protocol debt accumulator.
+
+Behavior
+
+- `borrow_cap` is stored inside `AssetParams` (raw asset units). A value of `0`
+  means "uncapped" and preserves current behaviour.
+- At borrow time, after accruing interest on the borrower's position, the
+  contract computes `total_debt_for(asset) + delta_principal` and rejects the
+  borrow with `LendingError::BorrowCapExceeded` if that value would exceed the
+  configured `borrow_cap` (and `borrow_cap != 0`).
+- Repayments decrement the tracked per-asset total so capacity is reclaimable.
+- All arithmetic is checked to avoid panics; numeric failures return
+  `LendingError::Overflow`.
+
+Worked example
+
+1. Admin sets `borrow_cap = 1000` for asset A.
+2. No current outstanding debt for asset A (total = 0).
+3. User X borrows 800 units of A: allowed → total becomes 800.
+4. User Y attempts to borrow 300 units of A: rejected with
+   `BorrowCapExceeded` because 800 + 300 > 1000.
+5. User X repays 200 units: total becomes 600. User Y can now borrow up to 400
+   units.
+
+Edge cases and notes
+
+- `borrow_cap = 0` means uncapped — useful for legacy behaviour and for
+  assets where the protocol does not want to impose a hard cap.
+- The cap is enforced after accrual — interest that increases a user's
+  principal can cause previously-available capacity to be consumed.
+- The enforcement uses checked arithmetic and rolls back per-user changes on
+  rejection so state remains consistent.
+- This feature is additive: it does not replace existing per-asset `debt_ceiling`
+  (a separate constraint) or overall protocol-level accounting.
+
+See code: `src/cross_asset.rs` for the enforcement site and `src/lib.rs` for the
+API change to `set_asset_params`.

--- a/stellar-lend/contracts/lending/src/cross_asset.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset.rs
@@ -578,6 +578,22 @@ pub fn borrow_asset_internal(
         }
         return Err(LendingError::DebtCeilingExceeded);
     }
+    // Enforce optional per-asset borrow cap: 0 means uncapped.
+    if params.borrow_cap != 0 && new_total_debt > params.borrow_cap {
+        save_debt_asset(
+            env,
+            user,
+            asset,
+            &DebtPosition {
+                principal: prev_principal,
+                last_update: now,
+            },
+        );
+        if prev_principal == 0 {
+            remove_from_user_debt_list(env, user, asset);
+        }
+        return Err(LendingError::BorrowCapExceeded);
+    }
     env.storage()
         .persistent()
         .set(&DataKey::TotalDebtAsset(asset.clone()), &new_total_debt);

--- a/stellar-lend/contracts/lending/src/cross_asset_borrow_cap_test.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_borrow_cap_test.rs
@@ -1,0 +1,81 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let asset = env.register(MockAsset, ());
+    client.initialize(&admin);
+    (env, client, id, admin, user)
+}
+
+#[test]
+fn test_uncapped_default_allows_large_borrow() {
+    let (env, client, id, admin, user) = setup();
+    let asset = env.register(MockAsset, ());
+    // uncapped borrow_cap == 0
+    client.set_asset_params(&admin, &asset, &7500i128, &8000i128, &1_000_000_000_000i128, &0i128);
+    client.deposit_collateral_asset(&user, &asset, &1_000_000i128);
+    // large borrow should succeed when uncapped (subject to HF)
+    let _ = client.borrow_asset(&user, &asset, &1000i128);
+}
+
+#[test]
+fn test_borrow_up_to_cap_allowed() {
+    let (env, client, id, admin, user) = setup();
+    let asset = env.register(MockAsset, ());
+    // set borrow cap to 1000
+    client.set_asset_params(&admin, &asset, &7500i128, &8000i128, &1_000_000_000_000i128, &1000i128);
+    client.deposit_collateral_asset(&user, &asset, &10_000i128);
+    let principal = client.borrow_asset(&user, &asset, &1000i128);
+    assert_eq!(principal, 1000);
+}
+
+#[test]
+fn test_borrow_over_cap_rejected() {
+    let (env, client, id, admin, user) = setup();
+    let asset = env.register(MockAsset, ());
+    client.set_asset_params(&admin, &asset, &7500i128, &8000i128, &1_000_000_000_000i128, &1000i128);
+    client.deposit_collateral_asset(&user, &asset, &10_000i128);
+    let res = client.try_borrow_asset(&user, &asset, &1001i128);
+    assert!(matches!(res, Err(Ok(LendingError::BorrowCapExceeded))));
+}
+
+#[test]
+fn test_repay_then_reborrow_under_cap() {
+    let (env, client, id, admin, user) = setup();
+    let asset = env.register(MockAsset, ());
+    client.set_asset_params(&admin, &asset, &7500i128, &8000i128, &1_000_000_000_000i128, &1000i128);
+    client.deposit_collateral_asset(&user, &asset, &10_000i128);
+    let _ = client.borrow_asset(&user, &asset, &800i128);
+    let remaining = client.repay_asset(&user, &asset, &300i128);
+    assert!(remaining <= 800);
+    // after repay 300, outstanding principal decreased — can borrow up to cap
+    let res = client.try_borrow_asset(&user, &asset, &500i128);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_cap_considers_accrual() {
+    let (env, client, id, admin, user) = setup();
+    let asset = env.register(MockAsset, ());
+    client.set_asset_params(&admin, &asset, &7500i128, &8000i128, &1_000_000_000_000i128, &1000i128);
+    client.deposit_collateral_asset(&user, &asset, &10_000i128);
+    // borrow small amount
+    let _ = client.borrow_asset(&user, &asset, &900i128);
+    // advance time so interest accrues and effective principal increases
+    env.ledger().with_mut(|l| l.timestamp += 31536000);
+    // now trying to borrow more that would push total (with accrued interest) > cap
+    let res = client.try_borrow_asset(&user, &asset, &200i128);
+    // either accepted or rejected depending on accrual; ensure borrow cap logic runs and returns typed error when exceeded
+    if let Err(Ok(err)) = res {
+        assert!(err == LendingError::BorrowCapExceeded || err == LendingError::HealthFactorTooLow);
+    }
+}

--- a/stellar-lend/contracts/lending/src/cross_asset_doctest.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_doctest.rs
@@ -11,8 +11,8 @@ mod doctest_worked_example {
         // Setup environment and client using existing test fixtures
         let (_env, client, _id, admin, user, asset_a, asset_b) = setup();
         // Configure assets to match worked example parameters
-        client.set_asset_params(&admin, &asset_a, 7500, 9000, 1_000_000_000_000i128);
-        client.set_asset_params(&admin, &asset_b, 8000, 8000, 1_000_000_000_000i128);
+        client.set_asset_params(&admin, &asset_a, 7500, 9000, 1_000_000_000_000i128, 0i128);
+        client.set_asset_params(&admin, &asset_b, 8000, 8000, 1_000_000_000_000i128, 0i128);
         // Deposit collateral: 100 units of asset_a (USDC), 1 unit of asset_b (ETH)
         client.deposit_collateral_asset(&user, &asset_a, 100i128);
         client.deposit_collateral_asset(&user, &asset_b, 1i128);

--- a/stellar-lend/contracts/lending/src/cross_asset_e2e_test.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_e2e_test.rs
@@ -61,9 +61,9 @@ fn setup() -> (
     client.initialize(&admin);
 
     // 75 % LTV / 80 % liquidation threshold for collateral asset
-    client.set_asset_params(&admin, &asset_col, &7500, &8000, &1_000_000_000_000i128);
+    client.set_asset_params(&admin, &asset_col, &7500, &8000, &1_000_000_000_000i128, &0i128);
     // 60 % LTV / 70 % liquidation threshold for debt asset
-    client.set_asset_params(&admin, &asset_dbt, &6000, &7000, &1_000_000_000_000i128);
+    client.set_asset_params(&admin, &asset_dbt, &6000, &7000, &1_000_000_000_000i128, &0i128);
 
     // Initial prices: both assets at $1.00
     set_price(&env, &id, &asset_col, 10_000_000);
@@ -455,7 +455,7 @@ fn e2e_two_collateral_one_debt_shock() {
 
     // Register a third asset as second collateral
     let asset_col2 = env.register(MockAsset, ());
-    client.set_asset_params(&admin, &asset_col2, &7500, &8000, &1_000_000_000_000i128);
+    client.set_asset_params(&admin, &asset_col2, &7500, &8000, &1_000_000_000_000i128, &0i128);
     set_price(&env, &id, &asset_col2, 10_000_000); // $1.00
 
     // Deposit both collateral assets

--- a/stellar-lend/contracts/lending/src/cross_asset_roundtrip_test.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_roundtrip_test.rs
@@ -34,6 +34,7 @@ fn setup() -> (
         &7500,                  // 75% LTV
         &8000,                  // 80% liquidation threshold
         &1_000_000_000_000i128, // debt ceiling
+        &0i128,                 // borrow_cap (0 = uncapped)
     );
     client.set_asset_params(
         &admin,
@@ -41,6 +42,7 @@ fn setup() -> (
         &6000,                  // 60% LTV
         &7000,                  // 70% liquidation threshold
         &1_000_000_000_000i128, // debt ceiling
+        &0i128,                 // borrow_cap (0 = uncapped)
     );
 
     // Set oracle prices: 10_000_000 = $1.00 (7-decimal precision)

--- a/stellar-lend/contracts/lending/src/cross_asset_test.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_test.rs
@@ -28,6 +28,7 @@ fn setup() -> (
         &7500,                  // 75% LTV
         &8000,                  // 80% liquidation threshold
         &1_000_000_000_000i128, // debt ceiling
+        &0i128,                 // borrow_cap (0 = uncapped)
     );
     client.set_asset_params(
         &admin,
@@ -35,6 +36,7 @@ fn setup() -> (
         &6000,                  // 60% LTV
         &7000,                  // 70% liquidation threshold
         &1_000_000_000_000i128, // debt ceiling
+        &0i128,                 // borrow_cap (0 = uncapped)
     );
 
     // Set oracle prices: 10_000_000 = $1.00 (7-decimal precision)
@@ -72,7 +74,7 @@ fn test_set_asset_params_stores_and_reads() {
 #[test]
 fn test_set_asset_params_rejects_invalid_ltv() {
     let (_env, client, _id, admin, _user, asset_a, _asset_b) = setup();
-    let res = client.try_set_asset_params(&admin, &asset_a, &15000i128, &8000i128, &1_000_000i128);
+    let res = client.try_set_asset_params(&admin, &asset_a, &15000i128, &8000i128, &1_000_000i128, &0i128);
     assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
@@ -301,7 +303,7 @@ fn test_missing_price_feed_rejects_withdraw() {
 #[test]
 fn test_zero_ltv_asset_cannot_borrow_against_it() {
     let (_env, client, _id, admin, user, asset_a, asset_b) = setup();
-    client.set_asset_params(&admin, &asset_a, &0i128, &0i128, &1_000_000_000_000i128);
+    client.set_asset_params(&admin, &asset_a, &0i128, &0i128, &1_000_000_000_000i128, &0i128);
     client.deposit_collateral_asset(&user, &asset_a, &1000i128);
     client.deposit_collateral_asset(&user, &asset_b, &1i128);
     // weighted collateral = asset_b only: 1*2000*0.7 = 1400
@@ -321,7 +323,7 @@ fn test_set_asset_params_rejects_unauthorized() {
     let asset = Address::generate(&env);
     env.mock_all_auths();
     client.initialize(&admin);
-    let res = client.try_set_asset_params(&attacker, &asset, &5000i128, &6000i128, &1_000_000i128);
+    let res = client.try_set_asset_params(&attacker, &asset, &5000i128, &6000i128, &1_000_000i128, &0i128);
     assert!(res.is_err());
 }
 
@@ -395,7 +397,7 @@ fn test_hf_below_10000_rejected() {
 #[test]
 fn test_debt_ceiling_rejects_excess() {
     let (_env, client, _id, admin, user, asset_a, asset_b) = setup();
-    client.set_asset_params(&admin, &asset_a, &7500i128, &8000i128, &100i128);
+    client.set_asset_params(&admin, &asset_a, &7500i128, &8000i128, &100i128, &0i128);
     client.deposit_collateral_asset(&user, &asset_b, &2i128);
     let res = client.try_borrow_asset(&user, &asset_a, &200i128);
     assert!(matches!(res, Err(Ok(LendingError::DebtCeilingExceeded))));

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -272,6 +272,9 @@ pub enum LendingError {
     PositionHealthy = 1011,
     DebtCeilingExceeded = 2001,
     DepositCapExceeded = 2002,
+    /// A borrow would push total outstanding debt for the asset beyond the
+    /// configured per-asset `borrow_cap`.
+    BorrowCapExceeded = 2003,
     InvalidFeeBps = 2005,
     InvalidFlashUtilizationBps = 2006,
     InsufficientCollateral = 2007,
@@ -367,6 +370,9 @@ pub struct AssetParams {
     pub ltv_bps: i128,
     pub liquidation_threshold_bps: i128,
     pub debt_ceiling: i128,
+    /// Per-asset protocol borrow cap: maximum total outstanding debt for this asset.
+    /// A value of 0 means uncapped (no limit enforced).
+    pub borrow_cap: i128,
 }
 
 #[contracttype]
@@ -384,6 +390,7 @@ pub struct AssetParamsSetEvent {
     pub ltv_bps: i128,
     pub liquidation_threshold_bps: i128,
     pub debt_ceiling: i128,
+    pub borrow_cap: i128,
 }
 
 #[contractevent]
@@ -1633,6 +1640,7 @@ impl LendingContract {
         ltv_bps: i128,
         liquidation_threshold_bps: i128,
         debt_ceiling: i128,
+        borrow_cap: i128,
     ) -> Result<(), LendingError> {
         admin.require_auth();
         if admin != Self::get_admin(env.clone()) {
@@ -1647,11 +1655,15 @@ impl LendingContract {
         if debt_ceiling < 0 {
             return Err(LendingError::InvalidAmount);
         }
+        if borrow_cap < 0 {
+            return Err(LendingError::InvalidAmount);
+        }
 
         let params = AssetParams {
             ltv_bps,
             liquidation_threshold_bps,
             debt_ceiling,
+            borrow_cap,
         };
         cross_asset::set_asset_params_internal(&env, &asset, &params);
 
@@ -1660,6 +1672,7 @@ impl LendingContract {
             ltv_bps,
             liquidation_threshold_bps,
             debt_ceiling,
+            borrow_cap,
         }
         .publish(&env);
 

--- a/stellar-lend/contracts/lending/src/liquidate_pause_test.rs
+++ b/stellar-lend/contracts/lending/src/liquidate_pause_test.rs
@@ -24,7 +24,7 @@ mod liquidate_pause_test {
         client.initialize(&admin);
         // configure a simple asset
         let asset = Address::generate(&env);
-        client.set_asset_params(&admin, &asset, &7500, &8000, &1_000_000_000_000i128);
+        client.set_asset_params(&admin, &asset, &7500, &8000, &1_000_000_000_000i128, &0i128);
         // make borrower unhealthy: deposit 100, borrow 200
         client.deposit(&borrower, &100);
         client.borrow(&borrower, &200);

--- a/stellar-lend/contracts/lending/src/storage_tier_test.rs
+++ b/stellar-lend/contracts/lending/src/storage_tier_test.rs
@@ -192,6 +192,7 @@ fn test_asset_params_uses_persistent_storage() {
         &7_000i128,
         &8_000i128,
         &1_000_000_000i128,
+        &0i128,
     );
 
     env.as_contract(&contract_id, || {


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed



Closes #1212 