### PR TITLE
Add a bridge outbound message-nonce ledger with monotonic per-destination sequencing in bridge/src/lib.rs

### DIFF
--- a/stellar-lend/Cargo.lock
+++ b/stellar-lend/Cargo.lock
@@ -1380,6 +1380,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarlend-bridge"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/stellar-lend/contracts/bridge/Cargo.toml
+++ b/stellar-lend/contracts/bridge/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stellarlend-bridge"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/stellar-lend/contracts/bridge/OUTBOUND_SEQUENCING.md
+++ b/stellar-lend/contracts/bridge/OUTBOUND_SEQUENCING.md
@@ -1,0 +1,56 @@
+# Bridge Outbound Sequencing
+
+## Overview
+
+Every outbound bridge message is assigned a **monotonically increasing, per-destination nonce**.
+This gives relayers and the destination chain a unique, ordered, replay-resistant identity for
+each message.
+
+## Per-Destination Monotonicity
+
+The nonce ledger is a `Map<u32, u64>` keyed by destination network ID.  Each entry is
+independent: advancing the nonce for destination A does not affect destination B.
+
+| Property | Guarantee |
+|---|---|
+| First nonce per destination | Always `0` |
+| Subsequent nonces | Strictly `prev + 1` |
+| Rollover | Rejected — `BridgeError::NonceOverflow` |
+| Cross-destination isolation | Independent sequences |
+
+## Relayer Ordering Contract
+
+1. **Uniqueness** — `(dest, nonce)` is globally unique.  No two outbound events share the same
+   pair, so deduplication on the destination chain is straightforward.
+2. **Ordering** — A nonce of `N` was emitted strictly before any nonce `> N` for the same
+   destination.  Relayers can deliver messages in nonce order to preserve causality.
+3. **Gap detection** — If a relayer observes nonce `N+2` before `N+1`, it knows a message is
+   missing and can hold delivery until the gap is filled.
+4. **Replay resistance** — Because the nonce is bound into the `OutboundMessageEvent`, a
+   replayed event carries the same `(dest, nonce)` pair and can be rejected by the destination
+   chain's inbound deduplication logic.
+
+## API
+
+```rust
+/// Assign and return the next nonce for `dest`, then increment the ledger.
+/// Returns BridgeError::NonceOverflow if the nonce would wrap past u64::MAX.
+pub fn next_outbound_nonce(env: Env, dest: u32) -> Result<u64, BridgeError>;
+
+/// Return the nonce that the next call to next_outbound_nonce will return,
+/// without modifying state.
+pub fn peek_outbound_nonce(env: Env, dest: u32) -> u64;
+```
+
+## Events
+
+Each call to `next_outbound_nonce` emits an `OutboundMessageEvent`:
+
+```rust
+pub struct OutboundMessageEvent {
+    pub dest: u32,   // destination network ID
+    pub nonce: u64,  // nonce assigned to this message
+}
+```
+
+Relayers subscribe to these events to build an ordered delivery queue per destination.

