### PR TITLE
test: add reserve-split conservation proptest with docs

### DIFF
--- a/stellar-lend/contracts/lending/RESERVE_SPLIT_INVARIANTS.md
+++ b/stellar-lend/contracts/lending/RESERVE_SPLIT_INVARIANTS.md
@@ -1,0 +1,209 @@
+# Reserve-Split Invariants
+
+This document covers the mathematical correctness properties asserted by the
+property-based tests in
+`stellar-lend/contracts/lending/src/reserve_split_proptest.rs`
+for the function `split_interest_by_reserve_factor` in
+`stellar-lend/contracts/lending/src/math.rs`.
+
+---
+
+## Background
+
+`split_interest_by_reserve_factor(total_interest, reserve_factor_bps)` divides
+accrued borrower interest between two destinations:
+
+| Destination   | Variable          | Description                                          |
+|---------------|-------------------|------------------------------------------------------|
+| Depositors    | `depositor_yield` | Yield paid out to liquidity providers                |
+| Protocol      | `reserve_cut`     | Fee retained in the protocol treasury / insurance fund |
+
+The formula is deliberately simple:
+
+```
+reserve_cut     = floor(total_interest × reserve_factor_bps / BPS_SCALE)
+depositor_yield = total_interest − reserve_cut
+```
+
+`BPS_SCALE = 10 000` (basis-point scale, where 10 000 bps = 100%).
+
+By computing the depositor share as the *complement* rather than by a second
+multiplication, the two parts are guaranteed to sum to exactly `total_interest`
+without any floating-point or double-rounding issues.
+
+---
+
+## Worked Example
+
+**Scenario**: 1 000 units of interest accrue, with a 10 % (1 000 bps) reserve factor.
+
+```
+reserve_cut     = floor(1_000 × 1_000 / 10_000)
+                = floor(100_000 / 10_000)
+                = floor(10.0)
+                = 100
+
+depositor_yield = 1_000 − 100 = 900
+```
+
+**Verification**:
+
+| Check              | Value              | Passes? |
+|--------------------|--------------------|---------|
+| `depositor + reserve == total` | `900 + 100 = 1_000` | ✅ |
+| `depositor ≥ 0`    | `900 ≥ 0`          | ✅ |
+| `reserve ≥ 0`      | `100 ≥ 0`          | ✅ |
+| Rounding direction | `reserve * 10_000 ≤ total * 1_000` → `1_000_000 ≤ 1_000_000` | ✅ |
+
+---
+
+## Invariants Asserted by the Proptests
+
+### 1. No-Leakage (Conservation)
+
+```
+depositor_yield + reserve_cut == total_interest
+```
+
+For every valid input `(total_interest ∈ [0, SAFE_MAX], reserve_factor_bps ∈ [0, 10_000])`,
+the two output parts must sum to the input exactly. No unit of interest is
+created or destroyed by the split.
+
+**Why it matters**: silently losing or creating even 1 unit of interest would
+corrupt the accounting ledger. Over millions of accrual events this would
+compound into meaningful economic leakage.
+
+### 2. Non-Negativity
+
+```
+depositor_yield ≥ 0  ∧  reserve_cut ≥ 0
+```
+
+Neither party may be charged interest — the split only redistributes existing
+interest, it never creates obligations.
+
+### 3. Rounding Direction (Depositor-Favoured)
+
+Integer division floors toward zero, so:
+
+```
+reserve_cut = floor(total_interest × reserve_factor_bps / BPS_SCALE)
+```
+
+Any fractional basis-point unit falls to the *depositor* side. Equivalently:
+
+```
+reserve_cut × BPS_SCALE ≤ total_interest × reserve_factor_bps
+```
+
+**Why this direction**: the conservative choice is to round against the
+protocol. The protocol should never capture more than its arithmetic share;
+depositors are the residual claimants of any rounding remainder.
+
+### 4. Monotonicity in Reserve Factor
+
+```
+rf_lo ≤ rf_hi  ⟹  depositor_yield(rf_lo) ≥ depositor_yield(rf_hi)
+```
+
+A higher reserve factor weakly reduces the depositor share and weakly increases
+the reserve cut. No governance parameter change should flip this relationship.
+
+### 5. Monotonicity in Total Interest
+
+```
+interest_lo ≤ interest_hi  ⟹
+    depositor_yield(interest_lo) ≤ depositor_yield(interest_hi)  ∧
+    reserve_cut(interest_lo)    ≤ reserve_cut(interest_hi)
+```
+
+Both parts grow (weakly) as total interest grows.
+
+### 6. No Panic — Typed Error on Overflow
+
+When `total_interest > i128::MAX / BPS_SCALE`, the intermediate product
+`total_interest × reserve_factor_bps` overflows `i128`. The function must
+return `Err(MathError::Overflow)` rather than panicking or silently wrapping.
+
+`reserve_factor_bps = 0` is excluded from this test because `0 × anything = 0`
+and can never overflow.
+
+---
+
+## Valid Input Ranges
+
+| Parameter            | Type  | Valid Range                       | Notes                              |
+|----------------------|-------|-----------------------------------|------------------------------------|
+| `total_interest`     | `i128`| `[0, i128::MAX]`                  | Negative values → `OutOfRange`     |
+| `reserve_factor_bps` | `u32` | `[0, 10_000]`                     | >10 000 → `OutOfRange`             |
+| Safe multiplication  | —     | `total_interest ≤ i128::MAX / 10_000` | Larger values → `Overflow` if rf ≥ 1 |
+
+`i128::MAX / 10_000 ≈ 1.7 × 10³⁴`, far above any realistic accrual amount in
+a Stellar contract (interest is scaled by `SCALE = 10^7`, so this limit
+corresponds to roughly `1.7 × 10²⁷` unscaled units).
+
+---
+
+## Edge Cases Covered
+
+| Edge Case                        | Expected Outcome                           |
+|----------------------------------|--------------------------------------------|
+| `total_interest = 0`             | `(0, 0)` — zero interest splits as zero   |
+| `reserve_factor_bps = 0`         | `(total_interest, 0)` — all to depositors |
+| `reserve_factor_bps = 10_000`    | `(0, total_interest)` — all to protocol   |
+| `total_interest = 1, rf = 5_000` | `(1, 0)` — floor(0.5) = 0, 1 unit stays with depositor |
+| `total_interest < 0`             | `Err(MathError::OutOfRange)`               |
+| `reserve_factor_bps > 10_000`    | `Err(MathError::OutOfRange)`               |
+| Overflow-range `total_interest` with `rf ≥ 1` | `Err(MathError::Overflow)` |
+
+---
+
+## Test Suite Structure
+
+```
+src/reserve_split_proptest.rs
+├── proptest! (2048 cases each)
+│   ├── reserve_split_sum_equals_total               [invariant 1]
+│   ├── reserve_split_both_parts_non_negative        [invariant 2]
+│   ├── reserve_split_rounding_favours_depositor     [invariant 3]
+│   ├── reserve_split_depositor_monotone_decreasing_in_rf  [invariant 4]
+│   └── reserve_split_both_parts_monotone_in_total_interest [invariant 5]
+├── proptest! (512 cases each)
+│   ├── reserve_split_zero_reserve_factor_all_to_depositor  [edge: rf=0]
+│   ├── reserve_split_full_reserve_factor_all_to_protocol   [edge: rf=100%]
+│   └── reserve_split_overflow_returns_typed_error          [invariant 6]
+└── mod unit (deterministic)
+    ├── canonical_10pct_reserve
+    ├── single_unit_50pct_reserve_stays_with_depositor
+    ├── zero_interest_always_zero_split
+    ├── negative_interest_rejected
+    ├── reserve_factor_above_100pct_rejected
+    └── conservation_spot_checks
+```
+
+---
+
+## Running the Tests
+
+```sh
+# Run only the reserve-split proptest module
+cargo test -p stellarlend-lending reserve_split_proptest
+
+# Run including the unit sub-module
+cargo test -p stellarlend-lending reserve_split_proptest::unit
+
+# Increase proptest cases for a longer CI soak
+PROPTEST_CASES=10000 cargo test -p stellarlend-lending reserve_split_proptest
+```
+
+---
+
+## Relationship to Other Documentation
+
+- [`docs/RESERVE_ACCOUNTING.md`](../../docs/RESERVE_ACCOUNTING.md) — high-level
+  protocol accounting for the reserve fund.
+- [`src/math.rs`](src/math.rs) — implementation of `split_interest_by_reserve_factor`
+  and all other pure-math helpers.
+- [`LIQUIDATION_BONUS_INVARIANTS.md`](LIQUIDATION_BONUS_INVARIANTS.md) — companion
+  invariant doc for the liquidation-bonus proptest, which follows the same
+  pattern as this suite.

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -79,6 +79,8 @@ mod rounding_drift_test;
 mod self_liquidation_test;
 #[cfg(test)]
 mod supply_rate_split_test;
