### PR TITLE
feat: add vesting grant-merge entrypoint consolidating multiple grants

### DIFF
--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -657,6 +657,56 @@ impl VestingContract {
         }
         total
     }
+
+    /// Merge all active (non-revoked) grants for `grantee` into a single consolidated grant.
+    ///
+    /// The resulting grant has:
+    /// - `total` = sum of all active grants' remaining (`total - claimed`) amounts
+    /// - `claimed` = 0 (fresh start on the merged grant)
+    /// - `start_seconds` = current `now`
+    /// - `duration_seconds` = `merge_duration`
+    /// - `cliff_seconds` = 0 (no cliff on merged grant — vesting started already)
+    ///
+    /// All original active grants are revoked and replaced by the single merged grant.
+    /// Returns the merged grant's total, or `VestingError::NoSuchGrant` if the grantee
+    /// has no active grants.
+    pub fn merge_grants(
+        &mut self,
+        caller: &str,
+        grantee: &str,
+        now: u64,
+        merge_duration: u64,
+    ) -> Result<u128, VestingError> {
+        if self.admin != caller {
+            return Err(VestingError::Unauthorized);
+        }
+        let grants = self.grants.get_mut(grantee).ok_or(VestingError::NoSuchGrant)?;
+
+        let mut merged_total: u128 = 0;
+        for grant in grants.iter_mut() {
+            if !grant.revoked {
+                let remaining = grant.total.saturating_sub(grant.claimed);
+                merged_total = merged_total.saturating_add(remaining);
+                grant.revoked = true;
+            }
+        }
+        if merged_total == 0 {
+            return Err(VestingError::NoSuchGrant);
+        }
+
+        let merged = Grant {
+            grantee: grantee.to_string(),
+            total: merged_total,
+            claimed: 0,
+            released: 0,
+            start_seconds: now,
+            duration_seconds: merge_duration,
+            cliff_seconds: 0,
+            revoked: false,
+        };
+        grants.push(merged);
+        Ok(merged_total)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1265

Adds merge_grants(caller, grantee, now, merge_duration) to VestingContract. Revokes all active grants for the grantee, sums remaining (unclaimed) tokens, and replaces them with a single merged grant under a new vesting schedule.