--- a/stellar-lend/contracts/bridge/src/lib.rs
+++ b/stellar-lend/contracts/bridge/src/lib.rs
@@ -1,0 +1,102 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracterror, contracttype, Env, Map};
+
+/// Error codes for Bridge contract operations.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BridgeError {
+    /// Nonce overflow: destination nonce has reached u64::MAX and cannot be incremented.
+    NonceOverflow = 1,
+}
+
+/// Ledger storage key for the outbound nonce map.
+#[contracttype]
+pub enum BridgeDataKey {
+    /// Maps destination network ID (u32) to its next outbound nonce (u64).
+    OutboundNonces,
+}
+
+/// Emitted when an outbound bridge message is created.
+/// Carries the destination network and the nonce assigned to this message,
+/// giving relayers and the destination chain a unique, ordered identity.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OutboundMessageEvent {
+    /// Destination network identifier.
+    pub dest: u32,
+    /// Monotonically increasing nonce for this destination.
+    pub nonce: u64,
+}
+
+/// Bridge contract with per-destination outbound nonce sequencing.
+///
+/// Each outbound transfer is assigned a strictly-increasing nonce keyed by
+/// destination network. This gives relayers and downstream chains a
+/// replay-resistant, deterministically ordered message identity.
+#[contract]
+pub struct Bridge;
+
+#[contractimpl]
+impl Bridge {
+    /// Retrieve the current outbound nonce map from storage, or return an empty map.
+    fn load_nonces(env: &Env) -> Map<u32, u64> {
+        env.storage()
+            .persistent()
+            .get::<BridgeDataKey, Map<u32, u64>>(&BridgeDataKey::OutboundNonces)
+            .unwrap_or_else(|| Map::new(env))
+    }
+
+    /// Persist the outbound nonce map to storage.
+    fn save_nonces(env: &Env, nonces: &Map<u32, u64>) {
+        env.storage()
+            .persistent()
+            .set(&BridgeDataKey::OutboundNonces, nonces);
+    }
+
+    /// Return the next outbound nonce for `dest`, then increment it.
+    ///
+    /// The first call for a fresh destination returns `0`.
+    /// Subsequent calls return strictly increasing values.
+    /// Panics with `BridgeError::NonceOverflow` if the nonce would exceed `u64::MAX`.
+    ///
+    /// # Arguments
+    /// * `dest` - Destination network identifier (u32).
+    ///
+    /// # Returns
+    /// The nonce assigned to this outbound message.
+    pub fn next_outbound_nonce(env: Env, dest: u32) -> Result<u64, BridgeError> {
+        let mut nonces = Self::load_nonces(&env);
+        let current = nonces.get(dest).unwrap_or(0u64);
+        let next = current.checked_add(1).ok_or(BridgeError::NonceOverflow)?;
+        nonces.set(dest, next);
+        Self::save_nonces(&env, &nonces);
+
+        // Emit outbound event so relayers can track the message identity.
+        env.events().publish(
+            (soroban_sdk::symbol_short!("outbound"),),
+            OutboundMessageEvent {
+                dest,
+                nonce: current,
+            },
+        );
+
+        Ok(current)
+    }
+
+    /// Return the next nonce that will be assigned for `dest` without incrementing.
+    ///
+    /// Returns `0` if no messages have been sent to `dest` yet.
+    ///
+    /// # Arguments
+    /// * `dest` - Destination network identifier (u32).
+    ///
+    /// # Returns
+    /// The nonce that the next `next_outbound_nonce` call will return for this destination.
+    pub fn peek_outbound_nonce(env: Env, dest: u32) -> u64 {
+        let nonces = Self::load_nonces(&env);
+        nonces.get(dest).unwrap_or(0u64)
+    }
+}
+
+#[cfg(test)]
+mod outbound_nonce_test;

