### PR TITLE
fix: lower DEFAULT_MAX_FLASH_BPS from 100% to 50% (#1483)

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -145,7 +145,7 @@ const DEFAULT_ORACLE_MAX_AGE_SECS: u64 = 3600;
 const ORACLE_SIGNATURE_DOMAIN: &[u8] = b"StellarLendOracle";
 const BPS_DENOM: i128 = 10_000;
 const SCHEMA_VERSION_V1: u32 = 1;
-const DEFAULT_MAX_FLASH_BPS: i128 = 10_000;
+const DEFAULT_MAX_FLASH_BPS: i128 = 5_000;
 /// Maximum number of utilization samples retained in persistent storage.
 ///
 /// Samples are kept in an oldest-first bounded vector internally. When the cap


### PR DESCRIPTION
Closes #1483

Change DEFAULT_MAX_FLASH_BPS from 10_000 (100%) to 5_000 (50%)
to prevent full-treasury flash loans on freshly-deployed pools
before an admin has explicitly configured a higher limit.