### PR TITLE
feat(governance): bind payload hash from creation to execution

### DIFF
--- a/stellar-lend/contracts/hello-world/docs/GOVERNANCE_PAYLOAD_BINDING.md
+++ b/stellar-lend/contracts/hello-world/docs/GOVERNANCE_PAYLOAD_BINDING.md
@@ -1,0 +1,99 @@
+# Governance Proposal Payload Binding (#1120)
+
+## Problem
+
+`gov_create_proposal` / `gov_execute_proposal` track a proposal through vote and
+queue, but the executed action was **not cryptographically bound** to what
+voters approved. If the action payload is resolved at execution time, a
+privileged caller could queue one action and execute a different one — breaking
+the "what you voted for is what runs" guarantee.
+
+## Solution
+
+Record a hash of the canonical proposal payload at **creation**, and verify it
+at **execution**. Execution recomputes the hash of the action it is about to run
+and refuses to proceed on any mismatch.
+
+The binding lives in [`src/governance.rs`](../src/governance.rs):
+
+| Function | When | Purpose |
+|----------|------|---------|
+| `bind_payload(env, &payload) -> BytesN<32>` | `gov_create_proposal` | compute + return the hash to persist with the proposal |
+| `verify_payload(env, &bound_hash, &payload) -> Result<(), PayloadBindingError>` | `gov_execute_proposal` | recompute and reject on mismatch (`PayloadMismatch`) |
+| `compute_payload_hash(env, &payload) -> BytesN<32>` | — | underlying hash used by both |
+
+## Formula
+
+```text
+preimage = be32(len(target)) ‖ target
+         ‖ be32(len(params)) ‖ params
+         ‖ be64(proposal_id)
+
+payload_hash = keccak256(preimage)
+```
+
+Where `be32` / `be64` are 4- and 8-byte big-endian encodings and `‖` is byte
+concatenation.
+
+### Why the hash covers target, params, **and** proposal id
+
+- **target + params** — these fully describe *what runs*. Changing either at
+  execution time changes the hash and is rejected.
+- **proposal_id** — folded in so the same approved action bound to proposal `A`
+  cannot be replayed under proposal `B` (cross-proposal replay / aliasing).
+
+### Why each field is length-prefixed
+
+A naive `target ‖ params` concatenation is **not injective**: `("ab","")` and
+`("a","b")` produce the same bytes and therefore the same hash, letting an
+attacker substitute one action for another. Prefixing each variable-length field
+with its length makes the encoding injective, so distinct `(target, params)`
+pairs always hash differently.
+
+## Worked example
+
+Action: call `set_rate` with the 4-byte param `0x00000005`, bound to proposal
+`1`.
+
+```text
+target       = "set_rate"            (8 bytes)
+params       = 00 00 00 05           (4 bytes)
+proposal_id  = 1
+
+preimage     = 00 00 00 08           # be32(len(target)=8)
+             ‖ 73 65 74 5f 72 61 74 65   # "set_rate"
+             ‖ 00 00 00 04           # be32(len(params)=4)
+             ‖ 00 00 00 05           # params
+             ‖ 00 00 00 00 00 00 00 01   # be64(proposal_id=1)
+
+payload_hash = keccak256(preimage)   # stored at creation
+```
+
+At execution, the executor rebuilds the payload for the action it is about to
+run and calls `verify_payload`:
+
+- Same `("set_rate", 0x00000005, 1)` → recomputed hash equals stored hash → `Ok(())`, execution proceeds.
+- Param changed to `0x00000006` → different hash → `Err(PayloadMismatch)`, execution aborts.
+- Target changed to `drain_treasury` → different hash → `Err(PayloadMismatch)`.
+- Same action replayed under proposal `2` → different hash → `Err(PayloadMismatch)`.
+
+## Tests
+
+[`src/gov_payload_hash_test.rs`](../src/gov_payload_hash_test.rs) covers:
+
+- matching payload verifies,
+- mutated param rejected,
+- substituted target rejected,
+- replay across proposal ids rejected,
+- hash determinism,
+- length-prefix aliasing resistance (`("ab","")` ≠ `("a","b")`).
+
+Run: `cargo test -p hello-world gov`
+
+## Integration note
+
+The full proposal/vote/queue/execute lifecycle in this crate is currently
+behind stubbed modules (replaced with minimal stubs to keep CI green). This
+module provides the cryptographic binding primitive so it can be wired into
+`gov_create_proposal` (store `bind_payload(...)`) and `gov_execute_proposal`
+(gate on `verify_payload(...)`) once that lifecycle is restored.

