### PR TITLE
feat: add utilization history view to lending

### DIFF
--- a/stellar-lend/contracts/lending/UTILIZATION_HISTORY.md
+++ b/stellar-lend/contracts/lending/UTILIZATION_HISTORY.md
@@ -1,0 +1,76 @@
+# Utilization History
+
+The lending contract exposes the current protocol utilization through
+`get_protocol_metrics`, but clients also need a short trend for dashboards,
+alerts, and rate-model inspection. Indexing every ledger is expensive for those
+callers, so the contract keeps a bounded history of recent utilization samples.
+
+## Storage Model
+
+Samples are stored as `UtilizationSample { ledger, utilization_bps }` under
+`DataKey::UtilizationHistory`. The internal vector is ordered oldest-first and
+has a fixed capacity of `UTILIZATION_HISTORY_CAPACITY` entries.
+
+When a new sample is written and the vector is full, the contract removes index
+`0` and appends the new sample. This mirrors the AMM TWAP snapshot policy's
+bounded-vector eviction shape: storage rent is capped, the newest sample is
+always retained, and the cost of the shift is bounded by a constant capacity.
+
+## Write Path
+
+The contract writes a sample from the existing borrow-rate cache miss path:
+
+1. `cached_borrow_rate` checks the temporary per-ledger cache.
+2. On a miss, it loads `TotalDebt`, `TotalDeposits`, and `RateParams`.
+3. It computes `utilization_bps = total_debt * 10_000 / total_deposits`.
+4. It writes one utilization sample for the current ledger.
+5. It stores the computed borrow rate in the temporary cache.
+
+Warm reads in the same ledger reuse the cached rate and do not append duplicate
+samples. No extra public entrypoint is needed to trigger writes.
+
+## Read Path
+
+`get_utilization_history()` returns a Soroban `Vec<UtilizationSample>` ordered
+newest-first, which is the shape charting clients usually need. If no rate
+update has happened yet, it returns an empty vector.
+
+## Worked Example
+
+Assume the capacity is above the number of observations shown here:
+
+| Ledger | Total Debt | Total Deposits | Utilization |
+| ------ | ---------- | -------------- | ----------- |
+| 100    | 1,000      | 10,000         | 1,000 bps   |
+| 101    | 7,500      | 10,000         | 7,500 bps   |
+| 102    | 10,000     | 10,000         | 10,000 bps  |
+
+The internal storage is oldest-first:
+
+```text
+[
+  { ledger: 100, utilization_bps: 1000 },
+  { ledger: 101, utilization_bps: 7500 },
+  { ledger: 102, utilization_bps: 10000 },
+]
+```
+
+The view returns newest-first:
+
+```text
+[
+  { ledger: 102, utilization_bps: 10000 },
+  { ledger: 101, utilization_bps: 7500 },
+  { ledger: 100, utilization_bps: 1000 },
+]
+```
+
+## Edge Cases
+
+- Empty history returns an empty vector, not a panic.
+- Zero total supply records `0` utilization.
+- Same-ledger repeated rate reads write at most one sample because the rate cache
+  is keyed by ledger sequence.
+- Capacity is fixed. Once full, each new sample evicts exactly one oldest sample.
+- Utilization arithmetic uses checked multiplication and division. An overflow
+  while computing `total_debt * 10_000` is surfaced instead of silently wrapping.

--- a/stellar-lend/contracts/lending/src/debt.rs
+++ b/stellar-lend/contracts/lending/src/debt.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{contracttype, Address, Env};
 
 use crate::math::split_interest_by_reserve_factor;
 use crate::rounding_strategy::{calculate_interest_with_rounding, RoundingError, RoundingMode};
-use crate::{rate_model, DataKey};
+use crate::{rate_model, write_utilization_sample, DataKey};
 use stellar_lend_common::BPS_DENOM;
 
 /// Default APR when no dynamic rate is available: 5% (500 bps).
@@ -34,6 +34,15 @@ pub struct RateSnapshot {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BorrowRateCache {
     pub ledger_sequence: u32,
+    pub rate_bps: i128,
+}
+
+/// Aggregate borrow-rate calculation output for one storage snapshot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BorrowRateComputation {
+    /// Current utilization in basis points.
+    pub utilization_bps: i128,
+    /// Borrow APR in basis points.
     pub rate_bps: i128,
 }
 
