### PR TITLE
feat(bridge): domain-separate quorum-proof payloads

### DIFF
--- a/stellar-lend/contracts/bridge/SECURITY_NOTES.md
+++ b/stellar-lend/contracts/bridge/SECURITY_NOTES.md
@@ -142,3 +142,62 @@ it does not replace quorum/epoch validation.
 
 Every conditional branch in `admit_inbound`, `set_inbound_cap`, and
 `roll_window_if_expired` is exercised by at least one test above.
+
+## Quorum-Proof Domain Separation (#1146)
+
+### Threat
+
+`verify_quorum_proof` originally had validators sign over
+`bincode((new_set_bytes, epoch))`. That payload carries **no domain separator
+and no bridge/chain identifier**, so a validator signature collected for one
+bridge instance (or one purpose) could be replayed against another instance that
+happens to share the same validator set and epoch — a cross-context
+signature-reuse attack.
+
+### Fix
+
+The signed payload is now **domain-separated**. Signers and verifiers both build
+it through `Bridge::quorum_proof_payload`:
+
+```text
+payload = bincode((
+    QUORUM_PROOF_DOMAIN,   // constant purpose tag: b"stellarlend::bridge::quorum_proof::v1"
+    bridge_id,             // per-instance id (set via Bridge::new_with_id)
+    new_set_bytes,         // Vec<Vec<u8>> validator public keys
+    epoch,                 // u64
+))
+```
+
+- **`QUORUM_PROOF_DOMAIN`** (the *purpose* tag) ensures a signature produced for
+  validator-set rotation can never be reinterpreted as a signature for some
+  other context. The trailing `v1` lets the format be bumped to atomically
+  invalidate all prior signatures.
+- **`bridge_id`** (per-instance) ensures a proof gathered for instance A does not
+  verify on instance B, even with an identical validator set and epoch.
+
+`bincode` length-prefixes each field, so the encoding is unambiguous (no field
+can "borrow" bytes from its neighbour).
+
+### Worked example
+
+Two bridges share validator set `S` and are rotating to set `S'` at epoch `1`:
+
+| | bridge_id | payload prefix | result of A's signatures on B |
+|---|---|---|---|
+| Instance A | `bridge-A` | `(DOMAIN, "bridge-A", S', 1)` | — |
+| Instance B | `bridge-B` | `(DOMAIN, "bridge-B", S', 1)` | **rejected** (different preimage → different hash → signature invalid) |
+
+A signature over A's payload does not satisfy B's verification because the
+`bridge_id` bytes differ, so `pk.verify(&payload_B, sig_over_A)` fails and the
+proof never reaches quorum.
+
+### Invariants preserved
+
+The quorum-counting and duplicate-signer dedup logic is unchanged; only the
+bytes being signed/verified changed. Old, un-tagged signatures no longer verify.
+
+### Coverage
+
+`src/domain_separation_test.rs`: correct-domain accepted; wrong-bridge-id
+rejected; wrong-purpose tag rejected; legacy un-tagged signature rejected;
+instance-A proof rejected on instance B; domain constant pinned.

