### PR TITLE
docs: add bridge inbound window tuning guide

### DIFF
--- a/stellar-lend/contracts/bridge/INBOUND_WINDOW_TUNING.md
+++ b/stellar-lend/contracts/bridge/INBOUND_WINDOW_TUNING.md
@@ -1,0 +1,123 @@
+# Inbound Window Tuning
+
+This guide explains how the bridge rolling-window inbound cap works and how an
+operator should choose `max_per_window` and `window_size` for different risk
+postures.
+
+The cap is a defense-in-depth control. Validator quorum and epoch checks decide
+whether an inbound message is authorized. The inbound window limits how much
+authorized inbound value can be admitted before operators get time to detect and
+respond to a bad validator set, relayer bug, or integration failure.
+
+## Algorithm
+
+`Bridge::admit_inbound(amount, current_time)` tracks four fields:
+
+- `max_per_window`: maximum cumulative inbound value allowed in the window.
+- `window_size`: length of the window in ledger-time seconds.
+- `window_start`: ledger time where the current window began.
+- `window_inbound_total`: value already admitted in the current window.
+
+For each inbound amount:
+
+1. Reject negative `amount`.
+2. Reject when `max_per_window == 0`; this is fail-closed, not unlimited.
+3. If `current_time >= window_start + window_size`, start a fresh window at
+   `current_time` and reset `window_inbound_total` to zero.
+4. Compute `window_inbound_total + amount` with checked arithmetic.
+5. Reject if the new total is greater than `max_per_window`.
+6. On success only, store the new total.
+
+Failed admission never mutates the running total. A rejected over-cap transfer
+does not consume any capacity, so a later smaller transfer can still fit.
+
+## Fail-Closed Startup
+
+A fresh `Bridge` starts with:
+
+```text
+max_per_window = 0
+window_size = 86_400
+window_start = 0
+window_inbound_total = 0
+```
+
+That means day-one inbound flow is disabled until an operator calls
+`set_inbound_cap(max_per_window, window_size, current_time)` with a positive
+cap. This is intentional: the safe default is to require an explicit operating
+limit before any value can enter.
+
+Use an explicit zero cap as an emergency pause. It rejects all inbound amounts,
+including zero-value transfers, until a positive cap is configured again.
+
+## Parameter Selection
+
+Choose `max_per_window` as the largest loss you are willing to tolerate before
+manual intervention, then choose `window_size` as the detection and response
+period.
+
+| Posture | Example config | Throughput implication | Use when |
+|---|---:|---|---|
+| Emergency pause | `max_per_window = 0`, `window_size = 86_400` | No inbound flow | Incident response, initial deployment before funding |
+| Conservative | `max_per_window = 1_000`, `window_size = 86_400` | Up to 1,000 units per day | New deployment, thin liquidity, manual monitoring |
+| Balanced | `max_per_window = 10_000`, `window_size = 86_400` | Up to 10,000 units per day | Normal operations with daily review |
+| Permissive | `max_per_window = 20_000`, `window_size = 3_600` | Up to 20,000 units per hour | Mature monitoring and automated alerting |
+
+Shorter windows replenish capacity sooner but increase the maximum value that
+can move over a day. For example, `20_000` per hour allows up to `480_000` units
+over 24 hours if every hourly window is filled.
+
+## Conservative Worked Example
+
+Configure a conservative daily cap at time zero:
+
+```text
+set_inbound_cap(max_per_window = 1_000, window_size = 86_400, current_time = 0)
+```
+
+Then:
+
+```text
+admit_inbound(600, current_time = 100)  -> Ok, total = 600
+admit_inbound(400, current_time = 200)  -> Ok, total = 1_000
+admit_inbound(1,   current_time = 300)  -> Err, total stays 1_000
+```
+
+At exactly one full window later, capacity replenishes:
+
+```text
+admit_inbound(1_000, current_time = 86_400) -> Ok
+window_start = 86_400
+window_inbound_total = 1_000
+```
+
+## Permissive Worked Example
+
+Configure an hourly cap:
+
+```text
+set_inbound_cap(max_per_window = 20_000, window_size = 3_600, current_time = 10)
+```
+
+Then three same-window admissions can fill the hour exactly:
+
+```text
+admit_inbound(7_500, current_time = 100) -> Ok, total = 7_500
+admit_inbound(7_500, current_time = 200) -> Ok, total = 15_000
+admit_inbound(5_000, current_time = 300) -> Ok, total = 20_000
+```
+
+Any additional value before `current_time = 3_610` is rejected. At
+`current_time = 3_610`, the window rolls and the full hourly cap is available
+again.
+
+## Operator Checklist
+
+- Configure a positive cap before enabling production inbound flow.
+- Keep `max_per_window` below the amount operators can tolerate losing within
+  the response window.
+- Use a shorter `window_size` only when monitoring and incident response are
+  fast enough to justify the higher daily throughput.
+- Use `max_per_window = 0` to pause inbound flow during incidents.
+- Reconfigure deliberately: `set_inbound_cap` starts a clean window and clears
+  the prior running total.

