### PR TITLE
Add a vesting schedule pause-aware time-offset so paused intervals do not count toward vested_at in vesting/src/lib.rs

### DIFF
--- a/stellar-lend/contracts/vesting/Cargo.toml
+++ b/stellar-lend/contracts/vesting/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stellarlend-vesting"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/stellar-lend/contracts/vesting/PAUSE_OFFSET.md
+++ b/stellar-lend/contracts/vesting/PAUSE_OFFSET.md
@@ -1,0 +1,75 @@
+# Pause-Aware Vesting Time Offset
+
+## Overview
+
+The vesting contract tracks cumulative paused duration and subtracts it from the
+current ledger timestamp before feeding it into `Grant::vested_at`. This means a
+pause truly freezes vesting accrual — it does not merely block claiming.
+
+## State variables
+
+| Key                | Type  | Purpose                                                         |
+|--------------------|-------|-----------------------------------------------------------------|
+| `Paused`           | bool  | Whether the contract is currently paused                        |
+| `PausedAt`         | u64   | Ledger timestamp at which the current pause began              |
+| `TotalPausedSecs`  | u64   | Cumulative seconds the contract has spent in a paused state    |
+
+## Timeline diagram
+
+```
+Wall clock ────────────────────────────────────────────────────────────────►
+           0    100   200   300   400   500   600   700   800   900  1000
+           │     │     │     │     │     │     │     │     │     │     │
+Ledger:    ├────▶│pause│◄────200s────►│resume│─────────────────────────────
+                             (paused interval = 200 s)
+
+Effective: ├──────────────────────────────────────────────────────────────►
+           0    100   200   200   200   300   400   500   600   700   800
+           (clock frozen during pause; resumes from where it left off)
+```
+
+After resuming, `effective_now = ledger_now - total_paused_secs`, so a grant
+with a 1 000 s linear schedule will have vested `800/1000 × total_amount` at
+ledger second 1 000 (i.e. 800 effective seconds, not 1 000).
+
+## Worked example: pause then resume, then claim
+
+```
+Grant:  total_amount = 10_000 tokens
+        start_ts     = 0
+        cliff_secs   = 0
+        duration     = 1_000 s
+
+Timeline:
+  t =   0  — initialize & create_grant
+  t = 300  — pause()          (PausedAt = 300)
+  t = 600  — resume()         (interval = 300 s → TotalPausedSecs = 300)
+  t = 800  — claim()
+
+At t = 800:
+  effective_now = 800 − 300 = 500 s
+  vested        = 10_000 × 500 / 1_000 = 5_000 tokens
+
+Without the offset, vested would have been 10_000 × 800 / 1_000 = 8_000 tokens —
+the 300-second pause interval would have accrued 3_000 extra tokens incorrectly.
+```
+
+## Multiple pause/resume cycles
+
+Each `resume()` call adds `now - paused_at` to `TotalPausedSecs`:
+
+```
+pause at t=100, resume at t=200  → total_paused = 100
+pause at t=400, resume at t=500  → total_paused = 200
+claim at t=600  → effective_now = 600 − 200 = 400
+```
+
+## Edge cases
+
+| Scenario                        | Behaviour                                              |
+|---------------------------------|--------------------------------------------------------|
+| Zero-length pause (pause+resume at same timestamp) | Adds 0 s — no effect   |
+| Pause spanning the cliff        | Cliff is evaluated against `effective_now`, not wall clock |
+| `claim` while paused            | Returns `VestingError::ContractPaused`                 |
+| `revoke` while paused           | Returns `VestingError::ContractPaused`                 |
+| Arithmetic overflow in accumulation | `saturating_add` / `saturating_sub` prevent panics |