--- a/stellar-lend/contracts/bridge/src/outbound_nonce_test.rs
+++ b/stellar-lend/contracts/bridge/src/outbound_nonce_test.rs
@@ -1,0 +1,164 @@
+use super::*;
+use soroban_sdk::Env;
+
+// ── peek_outbound_nonce ──────────────────────────────────────────────────────
+
+/// A fresh destination starts at nonce 0.
+#[test]
+fn test_peek_fresh_destination_is_zero() {
+    let env = Env::default();
+    let contract_id = env.register(Bridge, ());
+    let client = BridgeClient::new(&env, &contract_id);
+
+    assert_eq!(client.peek_outbound_nonce(&1u32), 0u64);
+    assert_eq!(client.peek_outbound_nonce(&999u32), 0u64);
+}
+
+// ── next_outbound_nonce ──────────────────────────────────────────────────────
+
+/// First nonce per fresh destination must be exactly 0.
+#[test]
+fn test_first_nonce_is_zero() {
+    let env = Env::default();
+    let contract_id = env.register(Bridge, ());
+    let client = BridgeClient::new(&env, &contract_id);
+
+    let nonce = client.next_outbound_nonce(&42u32);
+    assert_eq!(nonce, 0u64);
+}
+
+/// Nonces are strictly monotonic for the same destination.
+#[test]
+fn test_monotonic_increase_single_destination() {
+    let env = Env::default();
+    let contract_id = env.register(Bridge, ());
+    let client = BridgeClient::new(&env, &contract_id);
+
+    let dest: u32 = 7;
+    let n0 = client.next_outbound_nonce(&dest);
+    let n1 = client.next_outbound_nonce(&dest);
+    let n2 = client.next_outbound_nonce(&dest);
+
+    assert_eq!(n0, 0u64);
+    assert_eq!(n1, 1u64);
+    assert_eq!(n2, 2u64);
+}
+
+/// peek returns the value that next_outbound_nonce will return next.
+#[test]
+fn test_peek_reflects_next_value() {
+    let env = Env::default();
+    let contract_id = env.register(Bridge, ());
+    let client = BridgeClient::new(&env, &contract_id);
+
+    let dest: u32 = 3;
+
+    // Before any messages: peek = 0, next returns 0.
+    assert_eq!(client.peek_outbound_nonce(&dest), 0u64);
+    let n0 = client.next_outbound_nonce(&dest);
+    assert_eq!(n0, 0u64);
+
+    // After first message: peek = 1, next returns 1.
+    assert_eq!(client.peek_outbound_nonce(&dest), 1u64);
+    let n1 = client.next_outbound_nonce(&dest);
+    assert_eq!(n1, 1u64);
+
+    // After second message: peek = 2.
+    assert_eq!(client.peek_outbound_nonce(&dest), 2u64);
+}
+
+/// Sequences for different destinations are independent.
+#[test]
+fn test_independent_sequences_per_destination() {
+    let env = Env::default();
+    let contract_id = env.register(Bridge, ());
+    let client = BridgeClient::new(&env, &contract_id);
+
+    let dest_a: u32 = 1;
+    let dest_b: u32 = 2;
+
+    // Advance dest_a three times.
+    client.next_outbound_nonce(&dest_a);
+    client.next_outbound_nonce(&dest_a);
+    client.next_outbound_nonce(&dest_a);
+
+    // dest_b should still start at 0.
+    assert_eq!(client.peek_outbound_nonce(&dest_b), 0u64);
+    let nb0 = client.next_outbound_nonce(&dest_b);
+    assert_eq!(nb0, 0u64);
+
+    // dest_a should now be at 3.
+    assert_eq!(client.peek_outbound_nonce(&dest_a), 3u64);
+}
+
+/// peek does not advance the nonce.
+#[test]
+fn test_peek_does_not_advance_nonce() {
+    let env = Env::default();
+    let contract_id = env.register(Bridge, ());
+    let client = BridgeClient::new(&env, &contract_id);
+
+    let dest: u32 = 10;
+
+    // Multiple peeks should not change anything.
+    for _ in 0..5 {
+        assert_eq!(client.peek_outbound_nonce(&dest), 0u64);
+    }
+
+    // The first real call still returns 0.
+    assert_eq!(client.next_outbound_nonce(&dest), 0u64);
+}
+
+/// Rollover near u64::MAX is rejected.
+#[test]
+fn test_nonce_overflow_near_max_is_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(Bridge, ());
+
+    let dest: u32 = 55;
+
+    // Manually seed the nonce map to u64::MAX so the next increment overflows.
+    env.as_contract(&contract_id, || {
+        let mut nonces: Map<u32, u64> = env
+            .storage()
+            .persistent()
+            .get::<BridgeDataKey, Map<u32, u64>>(&BridgeDataKey::OutboundNonces)
+            .unwrap_or_else(|| Map::new(&env));
+        nonces.set(dest, u64::MAX);
+        env.storage()
+            .persistent()
+            .set(&BridgeDataKey::OutboundNonces, &nonces);
+    });
+
+    // The call must return NonceOverflow.
+    let client = BridgeClient::new(&env, &contract_id);
+    let result = client.try_next_outbound_nonce(&dest);
+    assert!(result.is_err(), "expected NonceOverflow error");
+}
+
+/// Many destinations can coexist without interfering with each other.
+#[test]
+fn test_many_destinations_independent() {
+    let env = Env::default();
+    let contract_id = env.register(Bridge, ());
+    let client = BridgeClient::new(&env, &contract_id);
+
+    let dests: [u32; 5] = [100, 200, 300, 400, 500];
+
+    // Send 3 messages to each destination.
+    for &dest in &dests {
+        for expected_nonce in 0u64..3 {
+            let n = client.next_outbound_nonce(&dest);
+            assert_eq!(n, expected_nonce, "dest={dest} expected nonce {expected_nonce}");
+        }
+    }
+
+    // Verify peek for each destination is now 3.
+    for &dest in &dests {
+        assert_eq!(
+            client.peek_outbound_nonce(&dest),
+            3u64,
+            "dest={dest} peek should be 3"
+        );
+    }
+}

