### PR TITLE
docs(bridge): document validator rotation and quorum-proof protocol

### DIFF
--- a/stellar-lend/contracts/bridge/README.md
+++ b/stellar-lend/contracts/bridge/README.md
@@ -12,6 +12,7 @@ Key features
 
 | Document | Description |
 |---|---|
+| [ROTATION_PROTOCOL.md](./ROTATION_PROTOCOL.md) | Sequenced validator-set rotation flow, signed payload, quorum math, and inbound epoch handling |
 | [SECURITY_NOTES.md](./SECURITY_NOTES.md) | Bridge validator rotation threat model and inbound-cap security rationale |
 | [INBOUND_WINDOW_TUNING.md](./INBOUND_WINDOW_TUNING.md) | Rolling-window cap algorithm and operator parameter-selection guide |
 | [WINDOW_GUARD.md](./WINDOW_GUARD.md) | Window-boundary guard rationale for zero windows, clock rollback, and overflow |
@@ -21,7 +22,7 @@ Key features
 Design notes
 - Validator public keys are stored as raw bytes to keep on-disk/state serialization simple and unambiguous.
 - Quorum threshold is a supermajority > 2/3 of current validators.
-- Signatures are over a canonical payload: `bincode((new_set_bytes_vec, epoch))` — this binds the epoch to the new set.
+- Signatures are over a canonical, domain-separated payload: `bincode((QUORUM_PROOF_DOMAIN, bridge_id, new_set_bytes_vec, epoch))` — this binds the purpose, bridge instance, epoch, and proposed set.
 - This crate is intentionally standalone (off-chain validator/quorum verification logic) and is not a member of the parent Soroban workspace; run `cargo test` from this directory.
 
 See `src/lib.rs` for implementation and unit tests.