--- a/stellar-lend/contracts/bridge/README.md
+++ b/stellar-lend/contracts/bridge/README.md
@@ -8,6 +8,16 @@ Key features
 - `validate_inbound_epoch(signed_epoch)` rejects messages signed by retired epochs (signed_epoch < current epoch)
 - `set_inbound_cap(max_per_window, window_size, current_time)` / `admit_inbound(amount, current_time)` enforce a configurable, rolling-ledger-time cap on cumulative inbound value — defense-in-depth against an authorized-but-compromised validator set draining the bridge in a single window. **Fail-closed by default**: a fresh `Bridge` admits no inbound value until a cap is explicitly configured. See `SECURITY_NOTES.md` for the full threat model and design rationale.
 
+## Documentation Index
+
+| Document | Description |
+|---|---|
+| [SECURITY_NOTES.md](./SECURITY_NOTES.md) | Bridge validator rotation threat model and inbound-cap security rationale |
+| [INBOUND_WINDOW_TUNING.md](./INBOUND_WINDOW_TUNING.md) | Rolling-window cap algorithm and operator parameter-selection guide |
+| [WINDOW_GUARD.md](./WINDOW_GUARD.md) | Window-boundary guard rationale for zero windows, clock rollback, and overflow |
+| [EPOCH_INVARIANTS.md](./EPOCH_INVARIANTS.md) | Epoch monotonicity and retired-validator replay invariants |
+| [VALIDATORSET_INVARIANTS.md](./VALIDATORSET_INVARIANTS.md) | Validator-set deduplication and quorum threshold invariants |
+
 Design notes
 - Validator public keys are stored as raw bytes to keep on-disk/state serialization simple and unambiguous.
 - Quorum threshold is a supermajority > 2/3 of current validators.

--- a/stellar-lend/contracts/bridge/SECURITY_NOTES.md
+++ b/stellar-lend/contracts/bridge/SECURITY_NOTES.md
@@ -86,6 +86,9 @@ on the total inbound value admitted within a rolling ledger-time window. This
 is defense-in-depth — it limits the *blast radius* of a failure elsewhere,
 it does not replace quorum/epoch validation.
 
+For operator-facing parameter guidance and code-verified examples, see
+[INBOUND_WINDOW_TUNING.md](./INBOUND_WINDOW_TUNING.md).
+
 ### Design notes
 
 - **Fail-closed by default.** A freshly constructed `Bridge` has

--- a/stellar-lend/contracts/bridge/src/lib.rs
+++ b/stellar-lend/contracts/bridge/src/lib.rs
@@ -253,6 +253,9 @@ mod epoch_monotonicity_proptest;
 mod window_guard_test;
 
 #[cfg(test)]
+mod window_tuning_doc_test;
+
+#[cfg(test)]
 mod validatorset_proptest;
 
 #[cfg(test)]