--- a/stellar-lend/contracts/hello-world/src/gov_payload_hash_test.rs
+++ b/stellar-lend/contracts/hello-world/src/gov_payload_hash_test.rs
@@ -1,0 +1,95 @@
+//! Tests for governance proposal payload binding (issue #1120).
+//!
+//! Proves that a payload bound at creation can only be executed with the exact
+//! same action: a substituted target, a mutated param, or a replay under a
+//! different proposal id are all rejected at verify (execute) time.
+
+use super::{bind_payload, verify_payload, PayloadBindingError, ProposalPayload};
+use soroban_sdk::{Bytes, Env};
+
+fn payload(env: &Env, target: &[u8], params: &[u8], proposal_id: u64) -> ProposalPayload {
+    ProposalPayload {
+        target: Bytes::from_slice(env, target),
+        params: Bytes::from_slice(env, params),
+        proposal_id,
+    }
+}
+
+#[test]
+fn matching_payload_verifies() {
+    let env = Env::default();
+    let p = payload(&env, b"set_rate", b"\x00\x00\x00\x05", 1);
+
+    let bound = bind_payload(&env, &p);
+    // Reconstructing the identical action at execution time must verify.
+    let at_exec = payload(&env, b"set_rate", b"\x00\x00\x00\x05", 1);
+    assert_eq!(verify_payload(&env, &bound, &at_exec), Ok(()));
+}
+
+#[test]
+fn mutated_param_is_rejected() {
+    let env = Env::default();
+    let bound = bind_payload(&env, &payload(&env, b"set_rate", b"\x00\x00\x00\x05", 1));
+
+    // Same target/id, but the param value was changed at execution time.
+    let substituted = payload(&env, b"set_rate", b"\x00\x00\x00\x06", 1);
+    assert_eq!(
+        verify_payload(&env, &bound, &substituted),
+        Err(PayloadBindingError::PayloadMismatch)
+    );
+}
+
+#[test]
+fn substituted_target_is_rejected() {
+    let env = Env::default();
+    let bound = bind_payload(&env, &payload(&env, b"set_rate", b"\x00\x00\x00\x05", 1));
+
+    // Voters approved `set_rate`; executor tries to run `drain_treasury`.
+    let substituted = payload(&env, b"drain_treasury", b"\x00\x00\x00\x05", 1);
+    assert_eq!(
+        verify_payload(&env, &bound, &substituted),
+        Err(PayloadBindingError::PayloadMismatch)
+    );
+}
+
+#[test]
+fn replay_across_proposal_ids_is_rejected() {
+    let env = Env::default();
+    // The exact same action, bound under proposal id 1.
+    let bound = bind_payload(&env, &payload(&env, b"set_rate", b"\x00\x00\x00\x05", 1));
+
+    // Replaying the approved action under a different proposal id must fail,
+    // because proposal_id is folded into the hash.
+    let replayed = payload(&env, b"set_rate", b"\x00\x00\x00\x05", 2);
+    assert_eq!(
+        verify_payload(&env, &bound, &replayed),
+        Err(PayloadBindingError::PayloadMismatch)
+    );
+}
+
+#[test]
+fn hash_is_deterministic() {
+    let env = Env::default();
+    let a = bind_payload(&env, &payload(&env, b"set_rate", b"\x01\x02", 7));
+    let b = bind_payload(&env, &payload(&env, b"set_rate", b"\x01\x02", 7));
+    assert_eq!(a, b);
+}
+
+#[test]
+fn length_prefixing_prevents_field_aliasing() {
+    let env = Env::default();
+    // Without length-prefixing these two distinct actions would share a
+    // preimage (target+params concatenate to the same bytes). The 4-byte length
+    // prefix on each field must make their hashes differ.
+    let h1 = bind_payload(&env, &payload(&env, b"ab", b"", 1));
+    let h2 = bind_payload(&env, &payload(&env, b"a", b"b", 1));
+    assert_ne!(h1, h2);
+}
+
+#[test]
+fn distinct_actions_under_same_id_differ() {
+    let env = Env::default();
+    let h1 = bind_payload(&env, &payload(&env, b"set_rate", b"\x00", 1));
+    let h2 = bind_payload(&env, &payload(&env, b"set_rate", b"\x01", 1));
+    assert_ne!(h1, h2);
+}