--- a/stellar-lend/contracts/bridge/ROTATION_PROTOCOL.md
+++ b/stellar-lend/contracts/bridge/ROTATION_PROTOCOL.md
@@ -1,0 +1,183 @@
+# Bridge validator-set rotation protocol
+
+This document defines how bridge operators propose, prove, and apply a
+validator-set rotation. It describes the protocol implemented by
+`Bridge::quorum_proof_payload`, `Bridge::rotate_validators`, and
+`Bridge::validate_inbound_epoch` in `src/lib.rs`.
+
+## Protocol roles and terms
+
+- **Current set**: the validator set stored on the bridge before a rotation.
+- **Active validator**: a member of the current set that is not paused.
+- **Proposed set**: the ordered validator public keys that will replace the
+  current set if the rotation succeeds.
+- **Epoch**: the monotonically increasing validator-set version. A new bridge
+  starts at epoch `0`.
+- **Quorum proof**: a list of `(public_key, Ed25519 signature)` pairs from
+  unique active members of the current set.
+
+The current set authorizes its successor. Validators in the proposed set do
+not authorize their own installation unless they are also active members of
+the current set.
+
+## What validators sign
+
+Every signer must sign the exact bytes returned by
+`Bridge::quorum_proof_payload`:
+
+```text
+payload = bincode((
+    QUORUM_PROOF_DOMAIN,
+    bridge_id,
+    proposed_set.to_bytes_vec(),
+    next_epoch,
+))
+```
+
+The fields bind the proof to:
+
+1. the validator-rotation purpose and payload version through
+   `QUORUM_PROOF_DOMAIN`;
+2. one bridge deployment through `bridge_id`;
+3. the complete proposed validator set, including its order; and
+4. the one epoch at which the set may be installed.
+
+Operators must distribute one canonical payload to all signers. Reordering
+the proposed keys, changing a key, changing the bridge ID, or changing the
+epoch produces different bytes and invalidates previously collected
+signatures.
+
+## Supermajority quorum
+
+For `n` active validators, the required number of unique valid signatures is:
+
+```text
+threshold(n) = floor((n * 2) / 3) + 1
+```
+
+This is strictly greater than two thirds. With no paused validators, `n` is
+the deduplicated size of the current set and matches
+`ValidatorSet::threshold()`. If validators are paused, `n` is the remaining
+active count and the bridge uses `Bridge::effective_threshold()`.
+
+| Active validators (`n`) | Required signatures |
+|---:|---:|
+| 3 | 3 |
+| 4 | 3 |
+| 5 | 4 |
+| 6 | 5 |
+| 7 | 5 |
+| 10 | 7 |
+| 32 | 22 |
+
+Proof verification applies these counting rules:
+
+- a signer must belong to the current validator set;
+- a paused validator is ignored and does not count toward quorum;
+- duplicate proof entries for one public key count once;
+- every counted signature must verify against the canonical payload; and
+- the number of unique, valid, active signers must meet the threshold.
+
+An empty proof, an outsider signer, an invalid counted signature, or too few
+unique active signatures rejects the rotation.
+
+## Rotation procedure
+
+Assume the bridge is at epoch `e` with current set `S`.
+
+1. **Choose the successor.** Build an ordered proposed set `S_next`. It must
+   contain between `MIN_VALIDATORS` and `MAX_VALIDATORS` unique public keys and
+   may not contain duplicate keys.
+2. **Choose the next epoch.** Set `next_epoch = e + 1`. Reusing `e`, skipping
+   to `e + 2`, or replaying an older epoch is rejected.
+3. **Build the payload.** Call `Bridge::quorum_proof_payload` with this
+   bridge's `bridge_id`, `S_next`, and `next_epoch`.
+4. **Collect signatures.** Active validators in `S` sign those exact bytes.
+   Collect at least `floor((n * 2) / 3) + 1` unique valid signatures, where
+   `n` is the active validator count.
+5. **Submit the proof.** Call
+   `rotate_validators(S_next, next_epoch, proofs)`.
+6. **Validate before mutation.** The bridge checks the epoch, proposed-set
+   bounds and duplicates, any configured churn limit, proof membership,
+   signatures, deduplication, and quorum.
+7. **Commit atomically.** Only after every check succeeds does the bridge
+   replace `S` with `S_next`, set its epoch to `next_epoch`, and clear pause
+   flags inherited from the retired set. The returned value is the symmetric
+   difference (churn) between the old and new sets.
+
+Any error leaves the validator set and epoch unchanged.
+
+## Worked example: five validators rotate at epoch 7
+
+Suppose the bridge is at epoch `7` with five active validators:
+
+```text
+current set S = [A1, A2, A3, A4, A5]
+proposed set  = [B1, B2, B3, B4]
+next_epoch    = 8
+```
+
+The current-set threshold is:
+
+```text
+floor((5 * 2) / 3) + 1 = floor(10 / 3) + 1 = 3 + 1 = 4
+```
+
+The operator constructs the canonical payload for the proposed set and epoch
+`8`, then asks `A1` through `A5` to sign it.
+
+- Signatures from `A1`, `A2`, `A3`, and `A4`: **accepted** (4 unique current
+  signers meet the threshold).
+- Signatures from only `A1`, `A2`, and `A3`: **rejected** (3 is below the
+  threshold).
+- Four proof entries containing only three unique signers: **rejected**
+  (duplicates count once).
+- Signatures from `B1` through `B4` alone: **rejected** unless those keys are
+  also in the current set; the proposed set cannot self-authorize.
+
+After the valid proof is applied, the bridge is at epoch `8`, `[B1, B2, B3,
+B4]` is the current set, and its unpaused quorum threshold is `3`. A later
+rotation must be authorized by that new current set for epoch `9`.
+
+## Inbound epoch validation and retired sets
+
+Inbound processing calls `validate_inbound_epoch(signed_epoch)` to prevent
+messages from a retired validator-set epoch from being replayed after a
+rotation.
+
+```text
+signed_epoch < bridge.epoch  => reject as a retired validator set
+signed_epoch == bridge.epoch => pass this retired-set check
+```
+
+In the worked example, once epoch `8` is installed, inbound messages carrying
+epoch `7` or earlier are rejected. Messages carrying epoch `8` pass this
+check. Signatures from set `S` also cannot authorize a later rotation because
+proof signers must belong to the current set, which is now the proposed set.
+
+`validate_inbound_epoch` is deliberately a retired-set guard, not a complete
+inbound authentication routine: the current implementation also returns
+success for a future epoch. Callers must still verify the message signature,
+bridge/domain binding, and any policy that requires the inbound epoch to equal
+the current epoch.
+
+## Operator checklist
+
+- Use a non-empty, deployment-unique `bridge_id`.
+- Preserve the proposed validator ordering when distributing the payload.
+- Confirm `next_epoch` equals the bridge's current epoch plus one.
+- Compute quorum from the current active set, not the proposed set.
+- Deduplicate signers before declaring the proof ready.
+- Submit the same proposed set and epoch that were signed.
+- After rotation, update relayers so they stop accepting or producing messages
+  for the retired epoch.
+
+## Related documentation
+
+- [README.md](./README.md) - bridge overview and documentation index.
+- [SECURITY_NOTES.md](./SECURITY_NOTES.md) - threat model and security rationale.
+- [EPOCH_INVARIANTS.md](./EPOCH_INVARIANTS.md) - epoch monotonicity invariants.
+- [VALIDATORSET_INVARIANTS.md](./VALIDATORSET_INVARIANTS.md) - validator-set
+  and threshold invariants.
+- [VALIDATOR_PAUSE.md](./VALIDATOR_PAUSE.md) - active-set quorum behavior when
+  validators are paused.

