### PR TITLE
test(twap): add coverage tests for has_window_coverage and find_snapshot_at_or_before

### DIFF
--- a/stellar-lend/contracts/hello-world/docs/TWAP_COVERAGE_TESTS.md
+++ b/stellar-lend/contracts/hello-world/docs/TWAP_COVERAGE_TESTS.md
@@ -1,0 +1,112 @@
+# TWAP Coverage Tests
+
+## Purpose
+
+`has_window_coverage` and `find_snapshot_at_or_before` are the two gateway
+functions that every TWAP price query passes through before any arithmetic is
+done.  If either of them returns the wrong answer — or panics — every caller
+sees a corrupt or reverted price.
+
+These tests lock down the contracts between the implementation and its callers:
+
+* **`has_window_coverage`** – decides whether the on-chain snapshot ring-buffer
+  contains enough history to serve a TWAP for a given look-back window.
+* **`find_snapshot_at_or_before`** – performs a binary search over the
+  ring-buffer to locate the anchor snapshot that brackets the start of a TWAP
+  window.
+
+Without systematic coverage, subtle off-by-one errors (e.g., `<` vs `≤` in the
+binary search) or missing early-returns (e.g., empty buffer, `window_secs`
+below minimum) can silently corrupt prices in production.
+
+---
+
+## Test Scenarios
+
+### `has_window_coverage`
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | No pool state at all (no storage entry) | `false` — early return without panic |
+| 2 | `window_secs < MIN_WINDOW_SECS` | `false` — first guard rejects small windows unconditionally |
+| 3 | Oldest snapshot is **newer** than window start | `false` — no anchor found |
+| 4 | Oldest snapshot is **older** than window start | `true` — anchor found, elapsed time sufficient |
+| 5 | Snapshot exactly **at** window start boundary | `true` — `≤` comparison qualifies the boundary |
+| 6 | Snapshot **one second after** window start | `false` — boundary exclusive on the snapshot side |
+| 7 | Pool state exists but **no snapshot yet**, sufficient elapsed time | `true` — falls back to `last_timestamp` |
+| 8 | Pool state exists but **no snapshot yet**, insufficient elapsed time | `false` — fallback also insufficient |
+
+### `find_snapshot_at_or_before`
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Empty buffer | `None` — no comparison made, no panic |
+| 2 | Target is an **exact hit** (middle or last) | `Some(snapshot)` with matching timestamp |
+| 3 | Target falls **between** two snapshots | `Some(lower bound)` — nearest snapshot ≤ target |
+| 4 | Target is **before** the first snapshot | `None` — no anchor satisfies `snap.ts ≤ target` |
+| 5 | Target equals the **first** snapshot | `Some(first)` — left-boundary path |
+| 6 | Single-element buffer, exact hit | `Some(that element)` |
+| 7 | Single-element buffer, target above | `Some(that element)` |
+| 8 | Single-element buffer, target below | `None` |
+| 9 | Target far beyond the last snapshot | `Some(last)` — rightmost entry |
+
+---
+
+## Worked Example
+
+Assume the ring-buffer holds three snapshots:
+
+```
+Index:  0      1      2
+       T=100  T=200  T=300
+```
+
+Current ledger time: **T = 320**.  Requested window: **25 s**.
+
+```
+target_start = 320 − 25 = 295
+```
+
+**`find_snapshot_at_or_before(snaps, 295)`** runs a binary search:
+
+1. `mid = 1`, `snaps[1].timestamp = 200 ≤ 295` → record candidate `T=200`, search right half.
+2. `mid = 2`, `snaps[2].timestamp = 300 > 295` → do not update candidate, search left half.
+3. Search exhausted → return `Some(T=200)`.
+
+**`has_window_coverage`** then checks:
+
+```
+elapsed = now − snap.timestamp = 320 − 200 = 120
+120 ≥ MIN_WINDOW_SECS (25)  →  true
+```
+
+The TWAP query proceeds with `T=200` as its start anchor.
+
+---
+
+## Edge Case Notes
+
+### Empty buffer
+The binary search initialises with `lo = 0, hi = len − 1` but immediately
+returns `None` when `len == 0` before any indexing.  Confirmed by
+`find_snapshot_returns_none_for_empty_buffer`.
+
+### `≤` vs `<` at the boundary
+The search condition `snap.timestamp ≤ target_ts` means a snapshot placed
+**exactly at** the window start qualifies.  This is the intended behaviour:
+if we have exactly `MIN_WINDOW_SECS` of history, we can serve the window.
+See `coverage_true_when_snapshot_exactly_at_window_start` and its mirror
+`coverage_false_when_snapshot_one_second_after_window_start`.
+
+### No-snapshot fallback
+When a pool has been updated at least once but the periodic snapshot writer
+has not yet fired (first update is within the first `SNAPSHOT_INTERVAL_SECS`),
+`has_window_coverage` falls back to `pool_state.last_timestamp`.  Tests
+`coverage_true_with_pool_state_but_no_snapshots_after_enough_elapsed_time` and
+`coverage_false_with_pool_state_but_no_snapshots_and_insufficient_elapsed_time`
+cover both branches of this fallback.
+
+### Binary search comparison count
+`snapshot_search_metrics_for_test` exposes the internal step counter so tests
+can assert O(log n) comparisons and that the empty-buffer path makes zero
+comparisons.  This guards against accidental O(n) regressions.

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -73,6 +73,8 @@ mod rate_clamp_test;
 mod twap_view_test;
 #[cfg(test)]
 mod twap_maxbuffer_perf_test;
