### PR TITLE
test: add calculate_utilization clamp tests with docs

### DIFF
--- a/stellar-lend/contracts/hello-world/docs/UTILIZATION_CLAMP_TESTS.md
+++ b/stellar-lend/contracts/hello-world/docs/UTILIZATION_CLAMP_TESTS.md
@@ -1,0 +1,21 @@
+# Utilization clamp tests
+
+## Rationale
+
+The `calculate_utilization` helper converts protocol totals into a utilization value expressed in basis points. The regression tests in this package verify the non-panicking edge cases around zero deposits, full utilization, and exact ratios that are important for downstream interest-rate math.
+
+## Worked example
+
+If the protocol has 1,000 deposits and 250 borrows, the utilization is:
+
+$$
+\frac{250 \times 10{,}000}{1{,}000} = 2{,}500 \text{ bps}
+$$
+
+That corresponds to 25% utilization. The tests assert that this value is returned exactly for representative ratios such as 25%, 50%, and 80%.
+
+## Edge cases covered
+
+- Zero deposits return zero instead of triggering a divide-by-zero panic.
+- Borrows that meet or exceed deposits clamp to the maximum utilization of 10,000 bps.
+- All returned values remain within the closed interval $[0, 10{,}000]$.

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -83,6 +83,8 @@ mod twap_maxbuffer_perf_test;
 mod twap_coverage_test;
 #[cfg(test)]
 mod cross_asset_storage_doc_test;
+#[cfg(test)]
+mod utilization_clamp_test;
 
 // Legacy test suite currently mismatches contract API and is excluded from CI compile.
 // #[cfg(test)]

--- a/stellar-lend/contracts/hello-world/src/utilization_clamp_test.rs
+++ b/stellar-lend/contracts/hello-world/src/utilization_clamp_test.rs
@@ -1,0 +1,86 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::interest_rate::{
+    calculate_utilization, initialize_interest_rate_config, set_protocol_totals, BASIS_POINTS_SCALE,
+};
+
+fn with_rate_contract<F, T>(env: &Env, f: F) -> T
+where
+    F: FnOnce(Address) -> T,
+{
+    let contract_id = env.register(crate::cross_asset::NoOpContract {}, ());
+    env.as_contract(&contract_id, || f(Address::generate(&env)))
+}
+
+fn init(env: &Env, admin: Address, total_deposits: i128, total_borrows: i128) {
+    initialize_interest_rate_config(env, admin).unwrap();
+    set_protocol_totals(env, total_deposits, total_borrows).unwrap();
+}
+
+fn assert_within_bounds(utilization: i128) {
+    assert!(utilization >= 0, "utilization should never be negative");
+    assert!(
+        utilization <= BASIS_POINTS_SCALE,
+        "utilization should never exceed 100%"
+    );
+}
+
+#[test]
+fn calculate_utilization_returns_zero_without_divide_by_zero_when_deposits_are_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    with_rate_contract(&env, |admin| {
+        init(&env, admin, 0, 1_000);
+
+        let utilization = calculate_utilization(&env).unwrap();
+        assert_eq!(utilization, 0);
+        assert_within_bounds(utilization);
+    });
+}
+
+#[test]
+fn calculate_utilization_clamps_to_full_utilization_when_borrows_cover_deposits() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    with_rate_contract(&env, |admin| {
+        init(&env, admin.clone(), 1_000, 1_000);
+
+        let equal_case = calculate_utilization(&env).unwrap();
+        assert_eq!(equal_case, BASIS_POINTS_SCALE);
+        assert_within_bounds(equal_case);
+
+        set_protocol_totals(&env, 1_000, 1_500).unwrap();
+
+        let over_borrow_case = calculate_utilization(&env).unwrap();
+        assert_eq!(over_borrow_case, BASIS_POINTS_SCALE);
+        assert_within_bounds(over_borrow_case);
+    });
+}
+
+#[test]
+fn calculate_utilization_matches_exact_bps_for_common_ratios() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    with_rate_contract(&env, |admin| {
+        init(&env, admin.clone(), 1_000, 0);
+
+        let cases = [
+            (1_000, 250, 2_500),
+            (1_000, 500, 5_000),
+            (1_000, 800, 8_000),
+        ];
+
+        for (deposits, borrows, expected) in cases {
+            set_protocol_totals(&env, deposits, borrows).unwrap();
+
+            let utilization = calculate_utilization(&env).unwrap();
+            assert_eq!(utilization, expected);
+            assert_within_bounds(utilization);
+        }
+    });
+}


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed

Closes #1237