### PR TITLE
fix: bound bridge quorum proof vectors

### DIFF
--- a/stellar-lend/contracts/bridge/QUORUM_PROOF_BOUNDS.md
+++ b/stellar-lend/contracts/bridge/QUORUM_PROOF_BOUNDS.md
@@ -1,0 +1,50 @@
+# Quorum Proof Bounds
+
+`Bridge::rotate_validators` accepts a quorum proof from the current validator set
+before it installs a new validator set. The proof vector is supplied by the
+caller, so its size and signer contents must be bounded before any expensive
+signature verification runs.
+
+## Bound
+
+`verify_quorum_proof` rejects any proof vector with more entries than the current
+validator set has unique validators:
+
+```text
+proofs.len() <= current_validator_set.len()
+```
+
+The current set is the correct bound because every proof signer must be a member
+of the current set. A larger proof cannot add valid voting power; it can only
+force redundant parsing, membership checks, and signature work.
+
+## Duplicate Signers
+
+Each signer public key may appear at most once in the proof vector. Duplicate
+proof entries are rejected before payload construction and before any signature
+verification.
+
+This is stricter than counting a duplicate once. Rejecting the whole proof makes
+malformed or spammy relay input visible to callers and prevents an attacker from
+padding a rotation attempt with repeated signatures.
+
+## DoS Rationale
+
+Signature verification dominates rotation cost. Without a proof-vector bound, an
+attacker can submit a very large `proofs` list with duplicated keys and force the
+bridge to do work unrelated to the number of validators.
+
+The early checks keep worst-case proof processing proportional to the current
+validator set:
+
+```text
+O(current_validator_set_size)
+```
+
+The verifier still preserves the existing valid-proof behavior:
+
+- an exact-quorum proof is accepted,
+- a proof with one entry per current validator is accepted when signatures are valid,
+- a below-quorum proof is rejected as insufficient,
+- paused validator signatures remain ignored for quorum weight after the vector
+  has passed the size and duplicate checks.

--- a/stellar-lend/contracts/bridge/README.md
+++ b/stellar-lend/contracts/bridge/README.md
@@ -14,6 +14,7 @@ Key features
 |---|---|
 | [SECURITY_NOTES.md](./SECURITY_NOTES.md) | Bridge validator rotation threat model and inbound-cap security rationale |
 | [INBOUND_WINDOW_TUNING.md](./INBOUND_WINDOW_TUNING.md) | Rolling-window cap algorithm and operator parameter-selection guide |
+| [QUORUM_PROOF_BOUNDS.md](./QUORUM_PROOF_BOUNDS.md) | Quorum-proof vector size and duplicate-signer DoS bounds |
 | [WINDOW_GUARD.md](./WINDOW_GUARD.md) | Window-boundary guard rationale for zero windows, clock rollback, and overflow |
 | [EPOCH_INVARIANTS.md](./EPOCH_INVARIANTS.md) | Epoch monotonicity and retired-validator replay invariants |
 | [VALIDATORSET_INVARIANTS.md](./VALIDATORSET_INVARIANTS.md) | Validator-set deduplication and quorum threshold invariants |

--- a/stellar-lend/contracts/bridge/VALIDATORSET_INVARIANTS.md
+++ b/stellar-lend/contracts/bridge/VALIDATORSET_INVARIANTS.md
@@ -28,8 +28,8 @@ For every generated validator set:
 
 `len()` now means the number of unique validator public keys, not the raw byte
 vector length. That matches how quorum proofs are counted in
-`Bridge::verify_quorum_proof`, which already deduplicates signers before
-comparing them to the threshold.
+`Bridge::verify_quorum_proof`, which now rejects duplicate proof signers before
+comparing unique valid signatures to the threshold.
 
 ## Worked example
 