--- a/stellar-lend/contracts/bridge/src/window_tuning_doc_test.rs
+++ b/stellar-lend/contracts/bridge/src/window_tuning_doc_test.rs
@@ -1,0 +1,91 @@
+#[cfg(test)]
+mod window_tuning_doc_tests {
+    use crate::{Bridge, ValidatorSet};
+
+    const HOUR: u64 = 3_600;
+    const DAY: u64 = 86_400;
+
+    /// Builds a bridge with a dummy validator set because inbound window
+    /// admission does not depend on quorum proof material.
+    fn make_bridge() -> Bridge {
+        Bridge::new(ValidatorSet {
+            validators: vec![vec![1, 2, 3]],
+        })
+    }
+
+    /// Builds a bridge with the supplied inbound cap configuration already
+    /// applied at `current_time`.
+    fn configured_bridge(max_per_window: i128, window_size: u64, current_time: u64) -> Bridge {
+        let mut bridge = make_bridge();
+        bridge
+            .set_inbound_cap(max_per_window, window_size, current_time)
+            .expect("documented tuning examples use valid window parameters");
+        bridge
+    }
+
+    /// Verifies the guide's fail-closed startup example: a fresh bridge rejects
+    /// inbound flow until operators explicitly configure a positive cap.
+    #[test]
+    fn fail_closed_default_matches_tuning_guide() {
+        let mut bridge = make_bridge();
+
+        assert_eq!(bridge.max_per_window, 0);
+        assert!(bridge.admit_inbound(0, 100).is_err());
+        assert!(bridge.admit_inbound(1, 100).is_err());
+        assert_eq!(bridge.window_inbound_total, 0);
+    }
+
+    /// Verifies the guide's conservative daily example, including admission at
+    /// the exact cap and full replenishment once the window expires.
+    #[test]
+    fn conservative_daily_cap_matches_tuning_guide() {
+        let mut bridge = configured_bridge(1_000, DAY, 0);
+
+        bridge.admit_inbound(600, 100).expect("under daily cap");
+        assert_eq!(bridge.window_inbound_total, 600);
+
+        bridge
+            .admit_inbound(400, 200)
+            .expect("lands exactly on daily cap");
+        assert_eq!(bridge.window_inbound_total, 1_000);
+
+        assert!(bridge.admit_inbound(1, 300).is_err());
+        assert_eq!(
+            bridge.window_inbound_total, 1_000,
+            "rejected over-cap amount must not consume capacity"
+        );
+
+        bridge
+            .admit_inbound(1_000, DAY)
+            .expect("expired daily window should replenish the full cap");
+        assert_eq!(bridge.window_start, DAY);
+        assert_eq!(bridge.window_inbound_total, 1_000);
+    }
+
+    /// Verifies the guide's permissive hourly example and the rejection of
+    /// extra value before the hour rolls over.
+    #[test]
+    fn permissive_hourly_cap_matches_tuning_guide() {
+        let mut bridge = configured_bridge(20_000, HOUR, 10);
+
+        bridge
+            .admit_inbound(7_500, 100)
+            .expect("first hourly slice");
+        bridge
+            .admit_inbound(7_500, 200)
+            .expect("second hourly slice");
+        bridge
+            .admit_inbound(5_000, 300)
+            .expect("fills hourly cap exactly");
+        assert_eq!(bridge.window_inbound_total, 20_000);
+
+        assert!(bridge.admit_inbound(1, 3_000).is_err());
+        assert_eq!(bridge.window_inbound_total, 20_000);
+
+        bridge
+            .admit_inbound(20_000, 3_610)
+            .expect("next hourly window should have the full cap available");
+        assert_eq!(bridge.window_start, 3_610);
+        assert_eq!(bridge.window_inbound_total, 20_000);
+    }
+}


### PR DESCRIPTION
Closes #1286

## Summary
- add `INBOUND_WINDOW_TUNING.md` with the rolling-window algorithm, fail-closed startup behavior, and operator parameter guidance
- document conservative, balanced, permissive, and emergency-pause configurations with throughput implications
- add code-verified doc-example tests for fail-closed startup, a conservative daily cap, and a permissive hourly cap
- cross-link the new guide from the bridge README and security notes

## Validation
- `rustfmt +1.91.1 --check src\window_tuning_doc_test.rs`
- `cd stellar-lend/contracts/bridge && cargo +1.91.1 test window_tuning -- --nocapture`
- `cd stellar-lend/contracts/bridge && cargo +1.91.1 test -- --nocapture`

Note: the bridge crate is standalone and named `bridge`; it is not a member of the parent `stellar-lend` workspace, so validation is run from `stellar-lend/contracts/bridge`.