### PR TITLE
test(amm): wire error code tests

### DIFF
--- a/stellar-lend/contracts/amm/src/lib.rs
+++ b/stellar-lend/contracts/amm/src/lib.rs
@@ -4,6 +4,8 @@ pub mod liquidity_math;
 pub mod math;
 
 #[cfg(test)]
+mod error_codes_test;
+#[cfg(test)]
 mod fee_accrual_overflow_test;
 #[cfg(test)]
 mod stored_fee_test;


### PR DESCRIPTION
## Summary

- Register the existing `error_codes_test` module in the AMM crate test build.
- Keep the declaration behind `cfg(test)` so production behavior is unchanged.

## Type of change

- [x] Bug fix

## Contracts Release Checklist

### Functional tests
- [x] Existing AMM error-code checks are now discovered by the test build.
- [ ] `cargo test -p stellarlend-amm` passes.

### CI
- [ ] `cargo fmt --check` passes.
- [ ] `cargo clippy -- -D warnings` passes.
- [x] No secrets or key material committed.

The focused Cargo build confirms that `error_codes_test.rs` is now compiled. The package cannot complete compilation on the current `main` baseline because the AMM crate already contains unrelated contract macro, return-type, and stale-test API errors.

No storage, public API, event, arithmetic, authorization, or upgrade behavior is changed.

Closes #1475