### PR TITLE
feat: add per-asset supply cap and collateral tracking

### DIFF
--- a/stellar-lend/contracts/lending/src/cross_asset_health_perf_test.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_health_perf_test.rs
@@ -159,6 +159,8 @@ fn setup_hf_with_n_assets(n: u32) -> (Env, Address, Address, Address, soroban_sd
                     ltv_bps: 7500,
                     liquidation_threshold_bps: 8000,
                     debt_ceiling: 1_000_000_000_000i128,
+                     borrow_cap: 0,
+                     supply_cap: 0,
                 },
             );
             env.storage().persistent().set(

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -181,6 +181,8 @@ pub enum DataKey {
     /// Per-asset total outstanding debt (cross-asset tracking).
     TotalDebtAsset(Address),
     /// Insurance fund balance credited by governance or protocol fees (i128).
+    /// Per-asset total supplied collateral (cross-asset tracking).
+    TotalCollateralAsset(Address),
     InsuranceFund,
     /// Share of accrued interest (in basis points) routed into the insurance
     /// fund on each settlement. Stored as `i128`; defaults to 0 when unset.
@@ -433,6 +435,9 @@ pub struct AssetParams {
     /// Per-asset protocol borrow cap: maximum total outstanding debt for this asset.
     /// A value of 0 means uncapped (no limit enforced).
     pub borrow_cap: i128,
+    /// Per-asset protocol supply cap: maximum total collateral supplied for this asset.
+    /// A value of 0 means uncapped (no limit enforced).
+    pub supply_cap: i128,
 }
 
 #[contracttype]
@@ -451,6 +456,7 @@ pub struct AssetParamsSetEvent {
     pub liquidation_threshold_bps: i128,
     pub debt_ceiling: i128,
     pub borrow_cap: i128,
+    pub supply_cap: i128,
 }
 
 #[contractevent]
@@ -1375,7 +1381,9 @@ impl LendingContract {
             // Dust guard: a repay of 0 would make the liquidation a no-op.
             if actual_repay <= 0 {
                 return Err(LendingError::InvalidAmount);
-            }
+            }if supply_cap < 0 {
+    return Err(LendingError::InvalidAmount);
+}
 
             // Liquidation incentive: floor rounding.
             // actual_repay * 11000 / 10000 — rounding down means the liquidator
@@ -1539,7 +1547,7 @@ impl LendingContract {
     /// interaction during a protocol pause or emergency shutdown.
     pub fn repay_flash_loan(env: Env, payer: Address, asset: Address, amount: i128) {
         check_pause_status(&env, ProtocolAction::FlashLoan);
-        check_emergency_status(&env, ProtocolAction::FlashLoan);
+        check_emergency_status(grep -n -A10 "pub struct AssetParams" contracts/lending/src/lib.rs&env, ProtocolAction::FlashLoan);
         payer.require_auth();
         let payer_key = DataKey::Balance(asset.clone(), payer.clone());
         let payer_bal: i128 = env.storage().persistent().get(&payer_key).unwrap_or(0);
@@ -1602,7 +1610,9 @@ impl LendingContract {
         let new_tre_bal = tre_bal
             .checked_sub(amount)
             .expect("flash_loan: treasury underflow during transfer");
-        env.storage().persistent().set(&tre_key, &new_tre_bal);
+        env.storage().persistent().set(&tre_key,if supply_cap < 0 {
+    return Err(LendingError::InvalidAmount);
+} &new_tre_bal);
 
         let rec_key = DataKey::Balance(asset.clone(), receiver.clone());
         let rec_bal: i128 = env.storage().persistent().get(&rec_key).unwrap_or(0);
@@ -1746,7 +1756,9 @@ impl LendingContract {
         liquidation_threshold_bps: i128,
         debt_ceiling: i128,
         borrow_cap: i128,
+        supply_cap: i128,
     ) -> Result<(), LendingError> {
+        
         admin.require_auth();
         if admin != Self::get_admin(env.clone()) {
             return Err(LendingError::Unauthorized);
@@ -1764,11 +1776,15 @@ impl LendingContract {
             return Err(LendingError::InvalidAmount);
         }
 
+        if supply_cap < 0 {
+            return Err(LendingError::InvalidAmount);
+        }
         let params = AssetParams {
             ltv_bps,
             liquidation_threshold_bps,
             debt_ceiling,
             borrow_cap,
+             supply_cap,
         };
         cross_asset::set_asset_params_internal(&env, &asset, &params);
 

--- a/stellar-lend/contracts/lending/src/position_summary_bench_test.rs
+++ b/stellar-lend/contracts/lending/src/position_summary_bench_test.rs
@@ -174,6 +174,8 @@ fn setup_with_n_assets(n: u32) -> (Env, Address, Address, Address, soroban_sdk::
                     ltv_bps: 7500,
                     liquidation_threshold_bps: 8000,
                     debt_ceiling: 1_000_000_000_000i128,
+                     borrow_cap: 0,
+                    supply_cap: 0,
                 },
             );
             env.storage().persistent().set(


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
Closes #1217