--- a/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_first_nonce_is_zero.1.json
+++ b/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_first_nonce_is_zero.1.json
@@ -1,0 +1,162 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OutboundNonces"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OutboundNonces"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u32": 42
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "outbound"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "dest"
+                  },
+                  "val": {
+                    "u32": 42
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "nonce"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_independent_sequences_per_destination.1.json
+++ b/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_independent_sequences_per_destination.1.json
@@ -1,0 +1,137 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OutboundNonces"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OutboundNonces"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u32": 1
+                      },
+                      "val": {
+                        "u64": 3
+                      }
+                    },
+                    {
+                      "key": {
+                        "u32": 2
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_many_destinations_independent.1.json
+++ b/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_many_destinations_independent.1.json
@@ -1,0 +1,175 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OutboundNonces"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OutboundNonces"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u32": 100
+                      },
+                      "val": {
+                        "u64": 3
+                      }
+                    },
+                    {
+                      "key": {
+                        "u32": 200
+                      },
+                      "val": {
+                        "u64": 3
+                      }
+                    },
+                    {
+                      "key": {
+                        "u32": 300
+                      },
+                      "val": {
+                        "u64": 3
+                      }
+                    },
+                    {
+                      "key": {
+                        "u32": 400
+                      },
+                      "val": {
+                        "u64": 3
+                      }
+                    },
+                    {
+                      "key": {
+                        "u32": 500
+                      },
+                      "val": {
+                        "u64": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_monotonic_increase_single_destination.1.json
+++ b/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_monotonic_increase_single_destination.1.json
@@ -1,0 +1,164 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OutboundNonces"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OutboundNonces"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u32": 7
+                      },
+                      "val": {
+                        "u64": 3
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "outbound"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "dest"
+                  },
+                  "val": {
+                    "u32": 7
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "nonce"
+                  },
+                  "val": {
+                    "u64": 2
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_nonce_overflow_near_max_is_rejected.1.json
+++ b/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_nonce_overflow_near_max_is_rejected.1.json
@@ -1,0 +1,125 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OutboundNonces"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OutboundNonces"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u32": 55
+                      },
+                      "val": {
+                        "u64": 18446744073709551615
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_peek_does_not_advance_nonce.1.json
+++ b/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_peek_does_not_advance_nonce.1.json
@@ -1,0 +1,167 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OutboundNonces"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OutboundNonces"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u32": 10
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "outbound"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "dest"
+                  },
+                  "val": {
+                    "u32": 10
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "nonce"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_peek_fresh_destination_is_zero.1.json
+++ b/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_peek_fresh_destination_is_zero.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_peek_reflects_next_value.1.json
+++ b/stellar-lend/contracts/bridge/test_snapshots/outbound_nonce_test/test_peek_reflects_next_value.1.json
@@ -1,0 +1,128 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OutboundNonces"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OutboundNonces"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u32": 3
+                      },
+                      "val": {
+                        "u64": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
Fixes #1260

## Summary
Basic implementation of: Add a bridge outbound message-nonce ledger with monotonic per-destination sequencing in bridge/src/lib.rs

## Changes
Implements the feature/fix as described in the issue, following existing code patterns.