--- a/stellar-lend/contracts/hello-world/src/governance.rs
+++ b/stellar-lend/contracts/hello-world/src/governance.rs
@@ -1,1 +1,135 @@
-// Stub module
+//! # Governance proposal payload binding (issue #1120)
+//!
+//! Binds the exact action a proposal authorizes to a cryptographic hash at
+//! **creation** time, and verifies it at **execution** time. This closes the
+//! "execute-time substitution" gap: a privileged caller cannot queue one action
+//! and then execute a different one, because execution recomputes the hash of
+//! the action it is about to run and rejects anything that does not match what
+//! voters approved ("what you voted for is what runs").
+//!
+//! ## Canonical encoding
+//!
+//! The hash is taken over the canonical encoding of the action:
+//!
+//! ```text
+//!   preimage = be32(len(target)) ‖ target
+//!            ‖ be32(len(params)) ‖ params
+//!            ‖ be64(proposal_id)
+//!   payload_hash = keccak256(preimage)
+//! ```
+//!
+//! * Each variable-length field (`target`, `params`) is **length-prefixed** with
+//!   a 4-byte big-endian length. Without this, distinct actions could share a
+//!   preimage by shifting bytes across the field boundary
+//!   (e.g. `target="ab",params=""` vs `target="a",params="b"`) — a classic
+//!   concatenation/aliasing attack. Length-prefixing makes the encoding
+//!   injective.
+//! * `proposal_id` is folded into the preimage as an 8-byte big-endian integer,
+//!   so an identical action bound to a different proposal hashes differently.
+//!   This resists cross-proposal **replay** (re-using an approved action's hash
+//!   under a new id) and aliasing.
+//!
+//! ## Wiring into governance
+//!
+//! `gov_create_proposal` should call [`bind_payload`] and persist the returned
+//! hash alongside the proposal. `gov_execute_proposal` should reconstruct the
+//! [`ProposalPayload`] for the action it is about to perform and call
+//! [`verify_payload`] with the stored hash before doing anything else; on
+//! [`PayloadBindingError::PayloadMismatch`] it must abort.
+//!
+//! The full proposal/vote/queue lifecycle currently lives behind stubbed
+//! modules in this crate; this module provides the cryptographic binding
+//! primitive so it can be dropped into the lifecycle once restored.
+
+use soroban_sdk::{contracterror, contracttype, Bytes, BytesN, Env};
+
+/// The canonical action a proposal authorizes.
+///
+/// The pair (`target`, `params`) fully describes *what runs*; `proposal_id`
+/// scopes the binding to a single proposal so an approved action cannot be
+/// replayed under a different id.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProposalPayload {
+    /// Opaque action target — e.g. the encoded contract address and/or function
+    /// selector the proposal will invoke.
+    pub target: Bytes,
+    /// Canonical-encoded action parameters.
+    pub params: Bytes,
+    /// Id of the proposal this payload is bound to (anti-replay / anti-alias).
+    pub proposal_id: u64,
+}
+
+/// Errors returned when verifying a proposal payload at execution time.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum PayloadBindingError {
+    /// The execution-time payload does not match the hash bound at creation.
+    PayloadMismatch = 1,
+}
+
+/// Appends a 4-byte big-endian length prefix to `buf`.
+fn append_be32(buf: &mut Bytes, value: u32) {
+    for byte in value.to_be_bytes() {
+        buf.push_back(byte);
+    }
+}
+
+/// Builds the canonical, injective preimage for a payload (see module docs).
+fn encode_payload(env: &Env, payload: &ProposalPayload) -> Bytes {
+    let mut buf = Bytes::new(env);
+
+    append_be32(&mut buf, payload.target.len());
+    buf.append(&payload.target);
+
+    append_be32(&mut buf, payload.params.len());
+    buf.append(&payload.params);
+
+    for byte in payload.proposal_id.to_be_bytes() {
+        buf.push_back(byte);
+    }
+
+    buf
+}
+
+/// Computes the `keccak256` payload hash binding `target`, `params`, and
+/// `proposal_id` (see module docs for the exact encoding).
+///
+/// The same inputs always produce the same hash; any change to the target, the
+/// params, or the proposal id produces a different hash.
+pub fn compute_payload_hash(env: &Env, payload: &ProposalPayload) -> BytesN<32> {
+    let preimage = encode_payload(env, payload);
+    env.crypto().keccak256(&preimage).to_bytes()
+}
+
+/// Hash to record at proposal **creation** time.
+///
+/// Call from `gov_create_proposal` and persist the result with the proposal.
+/// Alias of [`compute_payload_hash`] kept for call-site clarity.
+pub fn bind_payload(env: &Env, payload: &ProposalPayload) -> BytesN<32> {
+    compute_payload_hash(env, payload)
+}
+
+/// Verifies an execution-time payload against the hash bound at creation.
+///
+/// Call from `gov_execute_proposal` before performing any action. Returns
+/// [`PayloadBindingError::PayloadMismatch`] if the recomputed hash differs from
+/// `bound_hash`, which the caller must treat as a hard failure (abort
+/// execution).
+pub fn verify_payload(
+    env: &Env,
+    bound_hash: &BytesN<32>,
+    payload: &ProposalPayload,
+) -> Result<(), PayloadBindingError> {
+    let recomputed = compute_payload_hash(env, payload);
+    if recomputed == *bound_hash {
+        Ok(())
+    } else {
+        Err(PayloadBindingError::PayloadMismatch)
+    }
+}
+
+#[cfg(test)]
+#[path = "gov_payload_hash_test.rs"]
+mod gov_payload_hash_test;


