### PR TITLE
fix: wire up signer_shrink_guard_test in multisig lib.rs (#1474)

### DIFF
--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -419,3 +419,5 @@ mod tests {
 
 #[cfg(test)]
 mod execution_router_test;
+#[cfg(test)]
+mod signer_shrink_guard_test;


### PR DESCRIPTION
Closes #1474

Add `#[cfg(test)] mod signer_shrink_guard_test;` to
`stellar-lend/contracts/multisig/src/lib.rs` so the test file
is actually compiled and executed by `cargo test -p stellarlend-multisig`.