--- a/stellar-lend/contracts/bridge/src/domain_separation_test.rs
+++ b/stellar-lend/contracts/bridge/src/domain_separation_test.rs
@@ -1,0 +1,166 @@
+//! Domain-separation tests for bridge quorum proofs (issue #1146).
+//!
+//! These prove that a quorum signature is bound to BOTH:
+//!   1. the constant purpose tag [`QUORUM_PROOF_DOMAIN`], and
+//!   2. the per-instance `bridge_id`,
+//!
+//! so a signature gathered for one bridge instance/purpose cannot be replayed
+//! against another that shares the same validator set and epoch.
+
+#[cfg(test)]
+mod domain_separation_tests {
+    use crate::{Bridge, ValidatorSet, QUORUM_PROOF_DOMAIN};
+    use ed25519_dalek::{Keypair, PublicKey, Signature, Signer};
+
+    const BRIDGE_A: &[u8] = b"stellarlend-bridge-A";
+    const BRIDGE_B: &[u8] = b"stellarlend-bridge-B";
+
+    /// Deterministic keypair seeded from `index` (no `OsRng`), matching the
+    /// pattern used by the other bridge test modules.
+    fn det_keypair(index: u8) -> Keypair {
+        let mut seed = [0u8; 32];
+        seed[0] = index.wrapping_add(1);
+        for i in 1..32 {
+            seed[i] = index.wrapping_mul(7).wrapping_add(i as u8);
+        }
+        Keypair::from_bytes(&{
+            use ed25519_dalek::SecretKey;
+            let secret = SecretKey::from_bytes(&seed).expect("valid secret key");
+            let public: PublicKey = (&secret).into();
+            let mut combined = [0u8; 64];
+            combined[..32].copy_from_slice(&seed);
+            combined[32..].copy_from_slice(public.as_bytes());
+            combined
+        })
+        .expect("valid keypair from seed")
+    }
+
+    fn validator_set_from(kps: &[Keypair]) -> ValidatorSet {
+        ValidatorSet {
+            validators: kps.iter().map(|kp| kp.public.to_bytes().to_vec()).collect(),
+        }
+    }
+
+    /// Sign an arbitrary `payload` with each signer, producing the proof vec
+    /// `rotate_validators` expects.
+    fn sign_with(payload: &[u8], signers: &[&Keypair]) -> Vec<(PublicKey, Signature)> {
+        signers
+            .iter()
+            .map(|kp| (kp.public, kp.sign(payload)))
+            .collect()
+    }
+
+    /// Current set of 4 validators, a new set of 3, and the next epoch (1).
+    /// Threshold for a 4-validator set is `(4*2)/3 + 1 = 3`.
+    fn fixture() -> (Vec<Keypair>, ValidatorSet, ValidatorSet, u64) {
+        let current = (0..4).map(det_keypair).collect::<Vec<_>>();
+        let current_set = validator_set_from(&current);
+        let new = (10..13).map(det_keypair).collect::<Vec<_>>();
+        let new_set = validator_set_from(&new);
+        (current, current_set, new_set, 1)
+    }
+
+    #[test]
+    fn correct_domain_is_accepted() {
+        let (current, current_set, new_set, epoch) = fixture();
+        let mut bridge = Bridge::new_with_id(current_set, BRIDGE_A.to_vec());
+
+        // Sign the canonical, domain-separated payload for THIS bridge instance.
+        let payload = Bridge::quorum_proof_payload(&bridge.bridge_id, &new_set, epoch).unwrap();
+        let signers: Vec<&Keypair> = current.iter().take(3).collect();
+        let proofs = sign_with(&payload, &signers);
+
+        bridge
+            .rotate_validators(new_set, epoch, proofs)
+            .expect("a correctly domain-separated quorum proof must rotate");
+        assert_eq!(bridge.epoch, 1);
+    }
+
+    #[test]
+    fn wrong_bridge_id_is_rejected() {
+        let (current, current_set, new_set, epoch) = fixture();
+        let mut bridge = Bridge::new_with_id(current_set, BRIDGE_A.to_vec());
+
+        // Validators sign a payload bound to a DIFFERENT bridge instance (B).
+        let foreign = Bridge::quorum_proof_payload(BRIDGE_B, &new_set, epoch).unwrap();
+        let signers: Vec<&Keypair> = current.iter().take(3).collect();
+        let proofs = sign_with(&foreign, &signers);
+
+        assert!(
+            bridge.rotate_validators(new_set, epoch, proofs).is_err(),
+            "a proof bound to another bridge id must not verify"
+        );
+        assert_eq!(bridge.epoch, 0, "epoch must be unchanged on rejection");
+    }
+
+    #[test]
+    fn wrong_purpose_tag_is_rejected() {
+        let (current, current_set, new_set, epoch) = fixture();
+        let mut bridge = Bridge::new_with_id(current_set, BRIDGE_A.to_vec());
+
+        // Same bridge id, but signed under a different (non-quorum) purpose tag.
+        let other_purpose = b"stellarlend::bridge::some_other_purpose::v1".as_slice();
+        let payload = bincode::serialize(&(
+            other_purpose,
+            &bridge.bridge_id[..],
+            new_set.to_bytes_vec(),
+            epoch,
+        ))
+        .unwrap();
+        let signers: Vec<&Keypair> = current.iter().take(3).collect();
+        let proofs = sign_with(&payload, &signers);
+
+        assert!(
+            bridge.rotate_validators(new_set, epoch, proofs).is_err(),
+            "a proof signed under a different purpose tag must not verify"
+        );
+        assert_eq!(bridge.epoch, 0);
+    }
+
+    #[test]
+    fn legacy_untagged_signature_is_rejected() {
+        let (current, current_set, new_set, epoch) = fixture();
+        let mut bridge = Bridge::new_with_id(current_set, BRIDGE_A.to_vec());
+
+        // The OLD format: bincode((new_set_bytes, epoch)) with no domain prefix.
+        // Existing signatures over this payload must no longer verify.
+        let legacy = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let signers: Vec<&Keypair> = current.iter().take(3).collect();
+        let proofs = sign_with(&legacy, &signers);
+
+        assert!(
+            bridge.rotate_validators(new_set, epoch, proofs).is_err(),
+            "a legacy un-tagged signature must not verify after domain separation"
+        );
+        assert_eq!(bridge.epoch, 0);
+    }
+
+    #[test]
+    fn signature_for_one_instance_does_not_verify_on_another() {
+        let (current, current_set, new_set, epoch) = fixture();
+
+        // Collect a valid proof for instance A.
+        let payload_a = Bridge::quorum_proof_payload(BRIDGE_A, &new_set, epoch).unwrap();
+        let signers: Vec<&Keypair> = current.iter().take(3).collect();
+        let proofs = sign_with(&payload_a, &signers);
+
+        // Replay the very same proof against instance B (same validators/epoch,
+        // different bridge id). It must be rejected.
+        let mut bridge_b = Bridge::new_with_id(current_set, BRIDGE_B.to_vec());
+        assert!(
+            bridge_b.rotate_validators(new_set, epoch, proofs).is_err(),
+            "instance A's proof must not rotate instance B"
+        );
+        assert_eq!(bridge_b.epoch, 0);
+    }
+
+    #[test]
+    fn domain_constant_is_versioned() {
+        // The purpose tag is a stable, versioned constant; document its value via
+        // a test so an accidental change is caught.
+        assert_eq!(
+            QUORUM_PROOF_DOMAIN,
+            b"stellarlend::bridge::quorum_proof::v1"
+        );
+    }
+}

