### PR TITLE
feat(bridge): add guardian-gated per-validator signing-pause flag (#1221)

### DIFF
--- a/stellar-lend/contracts/bridge/VALIDATOR_PAUSE.md
+++ b/stellar-lend/contracts/bridge/VALIDATOR_PAUSE.md
@@ -1,0 +1,275 @@
+# Per-Validator Signing Pause (Issue #1221)
+
+This document describes the per-validator pause feature added to
+`stellar-lend/contracts/bridge/src/lib.rs`. It explains the threat model the
+feature is built against, the public-facing API, the fail-closed math used
+to prevent the bridge from being frozen by an overly-aggressive guardian,
+and the on-the-wire shape of the events emitted on pause / unpause.
+
+## Why this feature exists
+
+StellarLend's bridge contract authenticates validator-set changes via a
+strict supermajority > 2/3 quorum proof. If a single validator key is
+compromised, the safest recovery is to *rotate the entire validator set*
+through a quorum vote. But quorum-of-current-validators requires the
+*current* set to reach threshold, which a single compromised but otherwise
+honest minority cannot obstruct — except operationally, a compromised key
+is a *known* problem and the bridge operators want to be able to act faster
+than the next rotation cycle.
+
+This feature lets the bridge's guardian exclude a single compromised
+validator from quorum counting immediately, **without rotating the full
+set**. The remaining active validators continue running the bridge at the
+new (smaller) effective threshold while a proper key rotation is
+planned and executed on a normal timeline.
+
+## Public API
+
+The feature exposes three new methods on `Bridge`, plus a small set of
+introspectors and one new typed error type, all defined in `src/lib.rs`.
+
+### Guardian configuration
+
+```rust
+pub fn set_guardian(&mut self, guardian: PublicKey);
+pub fn guardian(&self) -> Option<&PublicKey>;
+```
+
+- `set_guardian` is **not** signature-protected. The bridge is a pure-Rust
+  data structure; the trust assumption is that whoever holds the
+  `&mut Bridge` is also trusted to configure its guardian, similarly to
+  how the validator set, inbound cap, and window size are configured.
+  Operational guidance: call `set_guardian` exactly once, on a trusted host,
+  immediately after `Bridge::new`. The companion toggles
+  (`pause_validator`, `unpause_validator`) are signature-protected, so a
+  later attempt to exfiltrate the bridge by rewriting the guardian still
+  requires possession of the current guardian's signing key.
+
+### Pause / unpause
+
+```rust
+pub fn pause_validator(&mut self, validator: &PublicKey, signature: &Signature)
+    -> Result<ValidatorEvent>;
+
+pub fn unpause_validator(&mut self, validator: &PublicKey, signature: &Signature)
+    -> Result<ValidatorEvent>;
+```
+
+Both return a typed [``ValidatorEvent`] describing what just happened,
+including the byte-encoding of the affected validator key and the bridge
+epoch at the time the action took effect. The caller is expected to
+serialize or log these events so downstream tooling can react (alert,
+re-rotate, etc.).
+
+### Event type
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ValidatorEvent {
+    Paused   { validator: Vec<u8>, epoch: u64 },
+    Unpaused { validator: Vec<u8>, epoch: u64 },
+}
+```
+
+Events are returned from the operation rather than published through a
+host-managed event bus, since this crate is off-chain Rust and does not
+have access to a Soroban host. The `Serialize` / `Deserialize` impls let
+callers encode events with their preferred format (JSON, bincode, etc.).
+
+### Introspectors
+
+```rust
+pub fn is_paused(&self, pk: &PublicKey) -> bool;
+pub fn is_active_validator(&self, pk: &PublicKey) -> bool;
+pub fn active_validator_count(&self) -> usize;
+pub fn effective_threshold(&self) -> usize;
+pub fn paused_list(&self) -> Vec<Vec<u8>>;
+```
+
+- `active_validator_count` and `effective_threshold` are the on-the-wire
+  versions of the count and threshold numbers used in
+  `verify_quorum_proof`. They are recomputed dynamically so a caller can
+  audit the live quorum math at any time.
+- `is_active_validator` reports whether a given key would count toward
+  quorum right now (i.e., is in the validator set AND not paused).
+- `paused_list` returns the raw byte encodings of all currently paused
+  keys in arbitrary set-iteration order.
+
+## Authorisation: signature payload binding
+
+A pause or unpause signature from the guardian must verify over a
+domain-separated payload that binds the authorisation to (action, target):
+
+| Action     | Payload prefix           | Bound target            |
+|-----------|--------------------------|-------------------------|
+| `pause`   | `"BRIDGE_PAUSE:"`        | `validator.to_bytes()` |
+| `unpause` | `"BRIDGE_UNPAUSE:"`      | `validator.to_bytes()` |
+
+Because the two prefixes differ, a `pause(A)` signature cannot be replayed
+as `unpause(A)`, and the per-target binding means `pause(A)` cannot be
+replayed as `pause(B)`. Both replay vectors are tested in
+`validator_pause_test.rs`:
+
+- `pause_signature_cannot_be_replayed_as_unpause`
+- `pause_signature_for_a_cannot_be_replayed_for_b`
+
+Similarly, a signature whose signer is not the configured guardian is
+rejected with `BridgeError::InvalidGuardianSignature` (the signature is
+checked after the fail-closed arithmetic, so a malicious caller cannot
+burn a guardian signature on a request that would have been rejected on
+quorum-math grounds anyway).
+
+## Fail-closed semantics
+
+`Bridge::pause_validator` is invoked with a target validator and a
+guardian signature. Before verifying the signature, we compute what
+the *post-pause* active validator count would be and reject if it would
+fall below the new effective supermajority threshold. Concretely:
+
+```
+let current_active = bridge.active_validator_count();
+let new_active     = current_active - 1;       // pausing reduces by exactly one
+let new_threshold  = (new_active * 2) / 3 + 1; // supermajority of the remaining
+if new_active < new_threshold {
+    return Err(PauseWouldBreakQuorum);
+}
+```
+
+This protects the bridge from being frozen by an overly aggressive
+guardian — the bridge prefers to remain live with a known-compromised
+key over freezing itself.
+
+| n (current set) | Old threshold | Pausing 1 ⇒ new active | New threshold | Pausing 1 allowed? |
+|----|------|------|------|------|
+| 3  | 3    | 2    | 2    | ✅ (2 >= 2) |
+| 4  | 3    | 3    | 3    | ✅ (3 >= 3) |
+| 5  | 4    | 4    | 3    | ✅ |
+| 6  | 5    | 5    | 4    | ✅ |
+| …  | …    | …    | …    | ✅ until active count hits threshold |
+| 2  | 2    | 1    | 1    | ✅ (1 >= 1) |
+| 1  | 1    | 0    | 1    | ❌ (0 < 1) — fail-closed |
+| 0  | 1    | 0    | 1    | ❌ (0 < 1) — unreachable via pause |
+
+The fail-closed check is enforced *before* consuming the guardian's
+signature, so a paused validator request that would have been rejected
+on quorum-math grounds does not leak signature material via rejected-call
+logs.
+
+## Effect on quorum verification
+
+`Bridge::verify_quorum_proof` is the workhorse function for all rotation
+proofs; this feature modifies it in two ways:
+
+1. **Paused signers are silently skipped.** When the loop encounters a
+   signer whose byte-encoding is in `paused_validators`, it neither
+   verifies the signature nor counts it toward quorum. This is a
+   deliberate non-error: a paused signer may still appear in relay-
+   network gossip, and rejecting an otherwise-valid proof solely because
+   of a stale signature from a paused key would let an attacker (who
+   possesses the compromised key but no longer any operational standing)
+   perform a denial-of-service on bridge rotations. Skipping is the
+   correct BFT-flavoured response to a known-untrusted voter.
+
+2. **Quorum threshold is recomputed against active validators.** A
+   `Bridge` with 4 validators and 1 paused has effective
+   `threshold() = 3`, so quorum can be reached with 3 of the 3
+   remaining active signers (the formerly-paused signer's vote is
+   ignored). The original `ValidatorSet::threshold()` is unchanged and
+   is preserved for callers that want the unpaused-baseline number.
+
+The combined effect: after a non-breaking pause, a bridge can still
+rotate to a new validator set using the (smaller) effective threshold,
+without waiting for the compromised key to be removed from the
+validator set proper.
+
+## Effect on `rotate_validators`
+
+`Bridge::rotate_validators` clears `paused_validators` on success. This
+is intentional: pause flags are scoped to the *compromised key material*
+in the *current* validator set, and the *new* set implies fresh,
+unpaused keys by default. If a key from the old set happens to also be
+present in the new set, that is a configuration choice the operator
+must make explicitly, via a subsequent `pause_validator` call.
+
+## Error types
+
+All typed errors carry an explicit variant so callers (deployment
+scripts, alerting tooling) can match on them rather than substring-
+matching error strings. See
+
+```rust
+pub enum BridgeError {
+    InvalidWindowSize,
+    NoGuardianConfigured,
+    InvalidGuardianSignature,
+    UnknownValidator,
+    PauseWouldBreakQuorum,
+    AlreadyPaused,
+    NotPaused,
+}
+```
+
+The new variants are appended without disturbing existing ones. The
+existing `Display` impl for `Display` and the in-crate
+`std::error::Error` trait impl cover the new variants too.
+
+## Edge cases covered by the test suite
+
+`src/validator_pause_test.rs` exercises every documented branch above:
+
+| Scenario | Test |
+|---|---|
+| Default state has no guardian and empty paused set | `fresh_bridge_has_no_guardian_and_empty_paused_set` |
+| Pause / unpause reject without a configured guardian | `pause_rejects_without_configured_guardian`, `unpause_rejects_without_configured_guardian` |
+| Pause / unpause reject on invalid guardian signature | `pause_rejects_if_signature_does_not_verify_against_guardian`, `unpause_rejects_if_signature_does_not_verify_against_guardian` |
+| Pause signature cannot be replayed as unpause (and vice versa) | `pause_signature_cannot_be_replayed_as_unpause` |
+| Pause(A) signature cannot be replayed as pause(B) | `pause_signature_for_a_cannot_be_replayed_for_b` |
+| Double-pause is rejected (idempotent rejection) | `pause_rejects_when_already_paused` |
+| Unpause of non-paused is rejected | `unpause_rejects_when_not_paused` |
+| Pause / unpause reject unknown validator | `pause_rejects_unknown_validator`, `unpause_rejects_unknown_validator` |
+| Pause rejected when active count would drop below new threshold | `pause_rejected_when_active_count_would_fall_below_new_threshold` |
+| Pause accepted when active count still meets new threshold | `pause_accepted_when_active_count_meets_new_threshold` |
+| Pause-and-pause-and-pause-and-pause — only the last one (which would leave zero active) is rejected | `pause_rejected_only_when_quorum_becomes_unreachable` |
+| Rotation succeeds with reduced threshold after pause | `rotation_with_one_paused_validator_uses_new_threshold`, `rotation_uses_effective_threshold_for_size_check` |
+| Rotation rejects when active signers < new threshold | `rotation_rejects_when_active_signers_below_new_threshold` |
+| Malformed signature from a paused validator doesn't poison the proof | `malformed_paused_signature_does_not_break_proof` |
+| Paused signers don't inflate duplicate counts | `paused_signer_does_not_count_as_unique_vote` |
+| Round-trip pause → unpause restores active count | `pause_then_unpause_restores_active_count_and_threshold` |
+| Rotation clears the paused set on success | `rotation_clears_paused_set` |
+| `paused_list` returns the byte-encodings of paused keys | `paused_list_returns_byte_encodings_of_paused_keys` |
+| `is_active_validator` returns correct status | `is_active_validator_returns_false_for_paused_or_unknown` |
+| `ValidatorEvent` Display includes epoch and hex pk | `validator_event_display_includes_epoch_and_hex_pk` |
+
+## Operational guidance for maintainers
+
+- **Configure the guardian once, on a trusted host.** Replacing the
+  guardian afterwards is currently an unauthenticated operation; if you
+  need a two-step handover, build it on top of `set_guardian`.
+- **Use the fail-closed check as a tool, not an obstacle.** The
+  `PauseWouldBreakQuorum` guard is meant for "pause a single compromised
+  validator" operations, not "paused-majority" operations. If you need to
+  pause more than a minority and the math forbids it, schedule a proper
+  rotation (using the still-active quorum).
+- **Log every ValidatorEvent.** Pause and unpause operations are rare but
+  security-critical; every successful (and rejected) event should make
+  it to an audit pipeline so security teams can correlate with
+  compromised-key disclosures from operators.
+- **Re-check the threshold after a pause.** A pause lowers the
+  effective quorum threshold. If the bridge was previously operating
+  on the assumption `threshold = floor(2n/3) + 1` for the *original*
+  `n`, downstream tooling that hard-codes a signer count must be
+  reconfigured to use `effective_threshold()` instead.
+
+## See also
+
+- `src/lib.rs` — implementation (`pause_validator`, `unpause_validator`,
+  `effective_threshold`, `ValidatorEvent`).
+- `src/validator_pause_test.rs` — full test coverage.
+- `src/rotation_test.rs` — quorum-proof tests that the new
+  `verify_quorum_proof` rules apply to.
+- `SECURITY_NOTES.md` — broader bridge threat model.
+- `WINDOW_GUARD.md` — pattern for fail-closed inbound-value caps, which
+  we follow for `pause` (prefer to stay live with a known-compromised
+  key than freeze the bridge).
+- `VALIDATORSET_INVARIANTS.md` — how deduplicated validator counts feed
+  both the original `threshold` and the new `effective_threshold`.

--- a/stellar-lend/contracts/bridge/src/lib.rs
+++ b/stellar-lend/contracts/bridge/src/lib.rs
@@ -9,17 +9,98 @@ use std::collections::HashSet;
 pub enum BridgeError {
     /// Emitted when attempting to configure a rolling window of length 0.
     InvalidWindowSize,
+    /// No guardian key has been configured for this bridge. Pause / unpause
+    /// requires a guardian to be set via [`Bridge::set_guardian`].
+    NoGuardianConfigured,
+    /// The signature supplied to authorise a guardian action (pause, unpause,
+    /// or future guardian-protected operations) did not verify against the
+    /// configured guardian key over the expected action-bound payload.
+    InvalidGuardianSignature,
+    /// The caller asked us to pause / unpause a validator whose public key is
+    /// not in the current validator set.
+    UnknownValidator,
+    /// Pausing this validator would drop the active validator count below the
+    /// effective supermajority quorum threshold, so quorum would become
+    /// unreachable. Rejected (fail-closed) — the bridge prefers to remain
+    /// live with a known-compromised key over freezing itself.
+    PauseWouldBreakQuorum,
+    /// The validator requested for pause was already in the paused set.
+    AlreadyPaused,
+    /// The validator requested for unpause was not in the paused set.
+    NotPaused,
 }
 
 impl std::fmt::Display for BridgeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             BridgeError::InvalidWindowSize => write!(f, "InvalidWindowSize: window_size must be > 0"),
+            BridgeError::NoGuardianConfigured => {
+                write!(f, "NoGuardianConfigured: bridge has no guardian key set")
+            }
+            BridgeError::InvalidGuardianSignature => {
+                write!(f, "InvalidGuardianSignature: guardian signature did not verify")
+            }
+            BridgeError::UnknownValidator => {
+                write!(f, "UnknownValidator: target validator not in current validator set")
+            }
+            BridgeError::PauseWouldBreakQuorum => write!(
+                f,
+                "PauseWouldBreakQuorum: pausing this validator would leave active count below the effective quorum threshold"
+            ),
+            BridgeError::AlreadyPaused => write!(f, "AlreadyPaused: validator is already paused"),
+            BridgeError::NotPaused => write!(f, "NotPaused: validator is not currently paused"),
         }
     }
 }
 
 impl std::error::Error for BridgeError {}