--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -1,0 +1,373 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Vec, IntoVal, Val};
+
+/// Errors for the vesting contract
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum VestingError {
+    /// Caller is not the admin
+    Unauthorized = 1,
+    /// Contract is currently paused
+    ContractPaused = 2,
+    /// Grant not found for grantee
+    GrantNotFound = 3,
+    /// Grant is fully vested or already claimed
+    NothingToClaim = 4,
+    /// Grant has already been revoked
+    AlreadyRevoked = 5,
+    /// Arithmetic overflow
+    Overflow = 6,
+    /// Contract is not paused (for resume call)
+    NotPaused = 7,
+    /// Invalid grant parameters
+    InvalidGrant = 8,
+}
+
+/// Storage keys for the vesting contract
+#[contracttype]
+#[derive(Clone)]
+pub enum VestingKey {
+    /// Admin address
+    Admin,
+    /// Grant for a specific grantee
+    Grant(Address),
+    /// Whether the contract is paused
+    Paused,
+    /// Timestamp when the contract was last paused (0 if not paused)
+    PausedAt,
+    /// Total accumulated paused seconds so far
+    TotalPausedSecs,
+}
+
+/// A vesting grant for a single grantee
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Grant {
+    /// Address of the beneficiary
+    pub grantee: Address,
+    /// Total token amount to vest over the full schedule
+    pub total_amount: i128,
+    /// Amount already claimed
+    pub claimed_amount: i128,
+    /// Unix timestamp at which vesting starts
+    pub start_ts: u64,
+    /// Duration in seconds before any tokens vest (cliff)
+    pub cliff_secs: u64,
+    /// Total vesting duration in seconds (from start_ts)
+    pub duration_secs: u64,
+    /// Whether this grant has been revoked
+    pub revoked: bool,
+}
+
+impl Grant {
+    /// Compute how many tokens have vested by `effective_now`.
+    ///
+    /// The caller must pass an already pause-adjusted effective timestamp so that
+    /// paused intervals are not counted toward vesting accrual.
+    ///
+    /// # Arguments
+    /// * `effective_now` - Wall-clock `now` minus total accumulated paused seconds
+    ///
+    /// # Returns
+    /// Number of tokens vested (capped at `total_amount`)
+    pub fn vested_at(&self, effective_now: u64) -> i128 {
+        if self.revoked {
+            return self.claimed_amount;
+        }
+        if effective_now < self.start_ts.saturating_add(self.cliff_secs) {
+            return 0;
+        }
+        let elapsed = effective_now.saturating_sub(self.start_ts);
+        if elapsed >= self.duration_secs {
+            return self.total_amount;
+        }
+        // Linear vesting: total_amount * elapsed / duration_secs
+        (self.total_amount as u64)
+            .checked_mul(elapsed)
+            .map(|v| (v / self.duration_secs) as i128)
+            .unwrap_or(self.total_amount)
+    }
+
+    /// How many tokens are claimable right now (vested minus already claimed).
+    ///
+    /// # Arguments
+    /// * `effective_now` - Pause-adjusted current timestamp
+    pub fn claimable_at(&self, effective_now: u64) -> i128 {
+        self.vested_at(effective_now)
+            .saturating_sub(self.claimed_amount)
+    }
+}
+
+/// Vesting contract
+#[contract]
+pub struct VestingContract;
+
+#[contractimpl]
+impl VestingContract {
+    /// Initialize the vesting contract with an admin address.
+    ///
+    /// Must be called before any other operation.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin address that controls pause/resume and grant management
+    pub fn initialize(env: Env, admin: Address) {
+        env.storage().persistent().set(&VestingKey::Admin, &admin);
+        env.storage().persistent().set(&VestingKey::Paused, &false);
+        env.storage().persistent().set(&VestingKey::PausedAt, &0u64);
+        env.storage().persistent().set(&VestingKey::TotalPausedSecs, &0u64);
+    }
+
+    /// Create a new vesting grant for `grantee`.
+    ///
+    /// Admin only. Replaces any existing (non-revoked) grant.
+    ///
+    /// # Arguments
+    /// * `caller`       - Must be the admin
+    /// * `grantee`      - Beneficiary address
+    /// * `total_amount` - Total tokens to vest
+    /// * `start_ts`     - Unix timestamp at which vesting begins
+    /// * `cliff_secs`   - Seconds from `start_ts` before any tokens vest
+    /// * `duration_secs`- Total vesting duration in seconds
+    pub fn create_grant(
+        env: Env,
+        caller: Address,
+        grantee: Address,
+        total_amount: i128,
+        start_ts: u64,
+        cliff_secs: u64,
+        duration_secs: u64,
+    ) -> Result<(), VestingError> {
+        Self::require_admin(&env, &caller)?;
+        if total_amount <= 0 || duration_secs == 0 {
+            return Err(VestingError::InvalidGrant);
+        }
+        let grant = Grant {
+            grantee: grantee.clone(),
+            total_amount,
+            claimed_amount: 0,
+            start_ts,
+            cliff_secs,
+            duration_secs,
+            revoked: false,
+        };
+        env.storage()
+            .persistent()
+            .set(&VestingKey::Grant(grantee.clone()), &grant);
+        Self::emit_event(&env, "grant_created", &grantee);
+        Ok(())
+    }
+
+    /// Pause the vesting contract.
+    ///
+    /// Records `paused_at = env.ledger().timestamp()`. While paused, `claim` and
+    /// `revoke` are rejected. The elapsed time between pause and resume will be
+    /// added to `total_paused_secs` so it does not count toward vesting accrual.
+    ///
+    /// # Arguments
+    /// * `caller` - Must be the admin
+    pub fn pause(env: Env, caller: Address) -> Result<(), VestingError> {
+        Self::require_admin(&env, &caller)?;
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::Paused)
+            .unwrap_or(false);
+        if paused {
+            return Ok(()); // idempotent
+        }
+        let now = env.ledger().timestamp();
+        env.storage().persistent().set(&VestingKey::Paused, &true);
+        env.storage().persistent().set(&VestingKey::PausedAt, &now);
+        Self::emit_event(&env, "paused", &caller);
+        Ok(())
+    }
+
+    /// Resume a paused vesting contract.
+    ///
+    /// Accumulates `total_paused_secs += now - paused_at` so that future calls to
+    /// `vested_at` skip over the frozen interval. Subsequent `claim` / `revoke`
+    /// calls will use `effective_now = now - total_paused_secs`.
+    ///
+    /// # Arguments
+    /// * `caller` - Must be the admin
+    pub fn resume(env: Env, caller: Address) -> Result<(), VestingError> {
+        Self::require_admin(&env, &caller)?;
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::Paused)
+            .unwrap_or(false);
+        if !paused {
+            return Err(VestingError::NotPaused);
+        }
+        let now = env.ledger().timestamp();
+        let paused_at: u64 = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::PausedAt)
+            .unwrap_or(now);
+        let total_paused: u64 = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::TotalPausedSecs)
+            .unwrap_or(0u64);
+
+        // Accumulate paused interval with checked arithmetic; saturate on overflow.
+        let interval = now.saturating_sub(paused_at);
+        let new_total = total_paused.checked_add(interval).unwrap_or(u64::MAX);
+
+        env.storage()
+            .persistent()
+            .set(&VestingKey::TotalPausedSecs, &new_total);
+        env.storage().persistent().set(&VestingKey::Paused, &false);
+        env.storage().persistent().set(&VestingKey::PausedAt, &0u64);
+        Self::emit_event(&env, "resumed", &caller);
+        Ok(())
+    }
+
+    /// Claim vested tokens for the calling grantee.
+    ///
+    /// Rejected while the contract is paused. Uses pause-adjusted `effective_now`
+    /// so that paused intervals do not inflate the claimable amount.
+    ///
+    /// # Arguments
+    /// * `grantee` - The beneficiary claiming tokens
+    ///
+    /// # Returns
+    /// The number of tokens claimed in this transaction
+    pub fn claim(env: Env, grantee: Address) -> Result<i128, VestingError> {
+        Self::require_not_paused(&env)?;
+        let mut grant: Grant = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::Grant(grantee.clone()))
+            .ok_or(VestingError::GrantNotFound)?;
+        if grant.revoked {
+            return Err(VestingError::AlreadyRevoked);
+        }
+        let effective_now = Self::effective_now(&env);
+        let claimable = grant.claimable_at(effective_now);
+        if claimable <= 0 {
+            return Err(VestingError::NothingToClaim);
+        }
+        grant.claimed_amount = grant
+            .claimed_amount
+            .checked_add(claimable)
+            .ok_or(VestingError::Overflow)?;
+        env.storage()
+            .persistent()
+            .set(&VestingKey::Grant(grantee.clone()), &grant);
+        Self::emit_event(&env, "claimed", &grantee);
+        Ok(claimable)
+    }
+
+    /// Revoke a grant.
+    ///
+    /// Admin only. Rejected while the contract is paused. Computes the vested
+    /// amount using pause-adjusted `effective_now` so the grantee only keeps what
+    /// truly accrued outside paused intervals; the remainder returns to the treasury.
+    ///
+    /// # Arguments
+    /// * `caller`  - Must be the admin
+    /// * `grantee` - The beneficiary whose grant is being revoked
+    ///
+    /// # Returns
+    /// `(vested_amount, clawback_amount)` — tokens kept by grantee and returned to treasury
+    pub fn revoke(env: Env, caller: Address, grantee: Address) -> Result<(i128, i128), VestingError> {
+        Self::require_admin(&env, &caller)?;
+        Self::require_not_paused(&env)?;
+        let mut grant: Grant = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::Grant(grantee.clone()))
+            .ok_or(VestingError::GrantNotFound)?;
+        if grant.revoked {
+            return Err(VestingError::AlreadyRevoked);
+        }
+        let effective_now = Self::effective_now(&env);
+        let vested = grant.vested_at(effective_now);
+        let clawback = grant.total_amount.saturating_sub(vested);
+        grant.revoked = true;
+        // Lock claimed_amount to vested so future claimable() == 0
+        grant.claimed_amount = vested;
+        env.storage()
+            .persistent()
+            .set(&VestingKey::Grant(grantee.clone()), &grant);
+        Self::emit_event(&env, "revoked", &grantee);
+        Ok((vested, clawback))
+    }
+
+    /// Return grant details for a grantee.
+    pub fn get_grant(env: Env, grantee: Address) -> Option<Grant> {
+        env.storage()
+            .persistent()
+            .get(&VestingKey::Grant(grantee))
+    }
+
+    /// Return the total accumulated paused seconds.
+    pub fn total_paused_secs(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&VestingKey::TotalPausedSecs)
+            .unwrap_or(0u64)
+    }
+
+    /// Return whether the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&VestingKey::Paused)
+            .unwrap_or(false)
+    }
+
+    // ─── internal helpers ──────────────────────────────────────────────────────
+
+    /// Compute `effective_now = ledger_now - total_paused_secs`.
+    ///
+    /// This is subtracted uniformly for all grants so that paused intervals do
+    /// not count toward vesting accrual.
+    fn effective_now(env: &Env) -> u64 {
+        let now = env.ledger().timestamp();
+        let total_paused: u64 = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::TotalPausedSecs)
+            .unwrap_or(0u64);
+        now.saturating_sub(total_paused)
+    }
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), VestingError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::Admin)
+            .ok_or(VestingError::Unauthorized)?;
+        if admin != *caller {
+            return Err(VestingError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn require_not_paused(env: &Env) -> Result<(), VestingError> {
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::Paused)
+            .unwrap_or(false);
+        if paused {
+            return Err(VestingError::ContractPaused);
+        }
+        Ok(())
+    }
+
+    fn emit_event(env: &Env, event: &str, actor: &Address) {
+        let topics = (soroban_sdk::Symbol::new(env, event), actor.clone());
+        let mut data: Vec<Val> = Vec::new(env);
+        data.push_back(actor.clone().into_val(env));
+        env.events().publish(topics, data);
+    }
+}
+
+#[cfg(test)]
+mod pause_offset_test;