--- a/stellar-lend/contracts/bridge/src/epoch_monotonicity_proptest.rs
+++ b/stellar-lend/contracts/bridge/src/epoch_monotonicity_proptest.rs
@@ -82,7 +82,7 @@ mod tests {
         epoch: u64,
         signers: &[&Keypair],
     ) -> Vec<(ed25519_dalek::PublicKey, Signature)> {
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch))
+        let payload = Bridge::quorum_proof_payload(&[], new_set, epoch)
             .expect("serialization must not fail");
         signers
             .iter()

--- a/stellar-lend/contracts/bridge/src/lib.rs
+++ b/stellar-lend/contracts/bridge/src/lib.rs
@@ -82,10 +82,28 @@ pub struct Bridge {
     pub window_start: u64,
     /// Cumulative inbound value admitted so far within `[window_start, window_start + window_size)`.
     pub window_inbound_total: i128,
+    /// Per-instance domain identifier mixed into every quorum-proof payload
+    /// (issue #1146). Two bridge instances that share the same validator set and
+    /// epoch but have different `bridge_id`s produce different signing payloads,
+    /// so a signature collected for one instance cannot be replayed against the
+    /// other. Defaults to empty for [`Bridge::new`]; set a unique value per
+    /// deployment via [`Bridge::new_with_id`].
+    pub bridge_id: Vec<u8>,
 }
 
 /// Default rolling window length: one day, in seconds.
 pub const DEFAULT_INBOUND_WINDOW_SECS: u64 = 86_400;
