### PR TITLE
perf(twap): benchmark and bound get_twap snapshot-scan cost

### DIFF
--- a/stellar-lend/contracts/hello-world/docs/TWAP_READ_PERF.md
+++ b/stellar-lend/contracts/hello-world/docs/TWAP_READ_PERF.md
@@ -1,0 +1,72 @@
+# TWAP read-cost budget
+
+`get_twap` reads the per-asset snapshot vector and selects the latest snapshot
+at or before `target_start = now - window_secs`. This document records the
+maximum vector size and lookup-comparison budget enforced by tests.
+
+## Cost model
+
+A TWAP read has two snapshot-related costs:
+
+1. Soroban storage deserializes the snapshot vector. This is linear in the
+   retained entry count, but `MAX_SNAPSHOTS = 1,440` gives it a fixed ceiling.
+2. `find_snapshot_at_or_before` searches the ordered vector. Binary search
+   bounds this step to `O(log n)` comparisons.
+
+For a non-empty vector, the worst-case search budget is:
+
+```text
+comparisons(n) = ceil(log2(n + 1))
+comparisons(1,440) = ceil(log2(1,441)) = 11
+```
+
+`TWAP_READ_SEARCH_COMPARISON_BUDGET` therefore fixes the maximum search cost at
+11 snapshot comparisons. A linear scan could require 1,440 comparisons and
+would fail the budget tests.
+
+## Benchmark matrix
+
+`twap_read_bench_test.rs` exercises the complete stable-price `get_twap` path
+and instruments its snapshot lookup at increasing retained counts:
+
+| Snapshots | Worst-case comparison budget |
+|---:|---:|
+| 1 | 1 |
+| 4 | 3 |
+| 16 | 5 |
+| 64 | 7 |
+| 512 | 10 |
+| 1,440 | 11 |
+
+Comparison counts are deterministic and more suitable for a CI budget than
+wall-clock timings, which vary with the host and Soroban SDK build profile.
+
+## Worked example
+
+For 64 snapshots ordered at 60-second intervals, a target between the 33rd and
+34th entries must resolve to the 33rd entry. Binary search halves the remaining
+range on each comparison and needs at most:
+
+```text
+ceil(log2(64 + 1)) = 7 comparisons
+```
+
+The edge-case matrix also checks a target before the first snapshot, the exact
+first and last timestamps, a middle gap, and a target after the last snapshot.
+
+## Enforced bounds
+
+- Snapshot storage/deserialization: at most 1,440 entries per asset.
+- Ordered snapshot search: at most 11 comparisons per TWAP read.
+- Search behavior: latest timestamp less than or equal to the target, including
+  vector ends and a middle gap.
+- Price behavior: a stable 1:1 pool still returns `PRICE_SCALE` at every tested
+  snapshot count.
+
+The current bounded vector plus binary search meets the read budget. Changing
+the storage layout to individually keyed snapshots would be required to make
+deserialization itself logarithmic; that migration is not necessary to stop
+cost growth because the retained vector is already capped.
+
+See [TWAP_SNAPSHOT_POLICY.md](./TWAP_SNAPSHOT_POLICY.md) for ring-buffer sizing
+and eviction guarantees.

--- a/stellar-lend/contracts/hello-world/src/amm_twap.rs
+++ b/stellar-lend/contracts/hello-world/src/amm_twap.rs
@@ -43,7 +43,8 @@
 /// eviction only removes data that is older than the longest supported query window, ensuring
 /// every valid `get_twap` call can still find a start snapshot.
 ///
-/// See `docs/TWAP_SNAPSHOT_POLICY.md` for the full rationale.
+/// See `docs/TWAP_SNAPSHOT_POLICY.md` for the storage rationale and
+/// `docs/TWAP_READ_PERF.md` for the read-cost budget.
 ///
 /// # Storage keys
 ///
@@ -92,6 +93,19 @@ pub const MAX_TWAP_WINDOW_SECS: u64 = 86_400;
 /// Eviction only removes the single oldest entry once the cap is hit, keeping
 /// the amortised write cost at O(1) per snapshot interval.
 pub const MAX_SNAPSHOTS: u32 = 1_440;