@@ -121,25 +130,57 @@ pub fn load_rate_snapshot(env: &Env) -> RateSnapshot {
 /// Computes the global borrow rate directly from current aggregate storage.
 pub fn uncached_borrow_rate(env: &Env) -> i128 {
     let snapshot = load_rate_snapshot(env);
+    compute_borrow_rate_from_snapshot(&snapshot).rate_bps
+}
 
-    match snapshot.params {
-        Some(p) => {
-            let utilization_bps = if snapshot.total_supply > 0 {
-                snapshot.total_debt.saturating_mul(BPS_DENOM) / snapshot.total_supply
-            } else {
-                0
-            };
-            rate_model::compute_borrow_rate(utilization_bps, &p)
-        }
+/// Computes utilization and borrow rate from a preloaded aggregate snapshot.
+///
+/// Utilization uses checked arithmetic and falls back to zero when supply is
+/// non-positive. Overflow in `debt * 10_000` returns [`DebtError::Overflow`].
+pub(crate) fn try_compute_borrow_rate_from_snapshot(
+    snapshot: &RateSnapshot,
+) -> Result<BorrowRateComputation, DebtError> {
+    let utilization_bps = if snapshot.total_supply > 0 {
+        snapshot
+            .total_debt
+            .checked_mul(BPS_DENOM)
+            .ok_or(DebtError::Overflow)?
+            .checked_div(snapshot.total_supply)
+            .ok_or(DebtError::Overflow)?
+    } else {
+        0
+    };
+
+    let rate_bps = match &snapshot.params {
+        Some(p) => rate_model::compute_borrow_rate(utilization_bps, p),
         None => DEFAULT_APR_BPS,
-    }
+    };
+
+    Ok(BorrowRateComputation {
+        utilization_bps,
+        rate_bps,
+    })
+}
+
+/// Computes utilization and borrow rate from a preloaded aggregate snapshot.
+///
+/// Panics on arithmetic overflow, matching the existing borrow-rate API shape
+/// while keeping the underlying arithmetic checked.
+pub(crate) fn compute_borrow_rate_from_snapshot(snapshot: &RateSnapshot) -> BorrowRateComputation {
+    try_compute_borrow_rate_from_snapshot(snapshot).expect("borrow-rate utilization overflow")
+}
+
+fn uncached_borrow_rate_computation(env: &Env) -> BorrowRateComputation {
+    let snapshot = load_rate_snapshot(env);
+    compute_borrow_rate_from_snapshot(&snapshot)
 }
 
 /// Returns the global borrow rate, computing it at most once per ledger.
 ///
 /// The temporary-storage key includes `env.ledger().sequence()`, so advancing
 /// the ledger naturally misses the previous cache entry and recomputes from a
-/// fresh `RateSnapshot`.
+/// fresh `RateSnapshot`. Each cache miss also writes one utilization sample for
+/// the current ledger into the bounded utilization-history ring buffer.
 pub fn cached_borrow_rate(env: &Env) -> i128 {
     let ledger_sequence = env.ledger().sequence();
     let key = DataKey::BorrowRateCache(ledger_sequence);
@@ -154,13 +195,14 @@ pub fn cached_borrow_rate(env: &Env) -> i128 {
         }
     }
 
-    let rate_bps = uncached_borrow_rate(env);
+    let computation = uncached_borrow_rate_computation(env);
+    write_utilization_sample(env, computation.utilization_bps);
     let cache = BorrowRateCache {
         ledger_sequence,
-        rate_bps,
+        rate_bps: computation.rate_bps,
     };
     env.storage().temporary().set(&key, &cache);
-    rate_bps
+    computation.rate_bps
 }
 
 // ─── Time helpers ─────────────────────────────────────────────────────────────

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -90,6 +90,8 @@ mod rounding_drift_test;
 mod self_liquidation_test;
 #[cfg(test)]
 mod supply_rate_split_test;
+#[cfg(test)]
+mod utilization_history_test;
 
 use debt::{
     borrow_amount, cached_borrow_rate, effective_debt, load_debt, repay_amount, save_debt,
@@ -113,6 +115,12 @@ const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
 const SCHEMA_VERSION_V1: u32 = 1;
 const DEFAULT_MAX_FLASH_BPS: i128 = 10_000;
+/// Maximum number of utilization samples retained in persistent storage.
+///
+/// Samples are kept in an oldest-first bounded vector internally. When the cap
+/// is reached, the next write evicts exactly one oldest entry before appending
+/// the newest sample, keeping rent and read cost bounded.
+pub const UTILIZATION_HISTORY_CAPACITY: u32 = 256;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -166,6 +174,8 @@ pub enum DataKey {
     /// Running total of debt currently backed by this isolated asset.
     /// Incremented on borrow, decremented on repay. Stored as `persistent`.
     IsolationDebt(Address),
+    /// Ring-buffered protocol utilization samples, stored oldest-first.
+    UtilizationHistory,
 }
 
 #[contractevent]
@@ -351,6 +361,20 @@ pub struct ProtocolMetrics {
     pub total_supply: i128,
     pub utilization_bps: i128,
     pub ledger: u32,
+}
+
+/// Point-in-time protocol utilization sample.
+///
+/// Samples are written from the borrow-rate recomputation path and retained in
+/// a fixed-capacity ring buffer. They are stable contract values intended for
+/// off-chain decoding and trend charting.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UtilizationSample {
+    /// Ledger sequence at which the rate path observed this utilization.
+    pub ledger: u32,
+    /// Utilization in basis points: `total_debt * 10_000 / total_deposits`.
+    pub utilization_bps: i128,
 }
 
 #[contracttype]