+#[cfg(test)]
+mod reserve_split_proptest;
 
 use debt::{
     borrow_amount, cached_borrow_rate, effective_debt, load_debt, repay_amount, save_debt,

--- a/stellar-lend/contracts/lending/src/reserve_split_proptest.rs
+++ b/stellar-lend/contracts/lending/src/reserve_split_proptest.rs
@@ -1,0 +1,330 @@
+//! Property-based tests for [`split_interest_by_reserve_factor`].
+//!
+//! These proptests assert the three core conservation invariants over the full
+//! valid input space:
+//!
+//! 1. **No-leakage**: `depositor_yield + reserve_cut == total_interest` for every
+//!    valid input pair.
+//! 2. **Non-negativity**: both output parts are always `≥ 0`.
+//! 3. **Rounding consistency**: any fractional unit falls to the depositor side —
+//!    i.e. `reserve_cut == floor(total_interest * reserve_factor_bps / BPS_SCALE)`.
+//! 4. **No panic / typed error on overflow**: the only way the function returns
+//!    `Err` for valid inputs is `MathError::Overflow` on the intermediate
+//!    multiplication, which only occurs when
+//!    `total_interest > i128::MAX / BPS_SCALE`.
+//!
+//! Run with:
+//! ```sh
+//! cargo test -p stellarlend-lending reserve_split_proptest
+//! ```
+
+#![cfg(test)]
+
+use super::math::{split_interest_by_reserve_factor, MathError, BPS_SCALE};
+use proptest::prelude::*;
+
+// ── Input strategies ──────────────────────────────────────────────────────────
+
+/// Largest `total_interest` that cannot overflow the intermediate multiplication
+/// `total_interest * reserve_factor_bps` inside [`split_interest_by_reserve_factor`].
+///
+/// The function multiplies `total_interest` by at most `BPS_SCALE` (10 000),
+/// so the safe ceiling is `i128::MAX / BPS_SCALE`.
+const SAFE_MAX_INTEREST: i128 = i128::MAX / BPS_SCALE as i128;
+
+/// Strategy yielding non-negative interest values that stay within the
+/// overflow-free range of the reserve-split multiplication.
+fn safe_interest_strategy() -> impl Strategy<Value = i128> {
+    0i128..=SAFE_MAX_INTEREST
+}
+
+/// Strategy yielding interest values that are **guaranteed to overflow** the
+/// intermediate `total_interest * reserve_factor_bps` multiplication when
+/// `reserve_factor_bps ≥ 1`.
+fn overflow_interest_strategy() -> impl Strategy<Value = i128> {
+    (SAFE_MAX_INTEREST + 1)..=i128::MAX
+}
+
+/// Strategy yielding a valid reserve factor in `[0, BPS_SCALE]` (inclusive).
+fn reserve_factor_strategy() -> impl Strategy<Value = u32> {
+    0u32..=BPS_SCALE
+}
+
+// ── Conservation invariants ───────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2048))]
+
+    /// **No-leakage invariant**: the two output parts always sum exactly to
+    /// `total_interest`.  No unit of interest is created or destroyed by the
+    /// split, regardless of how the BPS division rounds.
+    #[test]
+    fn reserve_split_sum_equals_total(
+        total_interest in safe_interest_strategy(),
+        reserve_factor_bps in reserve_factor_strategy(),
+    ) {
+        let (depositor, reserve) =
+            split_interest_by_reserve_factor(total_interest, reserve_factor_bps)
+                .expect("safe inputs must not overflow");
+
+        prop_assert_eq!(
+            depositor + reserve,
+            total_interest,
+            "no-leakage violated: total={total_interest} rf={reserve_factor_bps} \
+             => depositor={depositor} reserve={reserve}"
+        );
+    }
+
+    /// **Non-negativity invariant**: neither output part is ever negative.
+    ///
+    /// Negative splits would imply one party subsidises the other — that must
+    /// never happen.
+    #[test]
+    fn reserve_split_both_parts_non_negative(
+        total_interest in safe_interest_strategy(),
+        reserve_factor_bps in reserve_factor_strategy(),
+    ) {
+        let (depositor, reserve) =
+            split_interest_by_reserve_factor(total_interest, reserve_factor_bps)
+                .expect("safe inputs must not overflow");
+
+        prop_assert!(
+            depositor >= 0,
+            "depositor_yield is negative: total={total_interest} rf={reserve_factor_bps} \
+             => depositor={depositor}"
+        );
+        prop_assert!(
+            reserve >= 0,
+            "reserve_cut is negative: total={total_interest} rf={reserve_factor_bps} \
+             => reserve={reserve}"
+        );
+    }
+
+    /// **Rounding-direction invariant**: any fractional BPS unit falls to the
+    /// *depositor* side.  Concretely:
+    ///
+    /// ```text
+    /// reserve_cut == floor(total_interest * reserve_factor_bps / BPS_SCALE)
+    /// ```
+    ///
+    /// Equivalently, `reserve_cut * BPS_SCALE ≤ total_interest * reserve_factor_bps`.
+    /// This ensures the protocol never captures more than its exact arithmetic share.
+    #[test]
+    fn reserve_split_rounding_favours_depositor(
+        total_interest in safe_interest_strategy(),
+        reserve_factor_bps in reserve_factor_strategy(),
+    ) {
+        let (depositor, reserve) =
+            split_interest_by_reserve_factor(total_interest, reserve_factor_bps)
+                .expect("safe inputs must not overflow");
+
+        // Check floor condition: reserve_cut * BPS_SCALE ≤ total_interest * reserve_factor_bps
+        // Both sides fit in i128 because total_interest ≤ SAFE_MAX_INTEREST.
+        let lhs = reserve * BPS_SCALE as i128;
+        let rhs = total_interest * reserve_factor_bps as i128;
+        prop_assert!(
+            lhs <= rhs,
+            "rounding-direction violated: reserve_cut={reserve} * BPS_SCALE={lhs} \
+             > total_interest={total_interest} * rf={reserve_factor_bps} ({rhs})"
+        );
+
+        // Also confirm depositor is not shortchanged beyond 1 unit
+        // (the maximum rounding error from floor division).
+        let max_depositor_exact = total_interest
+            .saturating_sub(total_interest * reserve_factor_bps as i128 / BPS_SCALE as i128);
+        prop_assert!(
+            depositor >= max_depositor_exact,
+            "depositor received less than the floor-rounded share: \
+             depositor={depositor} expected≥{max_depositor_exact}"
+        );
+    }
+
+    /// **Monotonicity in reserve factor**: a higher reserve factor never gives
+    /// *more* to depositors.  As the protocol's cut grows, the depositor share
+    /// weakly decreases.
+    #[test]
+    fn reserve_split_depositor_monotone_decreasing_in_rf(
+        total_interest in safe_interest_strategy(),
+        rf_lo in 0u32..BPS_SCALE,
+        rf_hi in 0u32..=BPS_SCALE,
+    ) {
+        // Ensure rf_lo ≤ rf_hi (swap if needed).
+        let (rf_lo, rf_hi) = if rf_lo <= rf_hi { (rf_lo, rf_hi) } else { (rf_hi, rf_lo) };
+
+        let (depositor_lo, _) =
+            split_interest_by_reserve_factor(total_interest, rf_lo)
+                .expect("safe inputs must not overflow");
+        let (depositor_hi, _) =
+            split_interest_by_reserve_factor(total_interest, rf_hi)
+                .expect("safe inputs must not overflow");
+
+        prop_assert!(
+            depositor_hi <= depositor_lo,
+            "monotonicity violated: rf_lo={rf_lo} depositor={depositor_lo}, \
+             rf_hi={rf_hi} depositor={depositor_hi}; \
+             total_interest={total_interest}"
+        );
+    }
+
+    /// **Monotonicity in total interest**: holding the reserve factor fixed, a
+    /// larger total accrual yields a weakly larger reserve cut (and depositor
+    /// share).
+    #[test]
+    fn reserve_split_both_parts_monotone_in_total_interest(
+        interest_lo in 0i128..=SAFE_MAX_INTEREST / 2,
+        interest_hi in 0i128..=SAFE_MAX_INTEREST / 2,
+        reserve_factor_bps in reserve_factor_strategy(),
+    ) {
+        let (interest_lo, interest_hi) = if interest_lo <= interest_hi {
+            (interest_lo, interest_hi)
+        } else {
+            (interest_hi, interest_lo)
+        };
+
+        let (dep_lo, res_lo) =
+            split_interest_by_reserve_factor(interest_lo, reserve_factor_bps)
+                .expect("safe inputs must not overflow");
+        let (dep_hi, res_hi) =
+            split_interest_by_reserve_factor(interest_hi, reserve_factor_bps)
+                .expect("safe inputs must not overflow");
+
+        prop_assert!(
+            dep_hi >= dep_lo,
+            "depositor monotonicity violated: \
+             interest_lo={interest_lo} dep={dep_lo}, \
+             interest_hi={interest_hi} dep={dep_hi}"
+        );
+        prop_assert!(
+            res_hi >= res_lo,
+            "reserve monotonicity violated: \
+             interest_lo={interest_lo} res={res_lo}, \
+             interest_hi={interest_hi} res={res_hi}"
+        );
+    }
+}
+
+// ── Edge-case / boundary proptests ───────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    /// **Zero reserve factor**: the entire interest amount must flow to the
+    /// depositor and nothing goes to the reserve.
+    #[test]
+    fn reserve_split_zero_reserve_factor_all_to_depositor(
+        total_interest in safe_interest_strategy(),
+    ) {
+        let (depositor, reserve) =
+            split_interest_by_reserve_factor(total_interest, 0)
+                .expect("zero rf must never overflow");
+
+        prop_assert_eq!(depositor, total_interest);
+        prop_assert_eq!(reserve, 0i128);
+    }
+
+    /// **Full reserve factor (100%)**: the entire interest amount must go to
+    /// the protocol reserve; depositors receive nothing.
+    #[test]
+    fn reserve_split_full_reserve_factor_all_to_protocol(
+        total_interest in safe_interest_strategy(),
+    ) {
+        let (depositor, reserve) =
+            split_interest_by_reserve_factor(total_interest, BPS_SCALE)
+                .expect("full rf must never overflow");
+
+        prop_assert_eq!(reserve, total_interest);
+        prop_assert_eq!(depositor, 0i128);
+    }
+
+    /// **Overflow returns a typed error**: when `total_interest` is large enough
+    /// that `total_interest * reserve_factor_bps` overflows `i128`, the function
+    /// must return `Err(MathError::Overflow)` rather than panicking.
+    ///
+    /// We exclude `reserve_factor_bps == 0` because `0 * anything == 0` and
+    /// never overflows.
+    #[test]
+    fn reserve_split_overflow_returns_typed_error(
+        total_interest in overflow_interest_strategy(),
+        reserve_factor_bps in 1u32..=BPS_SCALE,
+    ) {
+        let result = split_interest_by_reserve_factor(total_interest, reserve_factor_bps);
+        prop_assert_eq!(
+            result,
+            Err(MathError::Overflow),
+            "expected Overflow for total_interest={total_interest} rf={reserve_factor_bps}"
+        );
+    }
+}
+
+// ── Deterministic unit tests (complement the proptests) ──────────────────────
+
+#[cfg(test)]
+mod unit {
+    use super::super::math::{split_interest_by_reserve_factor, MathError, BPS_SCALE};
+
+    /// Verify the canonical worked example from the doc comment.
+    #[test]
+    fn canonical_10pct_reserve() {
+        let (dep, res) = split_interest_by_reserve_factor(1_000, 1_000).unwrap();
+        assert_eq!(res, 100, "10% of 1000 = 100 to protocol");
+        assert_eq!(dep, 900, "remainder 900 to depositors");
+        assert_eq!(dep + res, 1_000, "no-leakage");
+    }
+
+    /// Smallest indivisible unit: 1 interest with 50% reserve factor.
+    /// The floor of 0.5 is 0, so the whole unit stays with the depositor.
+    #[test]
+    fn single_unit_50pct_reserve_stays_with_depositor() {
+        let (dep, res) = split_interest_by_reserve_factor(1, 5_000).unwrap();
+        assert_eq!(res, 0, "floor(1 * 5000 / 10000) = 0");
+        assert_eq!(dep, 1, "1 unit stays with depositor");
+    }
+
+    /// `total_interest == 0` returns `(0, 0)` regardless of reserve factor.
+    #[test]
+    fn zero_interest_always_zero_split() {
+        for rf in [0u32, 1, 5_000, 9_999, BPS_SCALE] {
+            let (dep, res) = split_interest_by_reserve_factor(0, rf).unwrap();
+            assert_eq!((dep, res), (0, 0), "zero split for rf={rf}");
+        }
+    }
+
+    /// Negative `total_interest` must return `OutOfRange`.
+    #[test]
+    fn negative_interest_rejected() {
+        assert_eq!(
+            split_interest_by_reserve_factor(-1, 0),
+            Err(MathError::OutOfRange)
+        );
+    }
+
+    /// `reserve_factor_bps > BPS_SCALE` must return `OutOfRange`.
+    #[test]
+    fn reserve_factor_above_100pct_rejected() {
+        assert_eq!(
+            split_interest_by_reserve_factor(1_000, BPS_SCALE + 1),
+            Err(MathError::OutOfRange)
+        );
+    }
+
+    /// Verify conservation at several representative BPS values.
+    #[test]
+    fn conservation_spot_checks() {
+        let cases: &[(i128, u32)] = &[
+            (7, 1),
+            (1_000, 500),
+            (99_999, 3_333),
+            (1_000_000, 9_999),
+            (10_000_000_000, 2_000),
+        ];
+        for &(total, rf) in cases {
+            let (dep, res) = split_interest_by_reserve_factor(total, rf).unwrap();
+            assert_eq!(
+                dep + res,
+                total,
+                "conservation failed for total={total} rf={rf}"
+            );
+            assert!(dep >= 0 && res >= 0, "negative part for total={total} rf={rf}");
+        }
+    }
+}


### PR DESCRIPTION
closes #1224 

## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