+
+/// Constant domain-separation tag (the "purpose" tag) prefixed onto every
+/// quorum-proof signing payload (issue #1146).
+///
+/// Including a fixed, purpose-specific tag ensures a validator signature
+/// produced for **validator-set rotation** can never be reinterpreted as a
+/// signature over some other message that happened to share the same byte
+/// layout — a cross-context / cross-purpose signature-reuse attack. Bumping the
+/// trailing version (`v1`) cleanly invalidates every previously collected
+/// signature if the payload format ever changes.
+pub const QUORUM_PROOF_DOMAIN: &[u8] = b"stellarlend::bridge::quorum_proof::v1";
 
 impl Bridge {
     /// Construct a new bridge. Inbound value transfer is **fail-closed by
@@ -93,6 +111,16 @@ impl Bridge {
     /// rejects everything until [`Bridge::set_inbound_cap`] is called with a
     /// non-zero cap.
     pub fn new(initial: ValidatorSet) -> Self {
+        Self::new_with_id(initial, Vec::new())
+    }
+
+    /// Construct a new bridge with an explicit per-instance `bridge_id` used for
+    /// quorum-proof domain separation (issue #1146).
+    ///
+    /// Use a value that is unique per bridge deployment (e.g. an encoded
+    /// chain id + bridge contract address). Quorum signatures are bound to this
+    /// id, so a proof gathered for one instance will not verify against another.
+    pub fn new_with_id(initial: ValidatorSet, bridge_id: Vec<u8>) -> Self {
         Bridge {
             epoch: 0,
             validators: initial,
@@ -100,7 +128,32 @@ impl Bridge {
             window_size: DEFAULT_INBOUND_WINDOW_SECS,
             window_start: 0,
             window_inbound_total: 0,
+            bridge_id,
         }
+    }
+
+    /// Builds the canonical, domain-separated payload that quorum proofs sign
+    /// over (issue #1146):
+    ///
+    /// ```text
+    ///   payload = bincode((QUORUM_PROOF_DOMAIN, bridge_id, new_set_bytes, epoch))
+    /// ```
+    ///
+    /// Prefixing the constant [`QUORUM_PROOF_DOMAIN`] tag and the per-instance
+    /// `bridge_id` makes a signature valid **only** for this bridge instance and
+    /// this purpose. Signers and verifiers must both go through this function so
+    /// the bytes always match.
+    pub fn quorum_proof_payload(
+        bridge_id: &[u8],
+        new_set: &ValidatorSet,
+        epoch: u64,
+    ) -> Result<Vec<u8>> {
+        Ok(bincode::serialize(&(
+            QUORUM_PROOF_DOMAIN,
+            bridge_id,
+            new_set.to_bytes_vec(),
+            epoch,
+        ))?)
     }
 
     /// Verify a quorum proof from the current validator set over the (new_set, epoch) payload
@@ -109,8 +162,10 @@ impl Bridge {
             return Err(anyhow!("empty proofs"));
         }
 
-        // payload to be signed: bincode(new_set_bytes_vec, epoch)
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch))?;
+        // Domain-separated payload: bincode(domain_tag, bridge_id, new_set_bytes, epoch).
+        // The constant tag + per-instance bridge_id bind every signature to this
+        // exact bridge instance and purpose, preventing cross-context reuse (#1146).
+        let payload = Self::quorum_proof_payload(&self.bridge_id, new_set, epoch)?;
 
         let mut unique_signers: HashSet<Vec<u8>> = HashSet::new();
         for (pk, sig) in proofs.iter() {
@@ -244,6 +299,9 @@ impl Bridge {
 mod rotation_test;
 
 #[cfg(test)]
+mod domain_separation_test;
+
+#[cfg(test)]
 mod inbound_cap_test;
 
 #[cfg(test)]
@@ -281,7 +339,7 @@ mod tests {
 
         // proofs: have >2/3 of A sign the (new_set, epoch=1) payload
         let epoch = 1u64;
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let payload = Bridge::quorum_proof_payload(&bridge.bridge_id, &new_set, epoch).unwrap();
 
         // need threshold of A: (4*2)/3+1 = 3
         let mut proofs = vec![];
@@ -313,7 +371,7 @@ mod tests {
         let new_set = ValidatorSet { validators: b_pks.iter().map(|p| p.to_bytes().to_vec()).collect() };
 
         let epoch = 1u64;
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let payload = Bridge::quorum_proof_payload(&bridge.bridge_id, &new_set, epoch).unwrap();
 
         // need threshold of A: (5*2)/3+1 = 4. Provide only 3 signatures => fail
         let mut proofs = vec![];
@@ -338,7 +396,7 @@ mod tests {
 
         // wrong epoch (must be 1)
         let epoch = 2u64;
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let payload = Bridge::quorum_proof_payload(&bridge.bridge_id, &new_set, epoch).unwrap();
 
         let mut proofs = vec![];
         for i in 0..2 {

--- a/stellar-lend/contracts/bridge/src/rotation_test.rs
+++ b/stellar-lend/contracts/bridge/src/rotation_test.rs
@@ -64,7 +64,7 @@ mod rotation_tests {
         epoch: u64,
         signers: &[&Keypair],
     ) -> Vec<(ed25519_dalek::PublicKey, Signature)> {
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch))
+        let payload = Bridge::quorum_proof_payload(&[], new_set, epoch)
             .expect("serialization must not fail");
         signers
             .iter()
@@ -249,7 +249,7 @@ mod rotation_tests {
         let new_set = validator_set_from(&new_kps);
 
         let epoch = 1u64;
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let payload = Bridge::quorum_proof_payload(&[], &new_set, epoch).unwrap();
 
         // kps[0] signs twice, kps[1] signs once → 3 entries but only 2 unique
         let mut proofs = Vec::new();
@@ -279,7 +279,7 @@ mod rotation_tests {
         let new_set = validator_set_from(&new_kps);
 
         let epoch = 1u64;
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let payload = Bridge::quorum_proof_payload(&[], &new_set, epoch).unwrap();
 
         let mut proofs = Vec::new();
         // kps[0] appears twice


### PR DESCRIPTION
verify_quorum_proof signed over bincode((new_set_bytes, epoch)) — no domain separator and no bridge/chain id — so a validator signature collected for one bridge instance or purpose could be replayed against another instance sharing the same validator set and epoch (cross-context signature reuse).

- lib.rs: add a constant purpose tag QUORUM_PROOF_DOMAIN (b"stellarlend::bridge::quorum_proof::v1") and a per-instance `bridge_id` field (set via new_with_id; defaults empty for new). New public helper `Bridge::quorum_proof_payload(bridge_id, new_set, epoch)` builds the canonical bincode((DOMAIN, bridge_id, new_set_bytes, epoch)) payload that both signers and verify_quorum_proof use. Quorum-counting and dedup logic unchanged; old un-tagged signatures no longer verify. NatSpec /// docs throughout.
- existing tests (rotation_test, epoch_monotonicity_proptest, inline) updated to sign through the new helper.
- domain_separation_test.rs: correct-domain accepted; wrong-bridge-id rejected; wrong-purpose tag rejected; legacy un-tagged signature rejected; instance-A proof rejected on instance B; domain constant pinned.
- SECURITY_NOTES.md: domain-separation rationale + formula + worked example.

Verified: `cargo test` in contracts/bridge → 54 passed (48 existing + 6 new); new test file is rustfmt-clean; clippy-clean on changed code.


closes #1146 