--- a/stellar-lend/contracts/vesting/src/pause_offset_test.rs
+++ b/stellar-lend/contracts/vesting/src/pause_offset_test.rs
@@ -1,0 +1,226 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{VestingContract, VestingContractClient, VestingError};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(VestingContract, ());
+    VestingContractClient::new(&env, &id).initialize(&admin);
+    (env, admin, id)
+}
+
+fn advance(env: &Env, secs: u64) {
+    env.ledger().with_mut(|li| li.timestamp += secs);
+}
+
+// ── basic pause / resume accumulation ────────────────────────────────────────
+
+#[test]
+fn test_pause_accumulates_total_paused_secs() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+
+    advance(&env, 1_000);
+    client.pause(&admin);
+    advance(&env, 500); // 500 s paused
+    client.resume(&admin);
+
+    assert_eq!(client.total_paused_secs(), 500);
+}
+
+#[test]
+fn test_multiple_pause_resume_cycles_accumulate() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+
+    advance(&env, 100);
+    client.pause(&admin);
+    advance(&env, 200);
+    client.resume(&admin); // +200
+
+    advance(&env, 100);
+    client.pause(&admin);
+    advance(&env, 300);
+    client.resume(&admin); // +300
+
+    assert_eq!(client.total_paused_secs(), 500);
+}
+
+#[test]
+fn test_zero_length_pause_adds_nothing() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+
+    client.pause(&admin);
+    // do NOT advance time
+    client.resume(&admin);
+
+    assert_eq!(client.total_paused_secs(), 0);
+}
+
+// ── claim rejected mid-pause ──────────────────────────────────────────────────
+
+#[test]
+fn test_claim_rejected_while_paused() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+    let grantee = Address::generate(&env);
+
+    // Grant: 1_000 tokens, no cliff, 1_000 s duration, starts now
+    let start = env.ledger().timestamp();
+    client.create_grant(&admin, &grantee, &1_000, &start, &0, &1_000);
+
+    advance(&env, 500);
+    client.pause(&admin);
+
+    let result = client.try_claim(&grantee);
+    assert_eq!(result, Err(Ok(VestingError::ContractPaused)));
+}
+
+// ── paused interval does not accrue ──────────────────────────────────────────
+
+#[test]
+fn test_paused_interval_does_not_count_toward_vesting() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+    let grantee = Address::generate(&env);
+
+    // 1_000 tokens, no cliff, 1_000 s duration
+    let start = env.ledger().timestamp();
+    client.create_grant(&admin, &grantee, &1_000, &start, &0, &1_000);
+
+    // Advance 200 s, then pause for 300 s, then resume and advance another 200 s.
+    // effective_now = (200 + 300 + 200) - 300 = 400 s  → 400 tokens vested.
+    advance(&env, 200);
+    client.pause(&admin);
+    advance(&env, 300);
+    client.resume(&admin);
+    advance(&env, 200);
+
+    let claimed = client.claim(&grantee);
+    assert_eq!(claimed, 400);
+}
+
+#[test]
+fn test_without_pause_normal_vesting() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+    let grantee = Address::generate(&env);
+
+    let start = env.ledger().timestamp();
+    client.create_grant(&admin, &grantee, &1_000, &start, &0, &1_000);
+
+    advance(&env, 400);
+
+    let claimed = client.claim(&grantee);
+    assert_eq!(claimed, 400);
+}
+
+// ── pause spanning the cliff ──────────────────────────────────────────────────
+
+#[test]
+fn test_pause_spanning_cliff() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+    let grantee = Address::generate(&env);
+
+    // cliff_secs = 100, duration = 1_000
+    let start = env.ledger().timestamp();
+    client.create_grant(&admin, &grantee, &1_000, &start, &100, &1_000);
+
+    // Pause before cliff, pause for 200 s, resume, then advance 100 s past cliff.
+    advance(&env, 50); // 50 s elapsed, before cliff
+    client.pause(&admin);
+    advance(&env, 200); // 200 s paused
+    client.resume(&admin);
+    // effective_now = 50 + 200 + 100 - 200 = 150, cliff at 100 → claimable
+    advance(&env, 100);
+
+    // effective elapsed from start = 150 s, cliff = 100 s
+    // vested = 1_000 * 150 / 1_000 = 150
+    let claimed = client.claim(&grantee);
+    assert_eq!(claimed, 150);
+}
+
+// ── revoke uses pause-adjusted vested amount ─────────────────────────────────
+
+#[test]
+fn test_revoke_uses_effective_now() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+    let grantee = Address::generate(&env);
+
+    let start = env.ledger().timestamp();
+    client.create_grant(&admin, &grantee, &1_000, &start, &0, &1_000);
+
+    advance(&env, 300);
+    client.pause(&admin);
+    advance(&env, 200); // 200 s paused — should not count
+    client.resume(&admin);
+
+    // effective_now = 300 + 200 - 200 = 300, vested = 300
+    let (vested, clawback) = client.revoke(&admin, &grantee);
+    assert_eq!(vested, 300);
+    assert_eq!(clawback, 700);
+}
+
+#[test]
+fn test_revoke_rejected_while_paused() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+    let grantee = Address::generate(&env);
+
+    let start = env.ledger().timestamp();
+    client.create_grant(&admin, &grantee, &1_000, &start, &0, &1_000);
+
+    advance(&env, 300);
+    client.pause(&admin);
+
+    let result = client.try_revoke(&admin, &grantee);
+    assert_eq!(result, Err(Ok(VestingError::ContractPaused)));
+}
+
+// ── full vesting after pause ──────────────────────────────────────────────────
+
+#[test]
+fn test_full_vesting_after_pause_capped_at_total() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+    let grantee = Address::generate(&env);
+
+    let start = env.ledger().timestamp();
+    client.create_grant(&admin, &grantee, &1_000, &start, &0, &1_000);
+
+    // Pause 500 s halfway through, then resume and advance past duration.
+    advance(&env, 500);
+    client.pause(&admin);
+    advance(&env, 500);
+    client.resume(&admin);
+    advance(&env, 1_000); // well past duration even adjusted
+
+    let claimed = client.claim(&grantee);
+    assert_eq!(claimed, 1_000);
+}
+
+// ── nothing to claim before cliff ────────────────────────────────────────────
+
+#[test]
+fn test_nothing_claimable_before_cliff() {
+    let (env, admin, id) = setup();
+    let client = VestingContractClient::new(&env, &id);
+    let grantee = Address::generate(&env);
+
+    let start = env.ledger().timestamp();
+    client.create_grant(&admin, &grantee, &1_000, &start, &200, &1_000);
+
+    advance(&env, 100); // before cliff
+
+    let result = client.try_claim(&grantee);
+    assert_eq!(result, Err(Ok(VestingError::NothingToClaim)));
+}


### PR DESCRIPTION
Fixes #1261

## Summary
- Introduces `vesting/src/lib.rs` with a new `VestingContract` that tracks `paused_at` on `pause()` and accumulates `total_paused_secs += now - paused_at` on `resume()`, then computes `effective_now = now.saturating_sub(total_paused_secs)` fed to `Grant::vested_at` / `claim` / `revoke`.
- Adds `vesting/src/pause_offset_test.rs` covering zero-length pause, multiple pause/resume cycles, cliff-spanning pause, mid-pause claim/revoke rejection, revoke clawback consistency, and full-vesting cap.
- Adds `vesting/PAUSE_OFFSET.md` with a timeline diagram and a worked pause-then-resume claim example.

## Changes
Implements the feature/fix as described in the issue, following existing code patterns.