--- a/stellar-lend/contracts/bridge/src/lib.rs
+++ b/stellar-lend/contracts/bridge/src/lib.rs
@@ -430,6 +430,13 @@ impl Bridge {
     /// Paused validator signatures are *silently skipped* — they are neither
     /// verified nor counted toward the quorum, and they do not cause the
     /// overall proof to fail.
+    ///
+    /// The supplied proof vector is attacker-influenced, so it is bounded before
+    /// any signature verification work runs. A proof cannot contain more
+    /// entries than there are unique validators in the current set, and each
+    /// signer public key may appear at most once. These checks cap verifier
+    /// work at O(current validator set size) and reject duplicate-laden proofs
+    /// before they can burn CPU on redundant signature checks.
     fn verify_quorum_proof(
         &self,
         new_set: &ValidatorSet,
@@ -438,6 +445,23 @@ impl Bridge {
     ) -> Result<()> {
         if proofs.is_empty() {
             return Err(anyhow!("empty proofs"));
+        }
+
+        let max_proofs = self.validators.len();
+        if proofs.len() > max_proofs {
+            return Err(anyhow!(
+                "quorum proof has {} entries but current validator set has {} unique validators",
+                proofs.len(),
+                max_proofs
+            ));
+        }
+
+        let mut seen_proof_signers: HashSet<Vec<u8>> = HashSet::new();
+        for (pk, _) in proofs.iter() {
+            let key_bytes = pk.to_bytes().to_vec();
+            if !seen_proof_signers.insert(key_bytes) {
+                return Err(anyhow!("quorum proof contains duplicate signer"));
+            }
         }
 
         // Domain-separated payload: bincode(domain_tag, bridge_id, new_set_bytes, epoch).
@@ -462,11 +486,6 @@ impl Bridge {
             // down the rest of the proof).
             let key_bytes = pk.to_bytes().to_vec();
             if self.paused_validators.contains(&key_bytes) {
-                continue;
-            }
-
-            // Deduplicate within the active subset.
-            if unique_active_signers.contains(&key_bytes) {
                 continue;
             }
 
@@ -529,20 +548,8 @@ impl Bridge {
             return Err(anyhow!("invalid epoch: must be current_epoch + 1"));
         }
 
-        // ── Validate new_set size bounds ──────────────────────────────────
-        let unique_count = new_set.len();
-        if unique_count < MIN_VALIDATORS {
-            return Err(anyhow!("{}", BridgeError::ValidatorSetTooSmall));
-        }
-        if unique_count > MAX_VALIDATORS {
-            return Err(anyhow!("{}", BridgeError::ValidatorSetTooLarge));
-        }
-
-        // ── Validate no duplicate keys ────────────────────────────────────
-        // We check the *raw* (pre-dedup) list.  The `len()` method deduplicates
-        // internally, but we also want to reject sets that contain any duplicate
-        // entries at all — they are never legitimate and always indicate an
-        // operator error.
+        // Reject raw duplicate keys before size checks so callers get the
+        // most specific error for malformed validator-set input.
         {
             let mut seen = std::collections::HashSet::new();
             for key_bytes in &new_set.validators {
@@ -550,6 +557,15 @@ impl Bridge {
                     return Err(anyhow!("{}", BridgeError::DuplicateValidatorKey));
                 }
             }
+        }
+
+        // ── Validate new_set size bounds ──────────────────────────────────
+        let unique_count = new_set.len();
+        if unique_count < MIN_VALIDATORS {
+            return Err(anyhow!("{}", BridgeError::ValidatorSetTooSmall));
+        }
+        if unique_count > MAX_VALIDATORS {
+            return Err(anyhow!("{}", BridgeError::ValidatorSetTooLarge));
         }
 
         // Compute churn: symmetric difference size between current set and new set.
@@ -883,6 +899,9 @@ mod rotation_test;
 
 #[cfg(test)]
 mod domain_separation_test;
+
+#[cfg(test)]
+mod quorum_proof_bound_test;
 
 #[cfg(test)]
 mod inbound_cap_test;

--- a/stellar-lend/contracts/bridge/src/quorum_proof_bound_test.rs
+++ b/stellar-lend/contracts/bridge/src/quorum_proof_bound_test.rs
@@ -1,0 +1,173 @@
+#[cfg(test)]
+mod quorum_proof_bound_tests {
+    use crate::{Bridge, ValidatorSet};
+    use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature, Signer};
+
+    /// Build a deterministic ed25519 keypair for reproducible quorum tests.
+    fn det_keypair(index: u8) -> Keypair {
+        let mut seed = [0u8; 32];
+        seed[0] = index.wrapping_add(1);
+        for i in 1..32 {
+            seed[i] = index.wrapping_mul(11).wrapping_add(i as u8);
+        }
+
+        let secret = SecretKey::from_bytes(&seed).expect("valid secret key");
+        let public: PublicKey = (&secret).into();
+        let mut combined = [0u8; 64];
+        combined[..32].copy_from_slice(&seed);
+        combined[32..].copy_from_slice(public.as_bytes());
+        Keypair::from_bytes(&combined).expect("valid keypair")
+    }
+
+    /// Build `n` deterministic keypairs with adjacent indices.
+    fn det_keypairs(start: u8, n: u8) -> Vec<Keypair> {
+        (start..start + n).map(det_keypair).collect()
+    }
+
+    /// Convert keypairs into the byte-backed validator-set representation.
+    fn validator_set_from(kps: &[Keypair]) -> ValidatorSet {
+        ValidatorSet {
+            validators: kps.iter().map(|kp| kp.public.to_bytes().to_vec()).collect(),
+        }
+    }
+
+    /// Sign a bridge rotation payload with the supplied signers.
+    fn sign_rotation(
+        bridge: &Bridge,
+        new_set: &ValidatorSet,
+        epoch: u64,
+        signers: &[&Keypair],
+    ) -> Vec<(PublicKey, Signature)> {
+        let payload = Bridge::quorum_proof_payload(&bridge.bridge_id, new_set, epoch)
+            .expect("payload serialization must succeed");
+
+        signers
+            .iter()
+            .map(|kp| (kp.public, kp.sign(&payload)))
+            .collect()
+    }
+
+    /// Return a syntactically valid but cryptographically invalid signature.
+    fn invalid_signature() -> Signature {
+        Signature::from_bytes(&[0u8; 64]).expect("zero bytes form a signature object")
+    }
+
+    /// Rejects proof vectors larger than the current validator set before
+    /// membership or signature verification can run.
+    #[test]
+    fn oversized_proof_vector_is_rejected_before_signature_work() {
+        let current = det_keypairs(0, 4);
+        let next = det_keypairs(10, 4);
+        let initial = validator_set_from(&current);
+        let new_set = validator_set_from(&next);
+        let mut bridge = Bridge::new(initial);
+
+        let outsider = det_keypair(99);
+        let mut proofs = sign_rotation(
+            &bridge,
+            &new_set,
+            1,
+            &[&current[0], &current[1], &current[2], &current[3]],
+        );
+        proofs.push((outsider.public, invalid_signature()));
+
+        let err = bridge
+            .rotate_validators(new_set, 1, proofs)
+            .expect_err("proof vector larger than the current set must reject");
+        assert!(
+            err.to_string().contains("current validator set has 4"),
+            "expected size-bound error before signer verification, got: {err}"
+        );
+        assert_eq!(bridge.epoch, 0);
+    }
+
+    /// Rejects duplicate signer entries before any signature is verified.
+    #[test]
+    fn duplicate_signer_entries_are_rejected_up_front() {
+        let current = det_keypairs(0, 4);
+        let next = det_keypairs(10, 4);
+        let initial = validator_set_from(&current);
+        let new_set = validator_set_from(&next);
+        let mut bridge = Bridge::new(initial);
+
+        let mut proofs = sign_rotation(&bridge, &new_set, 1, &[&current[0], &current[1]]);
+        proofs.push((current[0].public, invalid_signature()));
+
+        let err = bridge
+            .rotate_validators(new_set, 1, proofs)
+            .expect_err("duplicate signer entries must reject");
+        assert!(
+            err.to_string().contains("duplicate signer"),
+            "expected duplicate-signer error before signature verification, got: {err}"
+        );
+        assert_eq!(bridge.epoch, 0);
+    }
+
+    /// A proof vector exactly as large as the current set is still allowed when
+    /// all entries are unique and valid.
+    #[test]
+    fn proof_equal_to_current_validator_count_is_allowed() {
+        let current = det_keypairs(0, 4);
+        let next = det_keypairs(10, 4);
+        let initial = validator_set_from(&current);
+        let new_set = validator_set_from(&next);
+        let mut bridge = Bridge::new(initial);
+
+        let proofs = sign_rotation(
+            &bridge,
+            &new_set,
+            1,
+            &[&current[0], &current[1], &current[2], &current[3]],
+        );
+
+        bridge
+            .rotate_validators(new_set, 1, proofs)
+            .expect("unique full-set proof should satisfy quorum");
+        assert_eq!(bridge.epoch, 1);
+    }
+
+    /// Preserves the existing exact-quorum success path for valid in-bound
+    /// proofs.
+    #[test]
+    fn exact_quorum_unique_proof_is_allowed() {
+        let current = det_keypairs(0, 4);
+        let next = det_keypairs(10, 4);
+        let initial = validator_set_from(&current);
+        let new_set = validator_set_from(&next);
+        let mut bridge = Bridge::new(initial);
+
+        let proofs = sign_rotation(
+            &bridge,
+            &new_set,
+            1,
+            &[&current[0], &current[1], &current[2]],
+        );
+
+        bridge
+            .rotate_validators(new_set, 1, proofs)
+            .expect("three unique signers meet quorum for four validators");
+        assert_eq!(bridge.epoch, 1);
+    }
+
+    /// Preserves the existing below-quorum rejection path for valid but
+    /// insufficient unique proofs.
+    #[test]
+    fn below_quorum_unique_proof_still_rejects() {
+        let current = det_keypairs(0, 4);
+        let next = det_keypairs(10, 4);
+        let initial = validator_set_from(&current);
+        let new_set = validator_set_from(&next);
+        let mut bridge = Bridge::new(initial);
+
+        let proofs = sign_rotation(&bridge, &new_set, 1, &[&current[0], &current[1]]);
+
+        let err = bridge
+            .rotate_validators(new_set, 1, proofs)
+            .expect_err("two unique signers are below quorum for four validators");
+        assert!(
+            err.to_string().contains("insufficient quorum"),
+            "expected quorum error, got: {err}"
+        );
+        assert_eq!(bridge.epoch, 0);
+    }
+}

--- a/stellar-lend/contracts/bridge/src/rotation_test.rs
+++ b/stellar-lend/contracts/bridge/src/rotation_test.rs
@@ -5,7 +5,7 @@
 //!   - Non-incrementing epoch rejection (same epoch, stale epoch, jump >1)
 //!   - Exactly-threshold acceptance
 //!   - Below-threshold rejection (threshold - 1 proofs)
-//!   - Duplicate signer in proof set (counted only once)
+//!   - Duplicate signer in proof set rejection
 //!   - Signer not in current validator set
 //!   - Empty proof list
 //!   - Replay of inbound message signed under a rotated-out validator set
@@ -14,7 +14,6 @@
 #[cfg(test)]
 mod rotation_tests {
     use crate::{Bridge, ValidatorSet};
-    use bincode;
     use ed25519_dalek::{Keypair, Signature, Signer};
 
     // ---------------------------------------------------------------------------
@@ -234,11 +233,10 @@ mod rotation_tests {
     // Duplicate signer tests
     // ---------------------------------------------------------------------------
 
-    /// Duplicate entries for the same signer must be deduplicated — they should
-    /// count as only one vote. If deduplication causes the count to drop below
-    /// the quorum threshold the rotation must be rejected.
+    /// Duplicate entries for the same signer are rejected before quorum
+    /// counting or signature verification.
     #[test]
-    fn test_duplicate_signer_counts_once_below_threshold() {
+    fn test_duplicate_signer_rejected_before_quorum_counting() {
         // 4 validators → threshold = 3
         // Provide 3 proof entries but two of them are for the same keypair → unique = 2 < 3
         let kps = det_keypairs(4);
@@ -259,16 +257,18 @@ mod rotation_tests {
         proofs.push((kps[1].public, kps[1].sign(&payload)));
 
         let result = bridge.rotate_validators(new_set, epoch, proofs);
+        assert!(result.is_err(), "duplicate signer must be rejected");
+        let msg = result.unwrap_err().to_string();
         assert!(
-            result.is_err(),
-            "duplicate signer must not inflate quorum count"
+            msg.contains("duplicate signer"),
+            "error should mention duplicate signer, got: {msg}"
         );
     }
 
-    /// Even with a duplicate, if the remaining unique signers still meet the
-    /// threshold the rotation should succeed.
+    /// Duplicate entries are rejected even if the remaining unique signers
+    /// would otherwise meet the quorum threshold.
     #[test]
-    fn test_duplicate_signer_still_meets_threshold() {
+    fn test_duplicate_signer_rejected_even_if_unique_signers_meet_threshold() {
         // 4 validators → threshold = 3
         // Provide 4 entries: kps[0] twice, kps[1] once, kps[2] once → 3 unique = threshold
         let kps = det_keypairs(4);
@@ -289,10 +289,17 @@ mod rotation_tests {
         proofs.push((kps[1].public, kps[1].sign(&payload)));
         proofs.push((kps[2].public, kps[2].sign(&payload)));
 
-        bridge
-            .rotate_validators(new_set, epoch, proofs)
-            .expect("3 unique valid signers must meet threshold for 4-validator set");
-        assert_eq!(bridge.epoch, 1);
+        let result = bridge.rotate_validators(new_set, epoch, proofs);
+        assert!(
+            result.is_err(),
+            "duplicate signer must reject even when unique signers meet threshold"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("duplicate signer"),
+            "error should mention duplicate signer, got: {msg}"
+        );
+        assert_eq!(bridge.epoch, 0);
     }
 
     // ---------------------------------------------------------------------------

--- a/stellar-lend/contracts/bridge/src/validator_bounds_test.rs
+++ b/stellar-lend/contracts/bridge/src/validator_bounds_test.rs
@@ -17,7 +17,6 @@
 //! | `new_set` valid mid-size rotation | **Accepted** (if quorum met) |
 
 use crate::{Bridge, BridgeError, ValidatorSet, MIN_VALIDATORS, MAX_VALIDATORS};
-use bincode;
 use ed25519_dalek::{Keypair, Signature, Signer};
 
 // ---------------------------------------------------------------------------
@@ -58,14 +57,14 @@ fn validator_set_from(kps: &[Keypair]) -> ValidatorSet {
     }
 }
 
-/// Sign the rotation payload `(new_set_bytes, epoch)` with a subset of keypairs.
+/// Sign the canonical rotation payload with a subset of keypairs.
 /// Returns the proof vector expected by `rotate_validators`.
 fn sign_rotation(
     new_set: &ValidatorSet,
     epoch: u64,
     signers: &[&Keypair],
 ) -> Vec<(ed25519_dalek::PublicKey, Signature)> {
-    let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch))
+    let payload = Bridge::quorum_proof_payload(&[], new_set, epoch)
         .expect("serialization must not fail");
     signers
         .iter()

--- a/stellar-lend/contracts/bridge/src/validator_pause_test.rs
+++ b/stellar-lend/contracts/bridge/src/validator_pause_test.rs
@@ -81,7 +81,7 @@ mod validator_pause_tests {
     }
 
     fn sign_rotation(new_set: &ValidatorSet, epoch: u64, signers: &[&Keypair]) -> Vec<(ed25519_dalek::PublicKey, Signature)> {
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let payload = Bridge::quorum_proof_payload(&[], new_set, epoch).unwrap();
         signers
             .iter()
             .map(|kp| {
@@ -516,9 +516,9 @@ mod validator_pause_tests {
             .expect("paused-signer garbage must be silently skipped, not poison the proof");
     }
 
-    /// Paused validators are excluded from duplicate counting as well.
+    /// Duplicate paused signers are rejected before paused-signer skipping.
     #[test]
-    fn paused_signer_does_not_count_as_unique_vote() {
+    fn duplicate_paused_signer_is_rejected_up_front() {
         let (mut bridge, validators, guardian) = make_bridge_with_guardian(4, 200);
         let paused = &validators[0].public;
         bridge
@@ -529,21 +529,19 @@ mod validator_pause_tests {
         let new_set = validator_set_from(&next);
         let epoch = 1u64;
 
-        // Submit:
-        //   - paused signer twice (should be skipped both times — counted 0)
-        //   - validators[1] twice (should be deduped — counted 1)
-        //   - validators[2] once (counted 1)
-        // Total unique ACTIVE votes = 2. New threshold for active=3 is 3.
-        // 2 < 3 ⇒ must fail.
+        // The duplicate is rejected before the paused signer can be skipped.
         let mut proofs: Vec<(ed25519_dalek::PublicKey, Signature)> = Vec::new();
         proofs.push(signed_rotation_entry(&validators[0], &new_set, epoch));
         proofs.push(signed_rotation_entry(&validators[0], &new_set, epoch));
         proofs.push(signed_rotation_entry(&validators[1], &new_set, epoch));
-        proofs.push(signed_rotation_entry(&validators[1], &new_set, epoch));
-        proofs.push(signed_rotation_entry(&validators[2], &new_set, epoch));
 
         let result = bridge.rotate_validators(new_set, epoch, proofs);
-        assert!(result.is_err(), "unique active count of 2 < new threshold 3 must fail");
+        assert!(result.is_err(), "duplicate paused signer must be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("duplicate signer"),
+            "error should mention duplicate signer, got: {msg}"
+        );
     }
 
     fn signed_rotation_entry(
@@ -551,7 +549,7 @@ mod validator_pause_tests {
         new_set: &ValidatorSet,
         epoch: u64,
     ) -> (ed25519_dalek::PublicKey, Signature) {
-        let payload = bincode::serialize(&(new_set.to_bytes_vec(), epoch)).unwrap();
+        let payload = Bridge::quorum_proof_payload(&[], new_set, epoch).unwrap();
         let sig = kp.sign(&payload);
         (kp.public, sig)
     }


### PR DESCRIPTION
## Summary
- bound bridge quorum proof vectors to the current validator-set size before payload/signature work
- reject duplicate proof signers up front, including paused signer duplicates
- update bridge tests/docs and canonicalize stale rotation test helpers so the full bridge suite validates the verifier path

Closes #1282

## Validation
- `cargo +1.91.1 test -- --nocapture` from `stellar-lend/contracts/bridge` - 114 passed
- `git diff --check`

## Notes
- The suite still has one pre-existing warning for an unused `bincode` import in `epoch_monotonicity_proptest.rs`; this PR leaves that unrelated file untouched.