@@ -1618,6 +1642,15 @@ impl LendingContract {
         }
     }
 
+    /// Return recent protocol utilization samples newest-first.
+    ///
+    /// The view is read-only and returns an empty vector when no rate update has
+    /// written a sample yet. Each sample contains the ledger sequence and the
+    /// utilization observed in basis points.
+    pub fn get_utilization_history(env: Env) -> Vec<UtilizationSample> {
+        utilization_history_newest_first(&env)
+    }
+
     // ════════════════════════════════════════════════════════════════
     // Cross-Asset Entrypoints
     // ════════════════════════════════════════════════════════════════
@@ -2423,6 +2456,53 @@ fn assert_borrow_solvent(
 
 fn current_borrow_rate(env: &Env) -> i128 {
     cached_borrow_rate(env)
+}
+
+pub(crate) fn write_utilization_sample(env: &Env, utilization_bps: i128) {
+    let mut samples = utilization_history_oldest_first(env);
+
+    if let Some(last) = samples.last() {
+        let last: UtilizationSample = last;
+        if last.ledger == env.ledger().sequence() {
+            return;
+        }
+    }
+
+    while samples.len() >= UTILIZATION_HISTORY_CAPACITY {
+        samples.remove(0);
+    }
+
+    samples.push_back(UtilizationSample {
+        ledger: env.ledger().sequence(),
+        utilization_bps,
+    });
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::UtilizationHistory, &samples);
+}
+
+/// Load utilization samples in their storage order, oldest-first.
+pub(crate) fn utilization_history_oldest_first(env: &Env) -> Vec<UtilizationSample> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UtilizationHistory)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Load utilization samples in view order, newest-first.
+fn utilization_history_newest_first(env: &Env) -> Vec<UtilizationSample> {
+    let samples = utilization_history_oldest_first(env);
+    let mut newest_first = Vec::new(env);
+    let mut index = samples.len();
+
+    while index > 0 {
+        index -= 1;
+        let sample: UtilizationSample = samples.get(index).unwrap();
+        newest_first.push_back(sample);
+    }
+
+    newest_first
 }
 
 fn require_fresh_valuation_prices(env: &Env) -> Result<(), LendingError> {

--- a/stellar-lend/contracts/lending/src/utilization_history_test.rs
+++ b/stellar-lend/contracts/lending/src/utilization_history_test.rs
@@ -1,0 +1,174 @@
+#![cfg(test)]
+
+use crate::{
+    debt::{cached_borrow_rate, try_compute_borrow_rate_from_snapshot, RateSnapshot},
+    rate_model::RateParams,
+    write_utilization_sample, DataKey, LendingContract, LendingContractClient, UtilizationSample,
+    UTILIZATION_HISTORY_CAPACITY,
+};
+use soroban_sdk::{testutils::Ledger, Address, Env};
+
+fn setup() -> (Env, Address, LendingContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, contract_id, client)
+}
+
+fn set_rate_inputs(env: &Env, total_debt: i128, total_deposits: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalDebt, &total_debt);
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalDeposits, &total_deposits);
+    env.storage()
+        .instance()
+        .set(&DataKey::RateParams, &RateParams::default());
+}
+
+fn sample(history: &soroban_sdk::Vec<UtilizationSample>, index: u32) -> UtilizationSample {
+    history.get(index).expect("sample should exist")
+}
+
+#[test]
+fn empty_utilization_history_returns_empty_vec() {
+    let (_env, _contract_id, client) = setup();
+
+    let history = client.get_utilization_history();
+
+    assert_eq!(history.len(), 0);
+}
+
+#[test]
+fn utilization_history_records_single_rate_update_sample() {
+    let (env, contract_id, client) = setup();
+
+    env.ledger().set_sequence_number(42);
+    env.as_contract(&contract_id, || {
+        set_rate_inputs(&env, 4_000, 10_000);
+
+        assert_eq!(cached_borrow_rate(&env), 900);
+    });
+
+    let history = client.get_utilization_history();
+
+    assert_eq!(history.len(), 1);
+    assert_eq!(
+        sample(&history, 0),
+        UtilizationSample {
+            ledger: 42,
+            utilization_bps: 4_000,
+        }
+    );
+}
+
+#[test]
+fn utilization_history_uses_cache_miss_once_per_ledger() {
+    let (env, contract_id, client) = setup();
+
+    env.ledger().set_sequence_number(77);
+    env.as_contract(&contract_id, || {
+        set_rate_inputs(&env, 2_500, 10_000);
+
+        assert_eq!(cached_borrow_rate(&env), 600);
+        assert_eq!(cached_borrow_rate(&env), 600);
+    });
+
+    let history = client.get_utilization_history();
+
+    assert_eq!(history.len(), 1);
+    assert_eq!(sample(&history, 0).ledger, 77);
+    assert_eq!(sample(&history, 0).utilization_bps, 2_500);
+}
+
+#[test]
+fn utilization_history_view_returns_newest_first() {
+    let (env, contract_id, client) = setup();
+
+    env.as_contract(&contract_id, || {
+        env.ledger().set_sequence_number(100);
+        set_rate_inputs(&env, 1_000, 10_000);
+        assert_eq!(cached_borrow_rate(&env), 300);
+
+        env.ledger().set_sequence_number(101);
+        set_rate_inputs(&env, 7_500, 10_000);
+        assert_eq!(cached_borrow_rate(&env), 1_600);
+
+        env.ledger().set_sequence_number(102);
+        set_rate_inputs(&env, 10_000, 10_000);
+        assert_eq!(cached_borrow_rate(&env), 3_700);
+    });
+
+    let history = client.get_utilization_history();
+
+    assert_eq!(history.len(), 3);
+    assert_eq!(sample(&history, 0).ledger, 102);
+    assert_eq!(sample(&history, 0).utilization_bps, 10_000);
+    assert_eq!(sample(&history, 1).ledger, 101);
+    assert_eq!(sample(&history, 1).utilization_bps, 7_500);
+    assert_eq!(sample(&history, 2).ledger, 100);
+    assert_eq!(sample(&history, 2).utilization_bps, 1_000);
+}
+
+#[test]
+fn utilization_history_capacity_boundary_evicts_oldest() {
+    let (env, contract_id, client) = setup();
+    let first_ledger = 1_000u32;
+
+    env.as_contract(&contract_id, || {
+        for offset in 0..UTILIZATION_HISTORY_CAPACITY {
+            env.ledger().set_sequence_number(first_ledger + offset);
+            write_utilization_sample(&env, offset as i128);
+        }
+    });
+
+    let full_history = client.get_utilization_history();
+
+    assert_eq!(full_history.len(), UTILIZATION_HISTORY_CAPACITY);
+    assert_eq!(
+        sample(&full_history, 0).ledger,
+        first_ledger + UTILIZATION_HISTORY_CAPACITY - 1
+    );
+    assert_eq!(
+        sample(&full_history, UTILIZATION_HISTORY_CAPACITY - 1).ledger,
+        first_ledger
+    );
+
+    env.as_contract(&contract_id, || {
+        env.ledger()
+            .set_sequence_number(first_ledger + UTILIZATION_HISTORY_CAPACITY);
+        write_utilization_sample(&env, 9_999);
+    });
+
+    let evicted_history = client.get_utilization_history();
+
+    assert_eq!(evicted_history.len(), UTILIZATION_HISTORY_CAPACITY);
+    assert_eq!(
+        sample(&evicted_history, 0),
+        UtilizationSample {
+            ledger: first_ledger + UTILIZATION_HISTORY_CAPACITY,
+            utilization_bps: 9_999,
+        }
+    );
+    assert_eq!(
+        sample(&evicted_history, UTILIZATION_HISTORY_CAPACITY - 1).ledger,
+        first_ledger + 1
+    );
+}
+
+#[test]
+fn utilization_history_rate_math_reports_overflow() {
+    let snapshot = RateSnapshot {
+        total_debt: i128::MAX,
+        total_supply: 1,
+        params: Some(RateParams::default()),
+    };
+
+    assert!(try_compute_borrow_rate_from_snapshot(&snapshot).is_err());
+}


### PR DESCRIPTION
## Summary

- add a bounded utilization-history buffer to the lending crate
- write utilization samples from the existing per-ledger borrow-rate cache miss path
- expose `get_utilization_history` as a read-only newest-first view
- add focused utilization-history tests and reviewer-facing documentation

Closes #1215

## Testing

- `PATH=/home/jerry/.cargo/bin:$PATH cargo fmt --package stellarlend-lending`
- `git diff --cached --check`
- `PATH=/home/jerry/.cargo/bin:$PATH cargo test -p stellarlend-lending utilization_history` *(blocked locally: host linker `cc` is not installed in this environment)*