--- a/stellar-lend/contracts/bridge/src/lib.rs
+++ b/stellar-lend/contracts/bridge/src/lib.rs
@@ -391,27 +391,21 @@ impl Bridge {
         self.paused_validators.iter().cloned().collect()
     }
 
-    /// Verify a quorum proof from the current validator set over the (new_set, epoch) payload.
-    ///
-    /// Paused validator signatures are *silently skipped* — they are neither
-    /// verified nor counted toward the quorum, and they do not cause the
-    /// overall proof to fail. Skipping (rather than rejecting on sight) is a
-    /// deliberate choice: a compromised key may still be present in the
-    /// relay-network gossip, so silently ignoring it lets a bridge keep
-    /// operating under quorum with a known-compromised signer excluded. The
-    /// effective quorum threshold is recomputed from the active (non-paused)
-    /// validator subset.
-    /// Builds the canonical, domain-separated payload that quorum proofs sign
-    /// over (issue #1146):
+    /// Builds the canonical, domain-separated payload for a validator-set
+    /// rotation quorum proof.
     ///
     /// ```text
     ///   payload = bincode((QUORUM_PROOF_DOMAIN, bridge_id, new_set_bytes, epoch))
     /// ```
     ///
-    /// Prefixing the constant [`QUORUM_PROOF_DOMAIN`] tag and the per-instance
-    /// `bridge_id` makes a signature valid **only** for this bridge instance and
-    /// this purpose. Signers and verifiers must both go through this function so
-    /// the bytes always match.
+    /// `bridge_id` identifies the deployment, `new_set_bytes` preserves the
+    /// proposed set's storage order, and `epoch` is the exact successor epoch.
+    /// Current active validators must all sign the identical bytes returned by
+    /// this function; changing any field invalidates the signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload cannot be serialized.
     pub fn quorum_proof_payload(
         bridge_id: &[u8],
         new_set: &ValidatorSet,
@@ -425,11 +419,13 @@ impl Bridge {
         ))?)
     }
 
-    /// Verify a quorum proof from the current validator set over the (new_set, epoch) payload.
+    /// Verifies that current active validators authorized `new_set` for
+    /// `epoch` with a strict supermajority quorum proof.
     ///