+#[cfg(test)]
+mod twap_coverage_test;
 
 // Legacy test suite currently mismatches contract API and is excluded from CI compile.
 // #[cfg(test)]

--- a/stellar-lend/contracts/hello-world/src/twap_coverage_test.rs
+++ b/stellar-lend/contracts/hello-world/src/twap_coverage_test.rs
@@ -1,0 +1,409 @@
+/// twap_coverage_test.rs — Tests for `has_window_coverage` and
+/// `find_snapshot_at_or_before` in `amm_twap.rs`.
+///
+/// # Coverage targets
+/// ───────────────────
+/// ✓ `has_window_coverage`: false when no pool state exists (empty buffer)
+/// ✓ `has_window_coverage`: false when `window_secs` < `MIN_WINDOW_SECS`
+/// ✓ `has_window_coverage`: false when oldest snapshot is newer than window start
+/// ✓ `has_window_coverage`: true when oldest snapshot is older than window start
+/// ✓ `has_window_coverage`: snapshot exactly at window start boundary → true
+/// ✓ `has_window_coverage`: snapshot one second after window start → false
+/// ✓ `has_window_coverage`: pool state but no snapshots yet, enough elapsed time → true
+/// ✓ `find_snapshot_at_or_before`: empty buffer returns None without panic
+/// ✓ `find_snapshot_at_or_before`: exact timestamp hit returns matching snapshot
+/// ✓ `find_snapshot_at_or_before`: target between snapshots returns nearest lower bound
+/// ✓ `find_snapshot_at_or_before`: target before first snapshot returns None
+/// ✓ `find_snapshot_at_or_before`: target at first snapshot returns first snapshot
+/// ✓ `find_snapshot_at_or_before`: single-element buffer, exact hit
+/// ✓ `find_snapshot_at_or_before`: single-element buffer, target above → Some
+/// ✓ `find_snapshot_at_or_before`: single-element buffer, target below → None
+/// ✓ `find_snapshot_at_or_before`: target beyond last snapshot returns last
+
+#[cfg(test)]
+mod twap_coverage_tests {
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{testutils::Ledger, Address, Env};
+
+    use crate::amm_twap::{
+        has_window_coverage, snapshot_search_metrics_for_test, update_twap_accumulators,
+        TwapSnapshot, MIN_WINDOW_SECS, SNAPSHOT_INTERVAL_SECS,
+    };
+
+    // ── Test helpers ─────────────────────────────────────────────────────────
+
+    /// Advance the mock ledger by `secs` seconds.
+    fn advance(env: &Env, secs: u64) {
+        let t = env.ledger().timestamp();
+        env.ledger().set_timestamp(t + secs);
+    }
+
+    /// Return a freshly generated mock asset address.
+    fn mock_asset(env: &Env) -> Address {
+        Address::generate(env)
+    }
+
+    /// Build a `soroban_sdk::Vec<TwapSnapshot>` from a slice of timestamps.
+    ///
+    /// Cumulative values are set to zero; only timestamps matter for the
+    /// binary-search correctness tests in this file.
+    fn make_snaps(env: &Env, timestamps: &[u64]) -> soroban_sdk::Vec<TwapSnapshot> {
+        let mut v: soroban_sdk::Vec<TwapSnapshot> = soroban_sdk::Vec::new(env);
+        for &ts in timestamps {
+            v.push_back(TwapSnapshot {
+                timestamp: ts,
+                price0_cumulative: 0,
+                price1_cumulative: 0,
+            });
+        }
+        v
+    }
+
+    // ── has_window_coverage ──────────────────────────────────────────────────
+
+    /// No pool state has ever been written for the asset.
+    ///
+    /// `has_window_coverage` must return `false` immediately (the early-return
+    /// on missing `TwapPoolState`) without panicking.  This is the "completely
+    /// empty" case — no storage entry at all.
+    #[test]
+    fn coverage_false_when_no_pool_state() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let asset = mock_asset(&env);
+
+        // Intentionally skip update_twap_accumulators — nothing written.
+        assert!(
+            !has_window_coverage(&env, &asset, MIN_WINDOW_SECS),
+            "no pool state must return false without panicking"
+        );
+    }
+
+    /// `window_secs` is below the protocol-enforced minimum (`MIN_WINDOW_SECS`).
+    ///
+    /// The function's first guard rejects such requests unconditionally, even
+    /// when ample snapshot history exists.
+    #[test]
+    fn coverage_false_when_window_below_minimum() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let asset = mock_asset(&env);
+
+        // Build plenty of history.
+        update_twap_accumulators(&env, &asset, 1_000_000, 1_000_000);
+        advance(&env, MIN_WINDOW_SECS * 10);
+        update_twap_accumulators(&env, &asset, 1_000_000, 1_000_000);
+
+        assert!(
+            !has_window_coverage(&env, &asset, MIN_WINDOW_SECS - 1),
+            "window_secs below MIN_WINDOW_SECS must return false even with ample history"
+        );
+    }
+
+    /// The oldest (and only) snapshot sits **newer** than the requested window
+    /// start, so `find_snapshot_at_or_before` returns `None`.  The elapsed
+    /// history since the earliest recorded timestamp is also shorter than
+    /// `MIN_WINDOW_SECS`, so the function returns `false`.
+    ///
+    /// Setup:
+    ///   - Snapshot written at T = 1_000_000.
+    ///   - Ledger advances 20 s → T = 1_000_020.
+    ///   - `window_secs` = 25 → `target_start` = 999 995.
+    ///   - Snapshot timestamp 1_000_000 > 999_995 → no anchor → `None` path.
+    ///   - now − 1_000_000 = 20 < 25 (`MIN_WINDOW_SECS`) → `false`.
+    #[test]
+    fn coverage_false_when_oldest_snapshot_newer_than_window_start() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 1_000_000);
+
+        // Advance only 20 s — less than MIN_WINDOW_SECS (25).
+        advance(&env, 20);
+
+        assert!(
+            !has_window_coverage(&env, &asset, MIN_WINDOW_SECS),
+            "snapshot at T=1_000_000 is newer than window start T=999_995; must return false"
+        );
+    }
+
+    /// The oldest snapshot is **older** than the requested window start, so
+    /// `find_snapshot_at_or_before` returns a valid `Some` anchor.  The elapsed
+    /// time since that anchor is positive, so the function returns `true`.
+    ///
+    /// Setup:
+    ///   - Snapshot written at T = 1_000.
+    ///   - Ledger set to T = 10_000 (no further writes).
+    ///   - `window_secs` = 25 → `target_start` = 9_975.
+    ///   - Snapshot T=1_000 ≤ 9_975 → `Some` anchor.
+    ///   - now − 1_000 = 9_000 > 0 → `true`.
+    #[test]
+    fn coverage_true_when_oldest_snapshot_older_than_window_start() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 1_000_000);
+
+        // Jump forward; no new snapshot is needed.
+        env.ledger().set_timestamp(10_000);
+
+        assert!(
+            has_window_coverage(&env, &asset, MIN_WINDOW_SECS),
+            "snapshot at T=1_000 predates window start T=9_975; must return true"
+        );
+    }
+
+    /// The snapshot sits **exactly** at the window start boundary.
+    ///
+    /// `find_snapshot_at_or_before` uses a `≤` comparison, so a snapshot
+    /// at `target_start` qualifies as a valid anchor.  Because `now −
+    /// snap.timestamp` = `MIN_WINDOW_SECS` > 0, the function returns `true`.
+    ///
+    /// Setup:
+    ///   - Snapshot at T = 1_000_000.
+    ///   - Advance exactly `MIN_WINDOW_SECS` → now = 1_000_025.
+    ///   - `target_start` = 1_000_025 − 25 = 1_000_000 → exact match → anchor.
+    ///   - now − 1_000_000 = 25 > 0 → `true`.
+    #[test]
+    fn coverage_true_when_snapshot_exactly_at_window_start() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 1_000_000);
+        advance(&env, MIN_WINDOW_SECS);
+
+        assert!(
+            has_window_coverage(&env, &asset, MIN_WINDOW_SECS),
+            "snapshot exactly at window start qualifies as anchor; must return true"
+        );
+    }
+
+    /// One second short of boundary: snapshot is one second **after** the
+    /// window start, so no anchor exists.  Elapsed history is also too short,
+    /// so the function returns `false`.
+    ///
+    /// Setup:
+    ///   - Snapshot at T = 1_000_000.
+    ///   - Advance `MIN_WINDOW_SECS − 1` → now = 1_000_024.
+    ///   - `target_start` = 1_000_024 − 25 = 999_999.
+    ///   - Snapshot T=1_000_000 > 999_999 → `None` path.
+    ///   - now − 1_000_000 = 24 < 25 → `false`.
+    #[test]
+    fn coverage_false_when_snapshot_one_second_after_window_start() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 1_000_000);
+        advance(&env, MIN_WINDOW_SECS - 1);
+
+        assert!(
+            !has_window_coverage(&env, &asset, MIN_WINDOW_SECS),
+            "snapshot one second newer than window start must return false"
+        );
+    }
+
+    /// Pool state exists but no snapshot has been written yet (first update was
+    /// too recent for `maybe_write_snapshot` to trigger).  After enough time
+    /// has elapsed since the pool's `last_timestamp`, `has_window_coverage`
+    /// falls back to `current_state.last_timestamp` and returns `true`.
+    ///
+    /// Setup:
+    ///   - T = 30 < `SNAPSHOT_INTERVAL_SECS` (60) → update writes pool state
+    ///     but NOT a snapshot.
+    ///   - T = 100 → now − last_timestamp = 70 ≥ 25 → `true`.
+    #[test]
+    fn coverage_true_with_pool_state_but_no_snapshots_after_enough_elapsed_time() {
+        let env = Env::default();
+        // Start before SNAPSHOT_INTERVAL_SECS so no snapshot is written.
+        env.ledger().set_timestamp(30);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 1_000_000);
+
+        // Advance so that now − last_timestamp = 70 ≥ MIN_WINDOW_SECS (25).
+        env.ledger().set_timestamp(100);
+
+        assert!(
+            has_window_coverage(&env, &asset, MIN_WINDOW_SECS),
+            "70 s elapsed since pool's last_timestamp must satisfy MIN_WINDOW_SECS"
+        );
+    }
+
+    /// Mirrors the above but with insufficient elapsed time since the pool's
+    /// `last_timestamp`; `has_window_coverage` must return `false`.
+    ///
+    /// Setup:
+    ///   - T = 30, no snapshot written.
+    ///   - T = 54 → now − last_timestamp = 24 < 25 → `false`.
+    #[test]
+    fn coverage_false_with_pool_state_but_no_snapshots_and_insufficient_elapsed_time() {
+        let env = Env::default();
+        env.ledger().set_timestamp(30);
+        let asset = mock_asset(&env);
+
+        update_twap_accumulators(&env, &asset, 1_000_000, 1_000_000);
+
+        env.ledger().set_timestamp(54);
+
+        assert!(
+            !has_window_coverage(&env, &asset, MIN_WINDOW_SECS),
+            "24 s elapsed since pool's last_timestamp is less than MIN_WINDOW_SECS; must be false"
+        );
+    }
+
+    // ── find_snapshot_at_or_before ───────────────────────────────────────────
+
+    /// Empty snapshot buffer → `None` is returned and no comparisons are made.
+    ///
+    /// Validates the early-return on `len == 0` inside the binary search.
+    /// Must not panic.
+    #[test]
+    fn find_snapshot_returns_none_for_empty_buffer() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[]);
+
+        let (result, comparisons) = snapshot_search_metrics_for_test(&snaps, 1_000);
+
+        assert!(result.is_none(), "empty buffer must return None");
+        assert_eq!(comparisons, 0, "no comparisons expected for an empty buffer");
+    }
+
+    /// Target timestamp **exactly matches** a snapshot → that snapshot is returned.
+    ///
+    /// The binary search uses `snap.timestamp ≤ target_ts`, so an exact hit
+    /// continues searching rightward and ultimately returns the matched entry.
+    /// Validated for both the middle and the last element.
+    #[test]
+    fn find_snapshot_exact_timestamp_returns_matching_snapshot() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[100, 200, 300]);
+
+        // Exact hit at the middle entry.
+        let (result, _) = snapshot_search_metrics_for_test(&snaps, 200);
+        let snap = result.expect("exact hit at middle must return Some");
+        assert_eq!(snap.timestamp, 200, "exact match must return the snapshot at T=200");
+
+        // Exact hit at the last entry.
+        let (result_last, _) = snapshot_search_metrics_for_test(&snaps, 300);
+        let snap_last = result_last.expect("exact hit at last must return Some");
+        assert_eq!(snap_last.timestamp, 300, "exact match must return the snapshot at T=300");
+    }
+
+    /// Target falls **between** two consecutive snapshots → the most recent
+    /// snapshot at or before the target is returned (lower bound), not the
+    /// next one above it (upper bound).
+    ///
+    /// Buffer: [T=100, T=200, T=300].
+    ///   - target=250 → lower bound is T=200.
+    ///   - target=150 → lower bound is T=100.
+    #[test]
+    fn find_snapshot_between_timestamps_returns_nearest_lower_bound() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[100, 200, 300]);
+
+        let (result, _) = snapshot_search_metrics_for_test(&snaps, 250);
+        let snap = result.expect("target T=250 must return Some");
+        assert_eq!(
+            snap.timestamp, 200,
+            "T=250 is between T=200 and T=300; lower bound must be T=200"
+        );
+
+        let (result2, _) = snapshot_search_metrics_for_test(&snaps, 150);
+        let snap2 = result2.expect("target T=150 must return Some");
+        assert_eq!(
+            snap2.timestamp, 100,
+            "T=150 is between T=100 and T=200; lower bound must be T=100"
+        );
+    }
+
+    /// Target is strictly **before** the first snapshot → `None`.
+    ///
+    /// The binary search exhausts all candidates without ever satisfying
+    /// `snap.timestamp ≤ target_ts`, so no result is set and `None` is returned.
+    /// Must not panic.
+    #[test]
+    fn find_snapshot_target_before_first_snapshot_returns_none() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[100, 200, 300]);
+
+        let (result, _) = snapshot_search_metrics_for_test(&snaps, 50);
+
+        assert!(
+            result.is_none(),
+            "target T=50 is before earliest snapshot T=100; must return None"
+        );
+    }
+
+    /// Target equals the **first** snapshot's timestamp → that snapshot is returned.
+    ///
+    /// Validates the left-boundary path of the binary search where
+    /// `snap.timestamp == target_ts` at index 0.
+    #[test]
+    fn find_snapshot_target_at_first_snapshot_returns_first() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[100, 200, 300]);
+
+        let (result, _) = snapshot_search_metrics_for_test(&snaps, 100);
+        let snap = result.expect("target at first snapshot must return Some");
+        assert_eq!(
+            snap.timestamp, 100,
+            "target T=100 equals first snapshot; must return T=100"
+        );
+    }
+
+    /// Single-element buffer with an **exact** hit → returns that snapshot.
+    #[test]
+    fn find_snapshot_single_element_exact_hit() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[500]);
+
+        let (result, _) = snapshot_search_metrics_for_test(&snaps, 500);
+        let snap = result.expect("single-element exact hit must return Some");
+        assert_eq!(snap.timestamp, 500);
+    }
+
+    /// Single-element buffer with target **above** the snapshot → returns that snapshot.
+    #[test]
+    fn find_snapshot_single_element_target_above() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[500]);
+
+        let (result, _) = snapshot_search_metrics_for_test(&snaps, 999);
+        let snap = result.expect("target above single element must return Some");
+        assert_eq!(snap.timestamp, 500);
+    }
+
+    /// Single-element buffer with target **below** the snapshot → `None`.
+    #[test]
+    fn find_snapshot_single_element_target_below_returns_none() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[500]);
+
+        let (result, _) = snapshot_search_metrics_for_test(&snaps, 499);
+        assert!(
+            result.is_none(),
+            "target below a single-element buffer must return None"
+        );
+    }
+
+    /// Target far beyond the last snapshot → returns the **last** snapshot.
+    ///
+    /// Ensures the binary search never panics on an out-of-range target and
+    /// correctly converges on the rightmost qualifying entry.
+    #[test]
+    fn find_snapshot_target_beyond_last_snapshot_returns_last() {
+        let env = Env::default();
+        let snaps = make_snaps(&env, &[100, 200, 300]);
+
+        let (result, _) = snapshot_search_metrics_for_test(&snaps, u64::MAX);
+        let snap = result.expect("target beyond all snapshots must return Some");
+        assert_eq!(
+            snap.timestamp, 300,
+            "target beyond all entries must return the last snapshot T=300"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1236

## Summary

- Adds `stellar-lend/contracts/hello-world/src/twap_coverage_test.rs` with **15 test cases** covering all acceptance criteria for `has_window_coverage` and `find_snapshot_at_or_before`
- Declares the module in `lib.rs` under `#[cfg(test)]`
- Adds `stellar-lend/contracts/hello-world/docs/TWAP_COVERAGE_TESTS.md` with rationale, scenario table, worked example, and edge-case notes

## Test cases

### `has_window_coverage` (8 tests)
| Test | Scenario | Expected |
|------|----------|----------|
| `coverage_false_when_no_pool_state` | No storage entry at all | `false` without panic |
| `coverage_false_when_window_below_minimum` | `window_secs < MIN_WINDOW_SECS` | `false` regardless of history |
| `coverage_false_when_oldest_snapshot_newer_than_window_start` | Snapshot newer than window start | `false` |
| `coverage_true_when_oldest_snapshot_older_than_window_start` | Snapshot older than window start | `true` |
| `coverage_true_when_snapshot_exactly_at_window_start` | Snapshot exactly at boundary | `true` (≤ comparison) |
| `coverage_false_when_snapshot_one_second_after_window_start` | One second short of boundary | `false` |
| `coverage_true_with_pool_state_but_no_snapshots_after_enough_elapsed_time` | Pool state, no snapshot, sufficient elapsed | `true` |
| `coverage_false_with_pool_state_but_no_snapshots_and_insufficient_elapsed_time` | Pool state, no snapshot, insufficient elapsed | `false` |

### `find_snapshot_at_or_before` (7 tests)
| Test | Scenario | Expected |
|------|----------|----------|
| `find_snapshot_returns_none_for_empty_buffer` | Empty buffer | `None`, 0 comparisons |
| `find_snapshot_exact_timestamp_returns_matching_snapshot` | Exact hit at middle and last | `Some(matching)` |
| `find_snapshot_between_timestamps_returns_nearest_lower_bound` | Target between snapshots | `Some(lower bound)` |
| `find_snapshot_target_before_first_snapshot_returns_none` | Target before earliest | `None` |
| `find_snapshot_target_at_first_snapshot_returns_first` | Target equals first | `Some(first)` |
| `find_snapshot_single_element_*` (3 sub-cases) | Single-element buffer: exact/above/below | `Some`/`Some`/`None` |
| `find_snapshot_target_beyond_last_snapshot_returns_last` | Target beyond all entries | `Some(last)` |

## Acceptance criteria coverage

- [x] `has_window_coverage` returns `false` when oldest snapshot is newer than window start
- [x] `find_snapshot_at_or_before` returns the correct bounding snapshot for exact and between-timestamp targets
- [x] Empty buffer returns `None` / no coverage without panicking
- [x] Target before the first snapshot returns `None`

## Test runner

```bash
cargo test -p hello-world twap_coverage
```