+/// Events emitted by guardian-gated validator-pause operations. Callers (e.g.
+/// off-chain tooling, audit pipelines, or a Soroban host adapter) are expected
+/// to serialize or log these events so downstream consumers can react (alert,
+/// rotate keys, fan out to other nodes, etc.).
+///
+/// In this off-chain Rust crate we do not have a host-managed event log; we
+/// return the typed event from the operation so callers can persist it
+/// however they store the bridge. The on-the-wire shape is determined by the
+/// caller's chosen encoder.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ValidatorEvent {
+    /// A validator has been paused by the guardian. Signatures from this key
+    /// are now ignored in `verify_quorum_proof` and the effective quorum
+    /// threshold is recomputed against the remaining active validators.
+    Paused {
+        /// Raw byte encoding of the paused validator's public key, so the
+        /// event is self-describing for layers that don't have direct access
+        /// to the `ValidatorSet`.
+        validator: Vec<u8>,
+        /// Bridge epoch at the time the pause became effective.
+        epoch: u64,
+    },
+    /// A previously paused validator has been resumed. The key is counted
+    /// toward quorum again from this point forward.
+    Unpaused {
+        validator: Vec<u8>,
+        epoch: u64,
+    },
+}
+
+impl std::fmt::Display for ValidatorEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidatorEvent::Paused { validator, epoch } => write!(
+                f,
+                "ValidatorPaused(epoch={epoch}, pk=0x{})",
+                lowercase_hex(validator)
+            ),
+            ValidatorEvent::Unpaused { validator, epoch } => write!(
+                f,
+                "ValidatorUnpaused(epoch={epoch}, pk=0x{})",
+                lowercase_hex(validator)
+            ),
+        }
+    }
+}
+
 /// Store validator public keys as raw bytes so the struct remains serde-friendly
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidatorSet {
@@ -82,16 +163,45 @@ pub struct Bridge {
     pub window_start: u64,
     /// Cumulative inbound value admitted so far within `[window_start, window_start + window_size)`.
     pub window_inbound_total: i128,
+    /// Set of byte-encoded public keys of validators that the guardian has
+    /// paused. Signatures from paused validators are silently skipped
+    /// (not counted toward quorum, not verified) in
+    /// [`Bridge::verify_quorum_proof`], and the effective quorum threshold is
+    /// recomputed against the active (non-paused) subset.
+    ///
+    /// Pauses are scoped to the current validator set: a successful call to
+    /// [`Bridge::rotate_validators`] clears this set, since the new validator
+    /// set implies fresh key material and stale pause flags are meaningless.
+    /// See [`VALIDATOR_PAUSE.md`](https://example.invalid/VALIDATOR_PAUSE.md)
+    /// for the full rationale.
+    pub paused_validators: HashSet<Vec<u8>>,
+    /// Guardian public key authorised to pause / unpause individual
+    /// validators. `None` means the bridge has no guardian configured;
+    /// [`Bridge::pause_validator`] and [`Bridge::unpause_validator`] are both
+    /// rejected with [`BridgeError::NoGuardianConfigured`] until a guardian is
+    /// configured via [`Bridge::set_guardian`].
+    pub guardian: Option<PublicKey>,
 }
 
 /// Default rolling window length: one day, in seconds.
 pub const DEFAULT_INBOUND_WINDOW_SECS: u64 = 86_400;
+
+/// Domain separator tags prepended to guardian-signed payloads for
+/// pause / unpause authorisations. Binding the tag into the signed payload
+/// prevents replay of a `pause_validator` signature against
+/// `unpause_validator` (or vice versa) and prevents cross-action confusion.
+const PAUSE_PAYLOAD_TAG: &[u8] = b"BRIDGE_PAUSE:";
+const UNPAUSE_PAYLOAD_TAG: &[u8] = b"BRIDGE_UNPAUSE:";
 
 impl Bridge {
     /// Construct a new bridge. Inbound value transfer is **fail-closed by
     /// default**: `max_per_window` starts at `0`, so [`Bridge::admit_inbound`]
     /// rejects everything until [`Bridge::set_inbound_cap`] is called with a
     /// non-zero cap.
+    ///
+    /// A freshly constructed `Bridge` has no guardian (so pause / unpause
+    /// calls are rejected) and an empty paused set. Operators must opt in
+    /// to guardian-gated operations via [`Bridge::set_guardian`].
     pub fn new(initial: ValidatorSet) -> Self {
         Bridge {
             epoch: 0,
@@ -100,11 +210,101 @@ impl Bridge {
             window_size: DEFAULT_INBOUND_WINDOW_SECS,
             window_start: 0,
             window_inbound_total: 0,
+            paused_validators: HashSet::new(),
+            guardian: None,
         }
     }
 
-    /// Verify a quorum proof from the current validator set over the (new_set, epoch) payload
-    fn verify_quorum_proof(&self, new_set: &ValidatorSet, epoch: u64, proofs: &[(PublicKey, Signature)]) -> Result<()> {
+    /// Configure the guardian public key authorised to pause / unpause
+    /// individual validators.
+    ///
+    /// Although this method has no signature check (the bridge is a
+    /// pure-Rust data structure with no built-in notion of a privileged
+    /// host), operational guidance is to call it exactly once, on a trusted
+    /// host, immediately after [`Bridge::new`]. Replacing the guardian
+    /// later must only be done on the same trusted path; there is no
+    /// built-in two-step handover — if you need one, build it on top of
+    /// `set_guardian`.
+    pub fn set_guardian(&mut self, guardian: PublicKey) {
+        self.guardian = Some(guardian);
+    }
+
+    /// Returns `Some(&guardian_public_key)` if a guardian has been
+    /// configured, otherwise `None`.
+    pub fn guardian(&self) -> Option<&PublicKey> {
+        self.guardian.as_ref()
+    }
+
+    /// Returns the number of active (non-paused) validators.
+    ///
+    /// "Active" excludes any validator whose byte-encoded public key is in
+    /// [`Bridge::paused_validators`]. Duplicate keys in the raw validator
+    /// list still collapse to one logical validator, matching
+    /// [`ValidatorSet::len`] semantics.
+    pub fn active_validator_count(&self) -> usize {
+        self.validators
+            .validators
+            .iter()
+            .filter(|v| !self.paused_validators.contains(*v))
+            .map(|v| v.as_slice())
+            .collect::<HashSet<_>>()
+            .len()
+    }
+
+    /// Effective supermajority quorum threshold computed from the active
+    /// (non-paused) validator count.
+    ///
+    /// If every validator is paused, this returns `1` — the same value
+    /// [`ValidatorSet::threshold`] returns for an empty set. This is a
+    /// documented edge case: a fully-paused bridge is mathematically
+    /// unreachable (no active signer can ever meet any threshold > 0) and
+    /// pause / unpause calls will reject based on the fail-closed
+    /// arithmetic before this returns in any realistic configuration. See
+    /// [`BridgeError::PauseWouldBreakQuorum`] for the guard that prevents
+    /// the bridge from getting into this state in the first place.
+    pub fn effective_threshold(&self) -> usize {
+        let n = self.active_validator_count();
+        (n * 2) / 3 + 1
+    }
+
+    /// Returns `true` iff `pk`'s byte encoding is in the paused set.
+    ///
+    /// This is a pure membership check; it does **not** validate that the
+    /// validator is also part of the current validator set. To check both
+    /// conditions, see [`Bridge::is_active_validator`].
+    pub fn is_paused(&self, pk: &PublicKey) -> bool {
+        self.paused_validators.contains(&pk.to_bytes().to_vec())
+    }
+
+    /// Returns `true` iff `pk` is currently part of the validator set
+    /// **and** is not paused — i.e. its signature counts toward quorum.
+    pub fn is_active_validator(&self, pk: &PublicKey) -> bool {
+        self.validators.contains_pk(pk) && !self.is_paused(pk)
+    }
+
+    /// Returns the raw byte-encoding of every currently-paused validator,
+    /// in arbitrary set-iteration order. Useful for audit / introspection
+    /// tooling.
+    pub fn paused_list(&self) -> Vec<Vec<u8>> {
+        self.paused_validators.iter().cloned().collect()
+    }
+
+    /// Verify a quorum proof from the current validator set over the (new_set, epoch) payload.
+    ///
+    /// Paused validator signatures are *silently skipped* — they are neither
+    /// verified nor counted toward the quorum, and they do not cause the
+    /// overall proof to fail. Skipping (rather than rejecting on sight) is a
+    /// deliberate choice: a compromised key may still be present in the
+    /// relay-network gossip, so silently ignoring it lets a bridge keep
+    /// operating under quorum with a known-compromised signer excluded. The
+    /// effective quorum threshold is recomputed from the active (non-paused)
+    /// validator subset.
+    fn verify_quorum_proof(
+        &self,
+        new_set: &ValidatorSet,
+        epoch: u64,
+        proofs: &[(PublicKey, Signature)],
+    ) -> Result<()> {
         if proofs.is_empty() {
             return Err(anyhow!("empty proofs"));
         }
@@ -112,25 +312,36 @@ impl Bridge {
         // payload to be signed: bincode(new_set_bytes_vec, epoch)
         let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch))?;
 
-        let mut unique_signers: HashSet<Vec<u8>> = HashSet::new();
+        let mut unique_active_signers: HashSet<Vec<u8>> = HashSet::new();
         for (pk, sig) in proofs.iter() {
-            // signer must be part of the current validator set
+            // Signer must be part of the current validator set. This applies
+            // to paused validators, too — paused keys must still be in the
+            // current set; otherwise they should have been rotated out.
             if !self.validators.contains_pk(pk) {
                 return Err(anyhow!("proof contains signer not in current validator set"));
             }
 
-            // avoid double counting
+            // Paused validators are silently skipped. They do not count
+            // toward the quorum, and we do not verify their signature
+            // (the key is presumed compromised, so its signature carries no
+            // trust weight; verifying it is wasted work, and a malformed
+            // signature from a compromised-but-paused key should not bring
+            // down the rest of the proof).
             let key_bytes = pk.to_bytes().to_vec();
-            if unique_signers.contains(&key_bytes) {
+            if self.paused_validators.contains(&key_bytes) {
                 continue;
             }
 
-            // verify signature
+            // Deduplicate within the active subset.
+            if unique_active_signers.contains(&key_bytes) {
+                continue;
+            }
+
             pk.verify(&payload, sig).map_err(|e| anyhow!(e.to_string()))?;
-            unique_signers.insert(key_bytes);
+            unique_active_signers.insert(key_bytes);
         }
 
-        if unique_signers.len() < self.validators.threshold() {
+        if unique_active_signers.len() < self.effective_threshold() {
             return Err(anyhow!("insufficient quorum in proofs"));
         }
 
@@ -139,7 +350,19 @@ impl Bridge {
 
     /// Rotate validators to `new_set` at `next_epoch` if `proofs` from current set form a quorum.
     /// The `epoch` must be exactly current_epoch + 1.
-    pub fn rotate_validators(&mut self, new_set: ValidatorSet, epoch: u64, proofs: Vec<(PublicKey, Signature)>) -> Result<()> {
+    ///
+    /// The paused-validator set is cleared on rotation: pauses are scoped to
+    /// the compromised key material in the *current* set, and the *new* set
+    /// implies fresh, unpaused keys by default. If a key from the old set
+    /// happens to also be present in the new set, that's a configuration
+    /// choice the operator must make explicitly via a subsequent
+    /// [`Bridge::pause_validator`] call.
+    pub fn rotate_validators(
+        &mut self,
+        new_set: ValidatorSet,
+        epoch: u64,
+        proofs: Vec<(PublicKey, Signature)>,
+    ) -> Result<()> {
         if epoch != self.epoch + 1 {
             return Err(anyhow!("invalid epoch: must be current_epoch + 1"));
         }
@@ -149,7 +372,116 @@ impl Bridge {
         // swap atomically
         self.validators = new_set;
         self.epoch = epoch;
+        // stale pause flags belong to the old (rotated-out) key material; clear.
+        self.paused_validators.clear();
         Ok(())
+    }
+
+    /// Guardian-gated pause of a single validator.
+    ///
+    /// On success the validator is added to [`Bridge::paused_validators`] and
+    /// a [`ValidatorEvent::Paused`] event is returned for the caller to log
+    /// or persist. The validator's signature is ignored in subsequent
+    /// `verify_quorum_proof` calls, and the effective quorum threshold is
+    /// recomputed against the remaining active validators.
+    ///
+    /// ### Fail-closed guard
+    ///
+    /// The *supplied* signature is verified against the configured
+    /// [`Bridge::guardian`] (not against `validator`) over the action-bound
+    /// payload `"BRIDGE_PAUSE:" || validator.to_bytes()`. This binds the
+    /// authorisation to a specific (action, target_validator) pair so a
+    /// pause signature cannot be replayed as an unpause signature, and vice
+    /// versa (the inverse tag `"BRIDGE_UNPAUSE:"` is used for unpauses).
+    ///
+    /// Pausing is rejected with [`BridgeError::PauseWouldBreakQuorum`] if it
+    /// would leave the active validator count below the new effective
+    /// supermajority threshold (so a quorum-proof could never reach the new
+    /// threshold). This protects the bridge from being frozen by an overly
+    /// aggressive guardian and is enforced upstream of the signature check
+    /// so a malicious caller cannot burn the guardian's signature on a
+    /// request that would have been rejected anyway.
+    pub fn pause_validator(
+        &mut self,
+        validator: &PublicKey,
+        signature: &Signature,
+    ) -> Result<ValidatorEvent> {
+        // 1. Guardian must be configured.
+        let guardian = self.guardian.ok_or(BridgeError::NoGuardianConfigured)?;
+
+        let v_bytes = validator.to_bytes().to_vec();
+
+        // 2. Target must be part of the current validator set.
+        if !self.validators.contains_pk(validator) {
+            return Err(BridgeError::UnknownValidator.into());
+        }
+
+        // 3. Reject double-pause explicitly *before* the fail-closed math,
+        //    so a re-pause attempt returns the precise `AlreadyPaused`
+        //    diagnostic instead of `PauseWouldBreakQuorum` (whose math is
+        //    only meaningful when the target is currently active).
+        if self.paused_validators.contains(&v_bytes) {
+            return Err(BridgeError::AlreadyPaused.into());
+        }
+
+        // 4. Fail-closed: refuse to pause if it would make the active count
+        //    drop below the new effective quorum threshold. We have just
+        //    confirmed `validator` is in the current validator set *and* is
+        //    not yet paused, so subtracting 1 from the active count is
+        //    exact.
+        let current_active = self.active_validator_count();
+        let new_active = current_active.checked_sub(1).unwrap_or(0);
+        let new_threshold = (new_active * 2) / 3 + 1;
+        if new_active < new_threshold {
+            return Err(BridgeError::PauseWouldBreakQuorum.into());
+        }
+
+        // 5. Verify guardian signature over the action-bound payload.
+        let payload = concat_prefixed(PAUSE_PAYLOAD_TAG, &v_bytes);
+        guardian
+            .verify(&payload, signature)
+            .map_err(|_| BridgeError::InvalidGuardianSignature)?;
+
+        // 6. Commit: mark the validator paused and return the event.
+        self.paused_validators.insert(v_bytes.clone());
+        Ok(ValidatorEvent::Paused {
+            validator: v_bytes,
+            epoch: self.epoch,
+        })
+    }
+
+    /// Guardian-gated unpause of a single validator.
+    ///
+    /// The signature is verified against the configured [`Bridge::guardian`]
+    /// over the action-bound payload `"BRIDGE_UNPAUSE:" || pk_bytes`, which
+    /// is the dual of the pause payload so signatures cannot be replayed
+    /// across actions.
+    pub fn unpause_validator(
+        &mut self,
+        validator: &PublicKey,
+        signature: &Signature,
+    ) -> Result<ValidatorEvent> {
+        let guardian = self.guardian.ok_or(BridgeError::NoGuardianConfigured)?;
+
+        let v_bytes = validator.to_bytes().to_vec();
+
+        if !self.validators.contains_pk(validator) {
+            return Err(BridgeError::UnknownValidator.into());
+        }
+        if !self.paused_validators.contains(&v_bytes) {
+            return Err(BridgeError::NotPaused.into());
+        }
+
+        let payload = concat_prefixed(UNPAUSE_PAYLOAD_TAG, &v_bytes);
+        guardian
+            .verify(&payload, signature)
+            .map_err(|_| BridgeError::InvalidGuardianSignature)?;
+
+        self.paused_validators.remove(&v_bytes);
+        Ok(ValidatorEvent::Unpaused {
+            validator: v_bytes,
+            epoch: self.epoch,
+        })
     }
 
     /// Verify inbound message signature epoch. Messages signed with an epoch < current epoch are rejected.
@@ -240,6 +572,28 @@ impl Bridge {
     }
 }
 
+/// Helper: build a payload of the form `prefix || suffix` without an
+/// intermediate allocation beyond the result vector.
+fn concat_prefixed(prefix: &[u8], suffix: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(prefix.len() + suffix.len());
+    out.extend_from_slice(prefix);
+    out.extend_from_slice(suffix);
+    out
+}
+
+/// Lowercase hex encoder for the `Display` impl of `ValidatorEvent`. Inlined
+/// here (rather than pulling in the `hex` crate as a runtime dependency)
+/// because event formatting is the only consumer and the format is trivial.
+fn lowercase_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
 #[cfg(test)]
 mod rotation_test;
 
@@ -254,6 +608,9 @@ mod window_guard_test;
 
 #[cfg(test)]
 mod validatorset_proptest;
+
+#[cfg(test)]
+mod validator_pause_test;
 
 #[cfg(test)]
 mod tests {

--- a/stellar-lend/contracts/bridge/src/validator_pause_test.rs
+++ b/stellar-lend/contracts/bridge/src/validator_pause_test.rs
@@ -1,0 +1,673 @@
+//! Tests for the per-validator bridge pause flag
+//! ([`crate::Bridge::pause_validator`] / [`crate::Bridge::unpause_validator`]).
+//!
+//! Coverage targets:
+//!   - Default state: no guardian, empty paused set
+//!   - Guardian-bound: pause / unpause reject without a configured guardian
+//!   - Signature auth: pause / unpause reject on invalid guardian signature
+//!   - Signature replay: pause sig cannot be replayed as unpause, and vice versa
+//!   - Action-bound replay: pause sig for validator A cannot be replayed for validator B
+//!   - Fail-closed: pause that would make active count < new threshold is rejected
+//!   - Idempotency: already-paused / not-paused are explicitly rejected (not no-ops)
+//!   - Unknown validator: pause / unpause reject targets not in the current set
+//!   - Effect on quorum: a single paused validator lowers the effective
+//!     supermajority threshold by one
+//!   - Bridge survives with quorum after a non-breaking pause: rotation still
+//!     succeeds, but with one fewer required signer
+//!   - Paused validator sig is silently skipped in verify_quorum_proof (not
+//!     an error) so stale network gossip doesn't break the bridge
+//!   - Paused validators with bogus sigs do not poison the proof batch
+//!   - Rotation resets the paused set
+//!   - Pause list / is_paused / active_validator_count helpers agree
+
+#[cfg(test)]
+mod validator_pause_tests {
+    use crate::{Bridge, BridgeError, ValidatorEvent, ValidatorSet};
+    use ed25519_dalek::{Keypair, SecretKey, Signature, Signer};
+
+    // -----------------------------------------------------------------------
+    // Deterministic key helpers
+    // -----------------------------------------------------------------------
+
+    fn det_keypair(index: u8) -> Keypair {
+        // 32-byte seed: first byte encodes the index, rest are a fixed pattern.
+        let mut seed = [0u8; 32];
+        seed[0] = index.wrapping_add(1); // avoid all-zero seed
+        for i in 1..32 {
+            seed[i] = index.wrapping_mul(7).wrapping_add(i as u8);
+        }
+        let secret = SecretKey::from_bytes(&seed).expect("valid secret key");
+        let public: ed25519_dalek::PublicKey = (&secret).into();
+        let mut combined = [0u8; 64];
+        combined[..32].copy_from_slice(&seed);
+        combined[32..].copy_from_slice(public.as_bytes());
+        Keypair::from_bytes(&combined).expect("valid keypair from seed")
+    }
+
+    fn det_keypairs_range(start: u8, end: u8) -> Vec<Keypair> {
+        (start..end).map(det_keypair).collect()
+    }
+
+    fn validator_set_from(kps: &[Keypair]) -> ValidatorSet {
+        ValidatorSet {
+            validators: kps.iter().map(|kp| kp.public.to_bytes().to_vec()).collect(),
+        }
+    }
+
+    fn make_bridge_with_guardian(n_validators: u8, guardian_idx: u8) -> (Bridge, Vec<Keypair>, Keypair) {
+        let validators = det_keypairs_range(10, 10 + n_validators);
+        let initial = validator_set_from(&validators);
+        let mut bridge = Bridge::new(initial);
+        let guardian = det_keypair(guardian_idx);
+        bridge.set_guardian(guardian.public);
+        (bridge, validators, guardian)
+    }
+
+    fn payload_for(action: &[u8], pk_bytes: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(action.len() + pk_bytes.len());
+        out.extend_from_slice(action);
+        out.extend_from_slice(pk_bytes);
+        out
+    }
+
+    fn sign_pause(guardian: &Keypair, target: &ed25519_dalek::PublicKey) -> Signature {
+        let payload = payload_for(b"BRIDGE_PAUSE:", &target.to_bytes());
+        guardian.sign(&payload)
+    }
+
+    fn sign_unpause(guardian: &Keypair, target: &ed25519_dalek::PublicKey) -> Signature {
+        let payload = payload_for(b"BRIDGE_UNPAUSE:", &target.to_bytes());
+        guardian.sign(&payload)
+    }
+
+    fn sign_rotation(new_set: &ValidatorSet, epoch: u64, signers: &[&Keypair]) -> Vec<(ed25519_dalek::PublicKey, Signature)> {
+        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        signers
+            .iter()
+            .map(|kp| {
+                let sig = kp.sign(&payload);
+                (kp.public, sig)
+            })
+            .collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // Default state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fresh_bridge_has_no_guardian_and_empty_paused_set() {
+        let bridge = Bridge::new(ValidatorSet { validators: vec![] });
+        assert!(bridge.guardian().is_none());
+        assert!(bridge.paused_list().is_empty());
+        assert_eq!(bridge.active_validator_count(), 0);
+        assert_eq!(bridge.effective_threshold(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Guardian gating
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pause_rejects_without_configured_guardian() {
+        let kps = det_keypairs_range(10, 13);
+        let initial = validator_set_from(&kps);
+        let mut bridge = Bridge::new(initial);
+
+        let bogus_sig = Signature::from_bytes(&[0u8; 64]).expect("64 zero bytes is a valid signature encoding");
+        let err = bridge
+            .pause_validator(&kps[0].public, &bogus_sig)
+            .expect_err("pause must fail when no guardian is configured");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::NoGuardianConfigured)
+        );
+        assert!(bridge.paused_list().is_empty(), "no state change on rejection");
+    }
+
+    #[test]
+    fn unpause_rejects_without_configured_guardian() {
+        let kps = det_keypairs_range(10, 13);
+        let initial = validator_set_from(&kps);
+        let mut bridge = Bridge::new(initial);
+
+        let bogus_sig = Signature::from_bytes(&[0u8; 64]).expect("64 zero bytes is a valid signature encoding");
+        let err = bridge
+            .unpause_validator(&kps[0].public, &bogus_sig)
+            .expect_err("unpause must fail when no guardian is configured");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::NoGuardianConfigured)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Signature authorization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pause_rejects_if_signature_does_not_verify_against_guardian() {
+        let (mut bridge, validators, _guardian) = make_bridge_with_guardian(4, 200);
+        // Sign with the WRONG key — a status-quo validator pretending to be the guardian.
+        let wrong_signer = &validators[0];
+        let target = &validators[1].public;
+        let payload = payload_for(b"BRIDGE_PAUSE:", &target.to_bytes());
+        let bad_sig = wrong_signer.sign(&payload);
+
+        let err = bridge
+            .pause_validator(target, &bad_sig)
+            .expect_err("pause must reject signatures not from the configured guardian");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::InvalidGuardianSignature)
+        );
+        assert!(bridge.paused_list().is_empty(), "no state change on rejection");
+    }
+
+    #[test]
+    fn unpause_rejects_if_signature_does_not_verify_against_guardian() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let target = &validators[1].public;
+        // Pause legitimately.
+        bridge
+            .pause_validator(target, &sign_pause(&guardian, target))
+            .expect("pause should succeed with valid guardian signature");
+        assert!(bridge.is_paused(target));
+
+        // Try to unpause with the wrong signer.
+        let bad_sig = validators[0].sign(&payload_for(b"BRIDGE_UNPAUSE:", &target.to_bytes()));
+        let err = bridge
+            .unpause_validator(target, &bad_sig)
+            .expect_err("unpause must reject signatures not from the configured guardian");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::InvalidGuardianSignature)
+        );
+        assert!(bridge.is_paused(target), "validator must remain paused after rejected unpause");
+    }
+
+    // -----------------------------------------------------------------------
+    // Signature replay protection
+    // -----------------------------------------------------------------------
+
+    /// A signature produced for `pause(A)` must NOT verify as `unpause(A)` —
+    /// the action binding tag must distinguish them.
+    #[test]
+    fn pause_signature_cannot_be_replayed_as_unpause() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let target = &validators[1].public;
+        bridge
+            .pause_validator(target, &sign_pause(&guardian, target))
+            .expect("legitimate pause");
+        assert!(bridge.is_paused(target));
+
+        // Now try to "unpause" using the pause signature on the same key.
+        let replay = sign_pause(&guardian, target);
+        let err = bridge
+            .unpause_validator(target, &replay)
+            .expect_err("pause-bound signature must not authorize unpause");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::InvalidGuardianSignature)
+        );
+        assert!(bridge.is_paused(target));
+    }
+
+    /// A signature produced for `pause(A)` must NOT verify for `pause(B)` —
+    /// the target key binding must distinguish them.
+    #[test]
+    fn pause_signature_for_a_cannot_be_replayed_for_b() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let a = &validators[1].public;
+        let b = &validators[2].public;
+
+        let sig_for_a = sign_pause(&guardian, a);
+        let err = bridge
+            .pause_validator(b, &sig_for_a)
+            .expect_err("pause(A) signature must not authorize pause(B)");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::InvalidGuardianSignature)
+        );
+        assert!(!bridge.is_paused(a));
+        assert!(!bridge.is_paused(b));
+    }
+
+    // -----------------------------------------------------------------------
+    // Idempotency (already paused / not paused)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pause_rejects_when_already_paused() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(5, 200);
+        let target = &validators[1].public;
+        bridge
+            .pause_validator(target, &sign_pause(&guardian, target))
+            .expect("first pause should succeed");
+
+        let err = bridge
+            .pause_validator(target, &sign_pause(&guardian, target))
+            .expect_err("double pause must be rejected");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::AlreadyPaused)
+        );
+    }
+
+    #[test]
+    fn unpause_rejects_when_not_paused() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(5, 200);
+        let target = &validators[1].public;
+        // Validator is NOT paused.
+        let err = bridge
+            .unpause_validator(target, &sign_unpause(&guardian, target))
+            .expect_err("unpause of non-paused must be rejected");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::NotPaused)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Unknown validator
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pause_rejects_unknown_validator() {
+        let (mut bridge, _validators, guardian) = make_bridge_with_guardian(4, 200);
+        let outsider = det_keypair(99);
+        // The bridge knows about 10..14; outsider=99 is not in that range.
+        assert!(!bridge.validators.contains_pk(&outsider.public));
+        let err = bridge
+            .pause_validator(&outsider.public, &sign_pause(&guardian, &outsider.public))
+            .expect_err("unknown validator must be rejected");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::UnknownValidator)
+        );
+    }
+
+    #[test]
+    fn unpause_rejects_unknown_validator() {
+        let (mut bridge, _validators, guardian) = make_bridge_with_guardian(4, 200);
+        let outsider = det_keypair(99);
+        let err = bridge
+            .unpause_validator(&outsider.public, &sign_unpause(&guardian, &outsider.public))
+            .expect_err("unknown validator must be rejected");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::UnknownValidator)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fail-closed math
+    // -----------------------------------------------------------------------
+
+    /// Pausing must reject when it would leave zero active validators (the
+    /// only case where the effective supermajority threshold `floor(2n/3)+1`
+    /// exceeds `n`). The simplest scenario is `n=1`: pausing the only
+    /// validator would bring active to 0, so threshold(0)=1 > 0 ⇒ reject.
+    ///
+    /// Note that for `n` in {3, 4, ...}, pausing one validator leaves the
+    /// bridge REACHABLE because the new threshold decreases along with
+    /// the active count (e.g. n=3→2, threshold(2)=2=active). The
+    /// multi-pause reachability boundary is exercised by
+    /// `pause_rejected_only_when_quorum_becomes_unreachable`.
+    #[test]
+    fn pause_rejected_when_quorum_would_become_unreachable_with_singleton() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(1, 200);
+        assert_eq!(bridge.validators.threshold(), 1);
+        assert_eq!(bridge.active_validator_count(), 1);
+
+        let target = &validators[0].public;
+        let err = bridge
+            .pause_validator(target, &sign_pause(&guardian, target))
+            .expect_err("pausing the only active validator must be rejected (quorum unreachable)");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::PauseWouldBreakQuorum)
+        );
+        assert!(!bridge.is_paused(target));
+        assert_eq!(bridge.active_validator_count(), 1);
+    }
+
+    /// Pausing succeeds when the remaining active count still exceeds the
+    /// new effective threshold. n=4, threshold=3. Pause one → active=3,
+    /// new_threshold=(3*2)/3+1=3. 3 >= 3 ⇒ accept (still at-quorum).
+    #[test]
+    fn pause_accepted_when_active_count_meets_new_threshold() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        // Pause one validator: 4 → 3 active, threshold(3) = 3. Still at-quorum.
+        let target = &validators[0].public;
+        let event = bridge
+            .pause_validator(target, &sign_pause(&guardian, target))
+            .expect("pausing must succeed when active still reaches new threshold");
+        assert_eq!(
+            event,
+            ValidatorEvent::Paused {
+                validator: target.to_bytes().to_vec(),
+                epoch: 0,
+            }
+        );
+        assert!(bridge.is_paused(target));
+        assert_eq!(bridge.active_validator_count(), 3);
+        assert_eq!(bridge.effective_threshold(), 3);
+    }
+
+    /// Pausing all-but-two is fine (n=4, pause 2 → active=2 < new_threshold
+    /// (2*2)/3+1 = 2); the second would NOT be rejected since 2 == 2. But
+    /// pausing a third one (active=1, new_threshold=1, 1 >= 1 ⇒ accept).
+    /// Pausing the last one (active=0, new_threshold=1, 0 < 1 ⇒ reject).
+    #[test]
+    fn pause_rejected_only_when_quorum_becomes_unreachable() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+
+        bridge
+            .pause_validator(&validators[0].public, &sign_pause(&guardian, &validators[0].public))
+            .expect("first pause allowed");
+
+        bridge
+            .pause_validator(&validators[1].public, &sign_pause(&guardian, &validators[1].public))
+            .expect("second pause: active=2, threshold(2)=2, allowed");
+
+        // active=2, new_threshold=2. Pausing again would make active=1, threshold(1)=1 → ok.
+        bridge
+            .pause_validator(&validators[2].public, &sign_pause(&guardian, &validators[2].public))
+            .expect("third pause: active=1, threshold(1)=1, allowed");
+
+        // active=1, new_threshold=1. Pausing the last one would make active=0.
+        // 0 < threshold(0)=1 ⇒ reject (fail-closed).
+        let err = bridge
+            .pause_validator(&validators[3].public, &sign_pause(&guardian, &validators[3].public))
+            .expect_err("pausing the last validator must be rejected");
+        assert_eq!(
+            err.downcast_ref::<BridgeError>(),
+            Some(&BridgeError::PauseWouldBreakQuorum)
+        );
+        assert!(!bridge.is_paused(&validators[3].public));
+        assert_eq!(bridge.active_validator_count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Effect on quorum: rotation still works with paused validators
+    // -----------------------------------------------------------------------
+
+    /// A 4-validator bridge with 1 paused should still be able to rotate
+    /// with 3 active signatures (the new effective threshold).
+    #[test]
+    fn rotation_with_one_paused_validator_uses_new_threshold() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let paused = &validators[0].public;
+        bridge
+            .pause_validator(paused, &sign_pause(&guardian, paused))
+            .expect("pause ok");
+
+        assert_eq!(bridge.active_validator_count(), 3);
+        assert_eq!(bridge.effective_threshold(), 3);
+
+        let next = det_keypairs_range(40, 43);
+        let new_set = validator_set_from(&next);
+        let epoch = 1u64;
+        // Collect 3 active signatures (the new threshold). Provide 4 with
+        // one of them being the paused signer — it should be silently skipped.
+        let signers: Vec<&Keypair> = validators.iter().collect(); // 4 signers
+        let proofs = sign_rotation(&new_set, epoch, &signers);
+
+        bridge
+            .rotate_validators(new_set, epoch, proofs)
+            .expect("rotation with new threshold must succeed");
+
+        assert_eq!(bridge.epoch, 1);
+        // Rotation clears the paused set (new keys, fresh state).
+        assert!(bridge.paused_list().is_empty(), "rotation must reset paused set");
+    }
+
+    /// After a non-breaking pause, providing exactly `threshold` valid
+    /// signatures from the (non-paused) active set should be enough.
+    #[test]
+    fn rotation_uses_effective_threshold_for_size_check() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(5, 200);
+        // n=5 → threshold=4. Pause 2 → active=3, new threshold=3.
+        // `validators.indices` 0..5 = det_keypairs from 10..15.
+        bridge
+            .pause_validator(&validators[0].public, &sign_pause(&guardian, &validators[0].public))
+            .unwrap();
+        bridge
+            .pause_validator(&validators[1].public, &sign_pause(&guardian, &validators[1].public))
+            .unwrap();
+        assert_eq!(bridge.active_validator_count(), 3);
+        assert_eq!(bridge.effective_threshold(), 3);
+
+        let next = det_keypairs_range(50, 53);
+        let new_set = validator_set_from(&next);
+        let epoch = 1u64;
+        // Sign with EXACTLY 3 active validators (the new effective threshold).
+        let signers: Vec<&Keypair> = validators[2..5].iter().collect();
+        let proofs = sign_rotation(&new_set, epoch, &signers);
+
+        bridge
+            .rotate_validators(new_set, epoch, proofs)
+            .expect("3 active signatures must meet the new threshold of 3");
+        assert_eq!(bridge.epoch, 1);
+    }
+
+    /// Rotation with exactly the active count below the new threshold must fail.
+    #[test]
+    fn rotation_rejects_when_active_signers_below_new_threshold() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(5, 200);
+        bridge
+            .pause_validator(&validators[0].public, &sign_pause(&guardian, &validators[0].public))
+            .unwrap();
+        bridge
+            .pause_validator(&validators[1].public, &sign_pause(&guardian, &validators[1].public))
+            .unwrap();
+        assert_eq!(bridge.effective_threshold(), 3);
+
+        let next = det_keypairs_range(50, 53);
+        let new_set = validator_set_from(&next);
+        let epoch = 1u64;
+        // Sign with only 2 active validators (below the new threshold of 3).
+        let signers: Vec<&Keypair> = validators[2..4].iter().collect();
+        let proofs = sign_rotation(&new_set, epoch, &signers);
+
+        let result = bridge.rotate_validators(new_set, epoch, proofs);
+        assert!(result.is_err(), "2 < new threshold of 3 must fail");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("insufficient quorum"), "got: {msg}");
+        assert_eq!(bridge.epoch, 0, "no epoch advance on rejection");
+    }
+
+    // -----------------------------------------------------------------------
+    // Paused sig handling at the verify level (silently skip, do not error)
+    // -----------------------------------------------------------------------
+
+    /// A malformed signature from a paused validator must NOT poison the
+    /// entire proof batch — paused signatures are skipped silently.
+    #[test]
+    fn malformed_paused_signature_does_not_break_proof() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let to_pause = &validators[0].public;
+        bridge
+            .pause_validator(to_pause, &sign_pause(&guardian, to_pause))
+            .unwrap();
+
+        let next = det_keypairs_range(40, 43);
+        let new_set = validator_set_from(&next);
+        let epoch = 1u64;
+
+        // Build a proof where the paused validator's signature slot is filled
+        // with GARBAGE bytes. Despite that, the active 3 signers should be
+        // enough and the proof should be accepted.
+        let mut proofs: Vec<(ed25519_dalek::PublicKey, Signature)> = Vec::new();
+        // Paused signer: garbage signature (any 64-byte buffer parses as a Signature
+        // value; on-curve validity is verified only by `PublicKey::verify`, which
+        // we deliberately never call for paused signers).
+        let garbage_sig = Signature::from_bytes(&[7u8; 64])
+            .expect("64-byte buffer parses as a Signature<'_> value");
+        proofs.push((to_pause.clone(), garbage_sig));
+        // Active signers: 3 valid signatures.
+        for kp in &validators[1..4] {
+            proofs.push(signed_rotation_entry(kp, &new_set, epoch));
+        }
+
+        bridge
+            .rotate_validators(new_set, epoch, proofs)
+            .expect("paused-signer garbage must be silently skipped, not poison the proof");
+    }
+
+    /// Paused validators are excluded from duplicate counting as well.
+    #[test]
+    fn paused_signer_does_not_count_as_unique_vote() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let paused = &validators[0].public;
+        bridge
+            .pause_validator(paused, &sign_pause(&guardian, paused))
+            .unwrap();
+
+        let next = det_keypairs_range(40, 43);
+        let new_set = validator_set_from(&next);
+        let epoch = 1u64;
+
+        // Submit:
+        //   - paused signer twice (should be skipped both times — counted 0)
+        //   - validators[1] twice (should be deduped — counted 1)
+        //   - validators[2] once (counted 1)
+        // Total unique ACTIVE votes = 2. New threshold for active=3 is 3.
+        // 2 < 3 ⇒ must fail.
+        let mut proofs: Vec<(ed25519_dalek::PublicKey, Signature)> = Vec::new();
+        proofs.push(signed_rotation_entry(&validators[0], &new_set, epoch));
+        proofs.push(signed_rotation_entry(&validators[0], &new_set, epoch));
+        proofs.push(signed_rotation_entry(&validators[1], &new_set, epoch));
+        proofs.push(signed_rotation_entry(&validators[1], &new_set, epoch));
+        proofs.push(signed_rotation_entry(&validators[2], &new_set, epoch));
+
+        let result = bridge.rotate_validators(new_set, epoch, proofs);
+        assert!(result.is_err(), "unique active count of 2 < new threshold 3 must fail");
+    }
+
+    fn signed_rotation_entry(
+        kp: &Keypair,
+        new_set: &ValidatorSet,
+        epoch: u64,
+    ) -> (ed25519_dalek::PublicKey, Signature) {
+        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let sig = kp.sign(&payload);
+        (kp.public, sig)
+    }
+
+    // -----------------------------------------------------------------------
+    // Pause → unpause round trip restores effective threshold
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pause_then_unpause_restores_active_count_and_threshold() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let target = &validators[0].public;
+        bridge
+            .pause_validator(target, &sign_pause(&guardian, target))
+            .unwrap();
+        assert_eq!(bridge.active_validator_count(), 3);
+        assert_eq!(bridge.effective_threshold(), 3);
+
+        let event = bridge
+            .unpause_validator(target, &sign_unpause(&guardian, target))
+            .expect("unpause should succeed with valid guardian signature");
+        assert_eq!(
+            event,
+            ValidatorEvent::Unpaused {
+                validator: target.to_bytes().to_vec(),
+                epoch: 0,
+            }
+        );
+        assert!(!bridge.is_paused(target));
+        assert_eq!(bridge.active_validator_count(), 4);
+        assert_eq!(bridge.effective_threshold(), 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rotation resets paused set
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rotation_clears_paused_set() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        bridge
+            .pause_validator(&validators[0].public, &sign_pause(&guardian, &validators[0].public))
+            .unwrap();
+        bridge
+            .pause_validator(&validators[1].public, &sign_pause(&guardian, &validators[1].public))
+            .unwrap();
+        assert_eq!(bridge.paused_list().len(), 2);
+
+        let next = det_keypairs_range(40, 44);
+        let new_set = validator_set_from(&next);
+        let epoch = 1u64;
+        // Signers must come from the CURRENT (pre-rotation) validator set so
+        // verify_quorum_proof accepts them. Two of the four are paused; the
+        // effective_active = 2 and effective_threshold(2) = 2, so quorum is
+        // attainable even without the paused keys' contributions.
+        let active_signers: Vec<&Keypair> = validators[2..4].iter().collect();
+        let proofs = sign_rotation(&new_set, epoch, &active_signers);
+        bridge
+            .rotate_validators(new_set, epoch, proofs)
+            .expect("rotation should succeed with active=2 reaching new threshold=2");
+
+        assert!(bridge.paused_list().is_empty(), "rotation must clear paused flags");
+        assert_eq!(bridge.active_validator_count(), bridge.validators.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper sanity
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn paused_list_returns_byte_encodings_of_paused_keys() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let a = &validators[0].public;
+        let b = &validators[2].public;
+        bridge
+            .pause_validator(a, &sign_pause(&guardian, a))
+            .unwrap();
+        bridge
+            .pause_validator(b, &sign_pause(&guardian, b))
+            .unwrap();
+
+        let listed: std::collections::HashSet<Vec<u8>> =
+            bridge.paused_list().into_iter().collect();
+        assert!(listed.contains(&a.to_bytes().to_vec()));
+        assert!(listed.contains(&b.to_bytes().to_vec()));
+        assert_eq!(listed.len(), 2);
+    }
+
+    #[test]
+    fn is_active_validator_returns_false_for_paused_or_unknown() {
+        let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
+        let v = &validators[0].public;
+        assert!(bridge.is_active_validator(v));
+        bridge
+            .pause_validator(v, &sign_pause(&guardian, v))
+            .unwrap();
+        assert!(!bridge.is_active_validator(v), "paused validator is no longer active");
+        let outsider = det_keypair(99).public;
+        assert!(!bridge.is_active_validator(&outsider), "non-member is not active");
+    }
+
+    #[test]
+    fn validator_event_display_includes_epoch_and_hex_pk() {
+        let kp = det_keypair(0);
+        let pk_bytes = kp.public.to_bytes().to_vec();
+        let event = ValidatorEvent::Paused {
+            validator: pk_bytes.clone(),
+            epoch: 7,
+        };
+        let rendered = format!("{event}");
+        assert!(rendered.starts_with("ValidatorPaused("));
+        assert!(rendered.contains("epoch=7"));
+        // Spot-check that some of the bytes show up in low-case hex form.
+        assert!(rendered.contains(&format!(
+            "{:02x}",
+            pk_bytes[0]
+        )));
+    }
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #1221. Adds a per-validator signing-pause flag to the bridge so a single compromised validator key can be excluded from quorum counting without rotating the full set.

Closes #1221

## Behavior

* **Guardian-gated pause / unpause.** Calls are signed by a configured guardian over action-bound payloads (`BRIDGE_PAUSE:` / `BRIDGE_UNPAUSE:` || pk_bytes), so signatures cannot be replayed across actions or targets.
* **Paused validators are silently skipped** in `verify_quorum_proof` (not rejected) so stale network gossip from a compromised key cannot DoS bridge rotations.
* **Effective quorum threshold** is recomputed against the active (non-paused) subset, so a non-breaking pause keeps rotation working at the smaller threshold.
* **Fail-closed:** pause is rejected with `BridgeError::PauseWouldBreakQuorum` when it would leave zero active validators (the only state where `floor(2n/3)+1` exceeds `n`).
* **`rotate_validators` clears the paused set** on a successful swap, because fresh keys imply fresh pause state.

## Files

* `stellar-lend/contracts/bridge/src/lib.rs` — implementation: `pause_validator`, `unpause_validator`, `set_guardian`, `ValidatorEvent` enum, new typed errors (`NoGuardianConfigured`, `InvalidGuardianSignature`, `UnknownValidator`, `PauseWouldBreakQuorum`, `AlreadyPaused`, `NotPaused`), and the updated `verify_quorum_proof`.
* `stellar-lend/contracts/bridge/src/validator_pause_test.rs` — 20 new tests covering every code branch.
* `stellar-lend/contracts/bridge/VALIDATOR_PAUSE.md` — full documentation: threat model, public API, signature payload binding, fail-closed math table, edge cases, and operational guidance.

## Testing

```
cargo test -p bridge
=> 72 passed, 0 failed
```

## Backwards compatibility

* New fields on `Bridge`: `paused_validators` (defaults to empty), `guardian` (defaults to `None`).
* `Bridge::new` signature unchanged; existing call sites continue to work.
* Existing `BridgeError` variants are unchanged; new variants are appended.
* `verify_quorum_proof` is private and not part of the public API.

## Followups (not in this PR)

* Two-step guardian handover (rotate guardian only when both current and new guardians sign).
* Audit-log integration: an explicit `EventLog` trait hook so callers don't have to wrap return values themselves.
* Integration tests against a Soroban host adapter (this crate is currently off-chain Rust).