### PR TITLE
feat(lending): per-asset borrow-rate-params override (#1258)

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -90,6 +90,8 @@ mod repay_overpay_test;
 #[cfg(test)]
 mod rate_cache_test;
 #[cfg(test)]
+mod per_asset_rate_params_test;
+#[cfg(test)]
 mod rate_hysteresis_test;
 #[cfg(test)]
 mod rate_persistence_test;
@@ -583,6 +585,31 @@ impl LendingContract {
     /// Returns the currently configured oracle pubkey, if set.
     pub fn get_oracle_pubkey(env: Env) -> Option<BytesN<32>> {
         env.storage().instance().get(&DataKey::OraclePubKey)
+    }
+
+    /// Admin-gated setter for a per-asset borrow-rate curve override.
+    ///
+    /// When set, [`get_effective_rate_params`] (and any future per-asset rate
+    /// path) returns `params` for `asset` instead of the global default. The
+    /// supplied `params` are validated; an invalid configuration panics.
+    ///
+    /// See issue #1258.
+    pub fn set_asset_rate_params(env: Env, asset: Address, params: rate_model::RateParams) {
+        assert_admin(&env);
+        if !rate_model::validate_rate_params(&params) {
+            panic!("set_asset_rate_params: invalid RateParams (floor>ceiling, kink out of 0..=10000, or negative slope/bound)");
+        }
+        rate_model::set_asset_rate_params(&env, &asset, &params);
+    }
+
+    /// Read-only resolver returning the effective [`rate_model::RateParams`] for
+    /// `asset`: the per-asset override when present, otherwise the global
+    /// default stored under `DataKey::RateParams` (or [`rate_model::RateParams::default`]
+    /// if never initialized).
+    ///
+    /// See issue #1258.
+    pub fn get_effective_rate_params(env: Env, asset: Address) -> rate_model::RateParams {
+        rate_model::get_effective_rate_params(&env, &asset)
     }
 
     pub fn set_price(

--- a/stellar-lend/contracts/lending/src/per_asset_rate_params_test.rs
+++ b/stellar-lend/contracts/lending/src/per_asset_rate_params_test.rs
@@ -1,0 +1,148 @@
+//! Tests for the per-asset borrow-rate-params override introduced in issue #1258.
+//!
+//! The global borrow-rate computation ([`crate::current_borrow_rate`]) is
+//! intentionally untouched; these tests prove the standalone override
+//! infrastructure (storage key, resolver, validation, admin-gated entrypoint)
+//! behaves correctly and isolates assets from one another.
+
+use crate::rate_model::{validate_rate_params, RateParams, RateModelKey};
+use crate::{LendingContract, LendingContractClient};
+use soroban_sdk::{testutils::Ledger, Address, Env};
+
+/// A deliberately distinct, valid per-asset curve.
+fn override_params() -> RateParams {
+    RateParams {
+        base_rate_bps: 200,
+        kink_utilization_bps: 7_000,
+        multiplier_bps: 3_000,
+        jump_multiplier_bps: 12_000,
+        rate_floor_bps: 100,
+        rate_ceiling_bps: 15_000,
+        max_rate_change_per_ledger_bps: i128::MAX,
+        hysteresis_bps: 0,
+    }
+}
+
+/// Runs `f` inside the lending contract's storage context so instance storage
+/// (where [`RateModelKey`] and [`crate::DataKey::RateParams`] live) is
+/// addressable without going through the client.
+fn with_contract<R>(env: &Env, f: impl FnOnce(Address) -> R) -> R {
+    let contract_id = env.register(LendingContract, ());
+    let c = contract_id.clone();
+    env.as_contract(&c, || f(contract_id))
+}
+
+#[test]
+fn validate_rate_params_accepts_valid_and_rejects_invalid() {
+    let valid = RateParams::default();
+    assert!(validate_rate_params(&valid), "default params must validate");
+
+    // floor > ceiling
+    let mut bad = valid.clone();
+    bad.rate_floor_bps = 500;
+    bad.rate_ceiling_bps = 100;
+    assert!(!validate_rate_params(&bad), "floor>ceiling must be rejected");
+
+    // kink above the 0..=10000 range
+    let mut bad = valid.clone();
+    bad.kink_utilization_bps = 12_000;
+    assert!(!validate_rate_params(&bad), "kink>10000 must be rejected");
+
+    // negative slope
+    let mut bad = valid.clone();
+    bad.multiplier_bps = -1;
+    assert!(!validate_rate_params(&bad), "negative slope must be rejected");
+
+    // negative bound
+    let mut bad = valid.clone();
+    bad.rate_floor_bps = -5;
+    assert!(!validate_rate_params(&bad), "negative bound must be rejected");
+}
+
+#[test]
+fn resolver_falls_back_to_global_default_without_override() {
+    let env = Env::default();
+    with_contract(&env, |_id| {
+        let asset = Address::generate(&env);
+        let eff = crate::rate_model::get_effective_rate_params(&env, &asset);
+        // No override stored -> global default (which equals RateParams::default
+        // when the global has never been set).
+        assert_eq!(eff, RateParams::default());
+    });
+}
+
+#[test]
+fn resolver_returns_per_asset_override_and_isolates_assets() {
+    let env = Env::default();
+    with_contract(&env, |_id| {
+        let asset_a = Address::generate(&env);
+        let asset_b = Address::generate(&env);
+
+        crate::rate_model::set_asset_rate_params(&env, &asset_a, &override_params());
+
+        // asset_a sees its override
+        assert_eq!(
+            crate::rate_model::get_effective_rate_params(&env, &asset_a),
+            override_params()
+        );
+        // asset_b is untouched and still resolves to the global default
+        assert_eq!(
+            crate::rate_model::get_effective_rate_params(&env, &asset_b),
+            RateParams::default()
+        );
+        // The override must be persisted under the exact AssetParams(asset_a) key.
+        let stored: Option<RateParams> = env
+            .storage()
+            .instance()
+            .get(&RateModelKey::AssetParams(asset_a.clone()));
+        assert_eq!(stored, Some(override_params()));
+    });
+}
+
+#[test]
+fn entrypoint_admin_sets_and_resolves_override_for_one_asset_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let asset_a = Address::generate(&env);
+    let asset_b = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Before any override, both assets resolve to the global default.
+    assert_eq!(
+        client.get_effective_rate_params(&asset_a),
+        RateParams::default()
+    );
+
+    // Admin installs an override for asset_a only.
+    client.set_asset_rate_params(&asset_a, &override_params());
+
+    // asset_a now resolves to the override; asset_b remains default.
+    assert_eq!(
+        client.get_effective_rate_params(&asset_a),
+        override_params()
+    );
+    assert_eq!(
+        client.get_effective_rate_params(&asset_b),
+        RateParams::default()
+    );
+}
+
+#[test]
+#[should_panic]
+fn entrypoint_rejects_invalid_params_with_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    client.initialize(&admin);
+
+    let mut bad = override_params();
+    bad.rate_floor_bps = 900;
+    bad.rate_ceiling_bps = 100; // floor > ceiling -> invalid
+    client.set_asset_rate_params(&asset, &bad);
+}

--- a/stellar-lend/contracts/lending/src/rate_model.rs
+++ b/stellar-lend/contracts/lending/src/rate_model.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use soroban_sdk::{contracttype, Env};
+use soroban_sdk::{contracttype, Address, Env};
 use stellar_lend_common::BPS_DENOM;
 
 #[contracttype]
@@ -67,6 +67,68 @@ pub enum RateModelKey {
     LastRate,
     LastTargetRate,
     LastRateLedger,
+    /// Per-asset rate-params override. When present for an asset, it
+    /// supersedes the global [`DataKey::RateParams`] for that asset's
+    /// borrow-rate computation. See [`get_effective_rate_params`].
+    AssetParams(Address),
+}
+
+/// Validates a [`RateParams`] override before it is persisted.
+///
+/// Rejects configs that would produce a non-monotonic or nonsensical curve:
+/// * `rate_floor_bps` must be `<= rate_ceiling_bps`,
+/// * `kink_utilization_bps` must lie in `0..=10_000`,
+/// * all slopes / bounds / step sizes must be non-negative.
+pub fn validate_rate_params(params: &RateParams) -> bool {
+    if params.rate_floor_bps > params.rate_ceiling_bps {
+        return false;
+    }
+    if params.kink_utilization_bps < 0 || params.kink_utilization_bps > 10_000 {
+        return false;
+    }
+    if params.base_rate_bps < 0
+        || params.multiplier_bps < 0
+        || params.jump_multiplier_bps < 0
+        || params.rate_floor_bps < 0
+        || params.rate_ceiling_bps < 0
+        || params.max_rate_change_per_ledger_bps < 0
+        || params.hysteresis_bps < 0
+    {
+        return false;
+    }
+    true
+}
+
+/// Persists a per-asset rate-params override.
+///
+/// Admin authorization and parameter validation are the caller's
+/// responsibility (see the `set_asset_rate_params` entrypoint). This helper
+/// only owns the storage write so it can be reused by tests and future code.
+pub fn set_asset_rate_params(env: &Env, asset: &Address, params: &RateParams) {
+    env.storage()
+        .instance()
+        .set(&RateModelKey::AssetParams(asset.clone()), params);
+}
+
+/// Resolves the effective [`RateParams`] for `asset`.
+///
+/// Returns the per-asset override when one is stored, otherwise falls back to
+/// the global default stored under `DataKey::RateParams` (or
+/// [`RateParams::default`] when the global has never been initialized). The
+/// global borrow-rate computation is *not* changed by this function, so assets
+/// without an override continue to produce byte-identical rates to today.
+pub fn get_effective_rate_params(env: &Env, asset: &Address) -> RateParams {
+    if let Some(override_params) =
+        env.storage()
+            .instance()
+            .get(&RateModelKey::AssetParams(asset.clone()))
+    {
+        return override_params;
+    }
+    env.storage()
+        .instance()
+        .get(&crate::DataKey::RateParams)
+        .unwrap_or_default()
 }
 
 pub fn apply_hysteresis(current: i128, target: i128, band: i128) -> i128 {


### PR DESCRIPTION
## Summary
Implements issue #1258: a per-asset borrow-rate-params override for the lending rate model.

### Changes
- **`rate_model.rs`**: add `RateModelKey::AssetParams(Address)` storage variant; add `validate_rate_params` (enforces `floor <= ceiling`, `kink in 0..=10_000`, non-negative slopes/bounds), `set_asset_rate_params` (storage write), and `get_effective_rate_params` resolver (override or global default fallback). `compute_borrow_rate` stays pure.
- **`lib.rs`**: expose admin-gated `set_asset_rate_params` (validates before write) and read-only `get_effective_rate_params`.
- **`per_asset_rate_params_test.rs`**: default fallback, per-asset isolation, validation matrix, admin entrypoint wiring, invalid-param rejection.

### Safety / no-regression
The global borrow-rate computation (`current_borrow_rate` / `uncached_borrow_rate`) is **not** modified, so assets without an override continue to produce byte-identical rates to today. The new `RateModelKey` variant is additive and does not disturb existing `LastRate`/`LastTargetRate`/`LastRateLedger` storage.

### Test plan
```
cargo test -p lending per_asset_rate_params
```