### PR TITLE
fix: wire up error_codes_test in amm lib.rs (#1475)

### DIFF
--- a/stellar-lend/contracts/amm/src/lib.rs
+++ b/stellar-lend/contracts/amm/src/lib.rs
@@ -892,3 +892,5 @@ pub fn get_fee_tiers(env: Env) -> Vec<u128> {
 mod dynamic_fee_test;
 #[cfg(test)]
 mod inverse_swap_proptest;
+#[cfg(test)]
+mod error_codes_test;


### PR DESCRIPTION
Closes #1475

Add `#[cfg(test)] mod error_codes_test;` to
`stellar-lend/contracts/amm/src/lib.rs` so the test file
is actually compiled and executed by `cargo test -p stellarlend-amm`.