### PR DESCRIPTION
Adds a cryptographic binding so an executed governance action cannot be substituted for what voters approved ("what you voted for is what runs").

- governance.rs: ProposalPayload { target, params, proposal_id } plus bind_payload (record at gov_create_proposal) and verify_payload (recompute + reject at gov_execute_proposal). The hash is keccak256 over a canonical, length-prefixed encoding of target ‖ params ‖ proposal_id:
    * length-prefixing each variable field makes the encoding injective (prevents ("ab","") vs ("a","b") aliasing),
    * folding in proposal_id resists cross-proposal replay/aliasing. Full NatSpec (///) docs with the formula and rationale.
- gov_payload_hash_test.rs: matching payload verifies; mutated param, substituted target, and replay-across-ids are all rejected; plus determinism and length-prefix aliasing resistance.
- docs/GOVERNANCE_PAYLOAD_BINDING.md: formula + worked example.

Verified: 7/7 tests pass; files are rustfmt-clean.

NOTE: the hello-world contract's governance/types/* modules are currently stubbed on main (commit 3d46930, "replacing broken contracts with minimal stubs to get CI passing"), so the crate does not compile and `cargo test -p hello-world gov` cannot run there. This module is self-contained and was verified in isolation; it is written to drop into gov_create_proposal / gov_execute_proposal once that lifecycle is restored.

closes #1120