-    /// Paused validator signatures are *silently skipped* — they are neither
-    /// verified nor counted toward the quorum, and they do not cause the
-    /// overall proof to fail.
+    /// Signers must belong to the current set. Duplicate active signers count
+    /// once, paused signers are skipped, and every counted Ed25519 signature
+    /// must verify against [`Bridge::quorum_proof_payload`]. The proof succeeds
+    /// when unique valid active signers meet [`Bridge::effective_threshold`].
     fn verify_quorum_proof(
         &self,
         new_set: &ValidatorSet,
@@ -488,8 +484,11 @@ impl Bridge {
         self.max_churn = max_churn;
     }
 
-    /// Rotate validators to `new_set` at `next_epoch` if `proofs` from current set form a quorum.
-    /// The `epoch` must be exactly current_epoch + 1.
+    /// Applies a validator-set rotation authorized by the current active set.
+    ///
+    /// `epoch` must equal `self.epoch + 1`. `proofs` must contain a strict
+    /// supermajority of unique valid signatures from current active validators
+    /// over the canonical `(domain, bridge_id, new_set, epoch)` payload.
     ///
     /// # Security validation
     ///
@@ -518,7 +517,18 @@ impl Bridge {
     /// Also enforces the `max_churn` limit (if configured) on the symmetric difference
     /// between the current validator set and the new validator set.
     ///
-    /// Returns the computed churn count on success.
+    /// On success, the validator set and epoch advance atomically and stale
+    /// pause flags are cleared. On failure, those fields remain unchanged.
+    ///
+    /// # Returns
+    ///
+    /// Returns the symmetric-difference churn count between the old and new
+    /// validator sets.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a non-successor epoch, an out-of-bounds or duplicate-key set, a
+    /// churn-limit violation, or an invalid/insufficient quorum proof.
     pub fn rotate_validators(
         &mut self,
         new_set: ValidatorSet,
@@ -701,7 +711,11 @@ impl Bridge {
         })
     }
 
-    /// Verify inbound message signature epoch. Messages signed with an epoch < current epoch are rejected.
+    /// Rejects an inbound message epoch that belongs to a retired validator set.
+    ///
+    /// An epoch lower than [`Bridge::epoch`] fails. The current epoch and future
+    /// epochs pass this narrow guard, so callers must separately authenticate
+    /// the inbound message and enforce equality if their policy requires it.
     pub fn validate_inbound_epoch(&self, signed_epoch: u64) -> Result<()> {
         if signed_epoch < self.epoch {
             return Err(anyhow!("message signed by retired validator set (epoch too old)"));
@@ -880,6 +894,9 @@ fn lowercase_hex(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod rotation_test;
+
+#[cfg(test)]
+mod rotation_doc_test;
 
 #[cfg(test)]
 mod domain_separation_test;

--- a/stellar-lend/contracts/bridge/src/rotation_doc_test.rs
+++ b/stellar-lend/contracts/bridge/src/rotation_doc_test.rs
@@ -1,0 +1,30 @@
+use crate::ValidatorSet;
+
+fn validator_set_with_unique_keys(count: usize) -> ValidatorSet {
+    ValidatorSet {
+        validators: (0..count).map(|index| vec![index as u8; 32]).collect(),
+    }
+}
+
+#[test]
+fn documented_quorum_table_matches_threshold() {
+    let documented_cases = [(3, 3), (4, 3), (5, 4), (6, 5), (7, 5), (10, 7), (32, 22)];
+
+    for (validator_count, documented_threshold) in documented_cases {
+        let validator_set = validator_set_with_unique_keys(validator_count);
+        assert_eq!(
+            validator_set.threshold(),
+            documented_threshold,
+            "ROTATION_PROTOCOL.md quorum mismatch for n={validator_count}",
+        );
+    }
+}
+
+#[test]
+fn worked_five_validator_rotation_requires_four_signatures() {
+    let current_set = validator_set_with_unique_keys(5);
+
+    assert_eq!(current_set.threshold(), 4);
+    assert!(3 < current_set.threshold());
+    assert!(4 >= current_set.threshold());
+}


### PR DESCRIPTION
Close #1155 
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