+
+/// Maximum snapshot comparisons performed by one `get_twap` lookup.
+///
+/// `find_snapshot_at_or_before` uses binary search, whose worst-case cost for
+/// the capped ring is `ceil(log2(MAX_SNAPSHOTS + 1))`:
+///
+/// ```text
+/// ceil(log2(1_440 + 1)) = 11
+/// ```
+///
+/// Tests exercise increasing ring sizes and targets at both ends and the
+/// middle so a regression to a linear scan cannot silently exceed this budget.
+pub const TWAP_READ_SEARCH_COMPARISON_BUDGET: u32 = 11;
 
 /// Safety multiplier used during eviction to guarantee the oldest retained
 /// snapshot is never within the maximum query window.

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -80,6 +80,8 @@ mod twap_view_test;
 #[cfg(test)]
 mod twap_maxbuffer_perf_test;
 #[cfg(test)]
+mod twap_read_bench_test;
+#[cfg(test)]
 mod twap_coverage_test;
 #[cfg(test)]
 mod cross_asset_storage_doc_test;

--- a/stellar-lend/contracts/hello-world/src/twap_maxbuffer_perf_test.rs
+++ b/stellar-lend/contracts/hello-world/src/twap_maxbuffer_perf_test.rs
@@ -15,9 +15,8 @@ mod tests {
     use crate::amm_twap::{
         get_snapshots, get_twap, snapshot_search_metrics_for_test, update_twap_accumulators,
         MAX_SNAPSHOTS, MIN_WINDOW_SECS, PRICE_SCALE, SNAPSHOT_INTERVAL_SECS,
+        TWAP_READ_SEARCH_COMPARISON_BUDGET,
     };
-
-    const LOOKUP_COMPARISON_BUDGET: u32 = 11;
 
     /// Advances the mock ledger by `secs` seconds.
     fn advance(env: &Env, secs: u64) {
@@ -66,8 +65,8 @@ mod tests {
         let start_snap = start_snap.expect("full ring should have a bounding snapshot");
 
         assert!(
-            comparisons <= LOOKUP_COMPARISON_BUDGET,
-            "expected <= {LOOKUP_COMPARISON_BUDGET} comparisons, got {comparisons}"
+            comparisons <= TWAP_READ_SEARCH_COMPARISON_BUDGET,
+            "expected <= {TWAP_READ_SEARCH_COMPARISON_BUDGET} comparisons, got {comparisons}"
         );
         assert_eq!(
             comparisons,
@@ -102,8 +101,8 @@ mod tests {
         let start_snap = start_snap.expect("full ring should have a long-window anchor");
 
         assert!(
-            comparisons <= LOOKUP_COMPARISON_BUDGET,
-            "expected <= {LOOKUP_COMPARISON_BUDGET} comparisons, got {comparisons}"
+            comparisons <= TWAP_READ_SEARCH_COMPARISON_BUDGET,
+            "expected <= {TWAP_READ_SEARCH_COMPARISON_BUDGET} comparisons, got {comparisons}"
         );
         assert_eq!(comparisons, binary_search_budget(MAX_SNAPSHOTS));
         assert!(start_snap.timestamp <= target_start);
@@ -133,7 +132,7 @@ mod tests {
             MAX_SNAPSHOTS
         );
         assert!(
-            comparisons <= LOOKUP_COMPARISON_BUDGET,
+            comparisons <= TWAP_READ_SEARCH_COMPARISON_BUDGET,
             "comparison count should stay within the documented budget"
         );
     }

--- a/stellar-lend/contracts/hello-world/src/twap_read_bench_test.rs
+++ b/stellar-lend/contracts/hello-world/src/twap_read_bench_test.rs
@@ -1,0 +1,130 @@
+//! Deterministic read-cost benchmarks for the `get_twap` snapshot lookup.
+//!
+//! Comparison counts are used instead of wall-clock timings so the budget is
+//! stable across developer machines and CI runners.
+
+use soroban_sdk::{testutils::Ledger, Address, Env, Vec};
+
+use crate::amm_twap::{
+    get_snapshots, get_twap, snapshot_search_metrics_for_test, update_twap_accumulators,
+    TwapSnapshot, MAX_SNAPSHOTS, PRICE_SCALE, SNAPSHOT_INTERVAL_SECS,
+    TWAP_READ_SEARCH_COMPARISON_BUDGET,
+};
+
+const BENCHMARK_SNAPSHOT_COUNTS: [u32; 6] = [1, 4, 16, 64, 512, MAX_SNAPSHOTS];
+
+/// Advances the mock ledger by `seconds` without writing a snapshot.
+fn advance(env: &Env, seconds: u64) {
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp().saturating_add(seconds));
+}
+
+/// Builds an on-chain snapshot vector with `count` entries at a stable 1:1 price.
+fn fill_snapshot_vector(env: &Env, asset: &Address, count: u32) {
+    env.ledger().set_timestamp(0);
+    update_twap_accumulators(env, asset, 1_000_000, 1_000_000);
+
+    for _ in 0..count {
+        advance(env, SNAPSHOT_INTERVAL_SECS);
+        update_twap_accumulators(env, asset, 1_000_000, 1_000_000);
+    }
+}
+
+/// Returns the worst-case binary-search comparison count for `item_count` entries.
+fn binary_search_budget(item_count: u32) -> u32 {
+    let mut remaining = item_count;
+    let mut comparisons = 0u32;
+    while remaining > 0 {
+        comparisons = comparisons.saturating_add(1);
+        remaining /= 2;
+    }
+    comparisons
+}
+
+/// Returns a sorted synthetic snapshot vector with timestamps 60, 120, ... .
+fn synthetic_snapshots(env: &Env, count: u32) -> Vec<TwapSnapshot> {
+    let mut snapshots = Vec::new(env);
+    for index in 1..=count {
+        let timestamp = u64::from(index) * SNAPSHOT_INTERVAL_SECS;
+        snapshots.push_back(TwapSnapshot {
+            timestamp,
+            price0_cumulative: u128::from(timestamp) * PRICE_SCALE,
+            price1_cumulative: u128::from(timestamp) * PRICE_SCALE,
+        });
+    }
+    snapshots
+}
+
+#[test]
+fn get_twap_read_cost_stays_logarithmic_as_snapshots_grow() {
+    assert_eq!(
+        binary_search_budget(MAX_SNAPSHOTS),
+        TWAP_READ_SEARCH_COMPARISON_BUDGET
+    );
+
+    for snapshot_count in BENCHMARK_SNAPSHOT_COUNTS {
+        let env = Env::default();
+        let asset = Address::generate(&env);
+        fill_snapshot_vector(&env, &asset, snapshot_count);
+
+        let snapshots = get_snapshots(&env, &asset);
+        assert_eq!(snapshots.len(), snapshot_count);
+
+        // Query one interval after the latest write so the target lands on the
+        // newest snapshot and the complete get_twap path has a non-zero window.
+        advance(&env, SNAPSHOT_INTERVAL_SECS);
+        let target_timestamp = env
+            .ledger()
+            .timestamp()
+            .saturating_sub(SNAPSHOT_INTERVAL_SECS);
+        let (anchor, comparisons) = snapshot_search_metrics_for_test(&snapshots, target_timestamp);
+
+        assert_eq!(
+            anchor.map(|snapshot| snapshot.timestamp),
+            Some(target_timestamp)
+        );
+        assert!(
+            comparisons <= binary_search_budget(snapshot_count),
+            "{snapshot_count} snapshots required {comparisons} comparisons"
+        );
+        assert!(
+            comparisons <= TWAP_READ_SEARCH_COMPARISON_BUDGET,
+            "lookup exceeded the global read budget"
+        );
+        assert_eq!(get_twap(&env, &asset, SNAPSHOT_INTERVAL_SECS), PRICE_SCALE);
+    }
+}
+
+#[test]
+fn snapshot_lookup_budget_covers_vector_ends_and_middle() {
+    let env = Env::default();
+    let snapshot_count = 64u32;
+    let snapshots = synthetic_snapshots(&env, snapshot_count);
+    let first_timestamp = SNAPSHOT_INTERVAL_SECS;
+    let middle_timestamp = (u64::from(snapshot_count / 2) + 1) * SNAPSHOT_INTERVAL_SECS;
+    let last_timestamp = u64::from(snapshot_count) * SNAPSHOT_INTERVAL_SECS;
+    let cases = [
+        (first_timestamp - 1, None),
+        (first_timestamp, Some(first_timestamp)),
+        (middle_timestamp + 1, Some(middle_timestamp)),
+        (last_timestamp, Some(last_timestamp)),
+        (
+            last_timestamp + SNAPSHOT_INTERVAL_SECS,
+            Some(last_timestamp),
+        ),
+    ];
+
+    for (target_timestamp, expected_timestamp) in cases {
+        let (anchor, comparisons) = snapshot_search_metrics_for_test(&snapshots, target_timestamp);
+        assert_eq!(
+            anchor.map(|snapshot| snapshot.timestamp),
+            expected_timestamp,
+            "wrong anchor for target {target_timestamp}"
+        );
+        assert!(
+            comparisons <= binary_search_budget(snapshot_count),
+            "target {target_timestamp} exceeded the per-size budget"
+        );
+        assert!(comparisons <= TWAP_READ_SEARCH_COMPARISON_BUDGET);
+    }
+}


### PR DESCRIPTION
Close #1159
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
