### PR TITLE
fix: repair corrupted liquidate function and reentrancy test

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -1680,7 +1680,7 @@ impl LendingContract {
     /// interaction during a protocol pause or emergency shutdown.
     pub fn repay_flash_loan(env: Env, payer: Address, asset: Address, amount: i128) {
         check_pause_status(&env, ProtocolAction::FlashLoan);
-        check_emergency_status(grep -n -A10 "pub struct AssetParams" contracts/lending/src/lib.rs&env, ProtocolAction::FlashLoan);
+        check_emergency_status(&env, ProtocolAction::FlashLoan);
         payer.require_auth();
         let payer_key = DataKey::Balance(asset.clone(), payer.clone());
         let payer_bal: i128 = env.storage().persistent().get(&payer_key).unwrap_or(0);
@@ -1743,9 +1743,7 @@ impl LendingContract {
         let new_tre_bal = tre_bal
             .checked_sub(amount)
             .expect("flash_loan: treasury underflow during transfer");
-        env.storage().persistent().set(&tre_key,if supply_cap < 0 {
-    return Err(LendingError::InvalidAmount);
-} &new_tre_bal);
+        env.storage().persistent().set(&tre_key, &new_tre_bal);
 
         let rec_key = DataKey::Balance(asset.clone(), receiver.clone());
         let rec_bal: i128 = env.storage().persistent().get(&rec_key).unwrap_or(0);

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -1377,11 +1377,7 @@ impl LendingContract {
 
             require_no_active_flash_loan(&env);
 
-        let threshold_bps = Self::get_liquidation_threshold_bps(&env);
-        let hf = collateral
-            .checked_mul(threshold_bps)
-            .and_then(|v| v.checked_div(debt))
-            .ok_or(LendingError::Overflow)?;
+            let col_key = DataKey::Collateral(borrower.clone());
 
             let collateral: i128 = env.storage().persistent().get(&col_key).unwrap_or(0);
             let position = load_debt(&env, &borrower);
@@ -1398,22 +1394,11 @@ impl LendingContract {
                     .map_err(|_| LendingError::Overflow)?;
             save_debt(&env, &borrower, &settled_position);
 
-        let close_factor_bps = Self::get_close_factor_bps(&env);
-        let max_repay = debt
-            .checked_mul(close_factor_bps)
-            .and_then(|v| v.checked_div(10000))
-            .ok_or(LendingError::Overflow)?;
-        let actual_repay = if amount > max_repay {
-            max_repay
-        } else {
-            amount
-        };
+            let debt = settled_position.principal;
 
-        let incentive_bps = Self::get_liquidation_incentive_bps(&env);
-        let seized_collateral = actual_repay
-            .checked_mul(10000 + incentive_bps)
-            .and_then(|v| v.checked_div(10000))
-            .ok_or(LendingError::Overflow)?;
+            if debt == 0 {
+                return Err(LendingError::PositionHealthy);
+            }
 
             // Health-factor computation: floor rounding.
             // collateral * LIQUIDATION_THRESHOLD_BPS / debt — rounding down makes HF
@@ -1444,9 +1429,7 @@ impl LendingContract {
             // Dust guard: a repay of 0 would make the liquidation a no-op.
             if actual_repay <= 0 {
                 return Err(LendingError::InvalidAmount);
-            }if supply_cap < 0 {
-    return Err(LendingError::InvalidAmount);
-}
+            }
 
             // Liquidation incentive: floor rounding.
             // actual_repay * (10000 + incentive_bps) / 10000 — rounding down means the
@@ -1503,15 +1486,6 @@ impl LendingContract {
             let new_col = collateral
                 .checked_sub(final_seized)
                 .ok_or(LendingError::Overflow)?;
-            env.storage()
-                .persistent()
-                .set(&DataKey::BadDebt, &new_bad_debt);
-            env.events()
-                .publish((Symbol::new(&env, "bad_debt"), borrower.clone()), shortfall);
-            available_collateral
-        } else {
-            seized_collateral
-        };
 
             let updated_position = DebtPosition {
                 principal: new_debt,

--- a/stellar-lend/contracts/lending/tests/reentrancy_guard_test.rs
+++ b/stellar-lend/contracts/lending/tests/reentrancy_guard_test.rs
@@ -306,7 +306,7 @@ fn test_borrow_blocked_during_flash_loan() {
     let receiver = env.register(BorrowReentrant, ());
     let initiator = Address::generate(&env);
 
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes()
+    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "borrow during flash loan must fail");

--- a/stellar-lend/contracts/lending/tests/reentrancy_guard_test.rs
+++ b/stellar-lend/contracts/lending/tests/reentrancy_guard_test.rs
@@ -268,7 +268,7 @@ fn test_deposit_blocked_during_flash_loan() {
     let (client, contract_id, asset) = setup(&env, 10_000);
     let receiver = env.register(DepositReentrant, ());
     let initiator = Address::generate(&env);
-let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
+    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "deposit during flash loan must fail");
@@ -287,7 +287,6 @@ fn test_withdraw_blocked_during_flash_loan() {
     let initiator = Address::generate(&env);
 
     let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
-
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "withdraw during flash loan must fail");
@@ -326,7 +325,6 @@ fn test_repay_blocked_during_flash_loan() {
 
     let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
 
-
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "repay during flash loan must fail");
     assert_eq!(read_treasury(&env, &contract_id, &asset), 10_000);
@@ -345,7 +343,6 @@ fn test_liquidate_blocked_during_flash_loan() {
 
     let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
 
-
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "liquidate during flash loan must fail");
     assert_eq!(read_treasury(&env, &contract_id, &asset), 10_000);
@@ -363,7 +360,6 @@ fn test_nested_flash_loan_blocked() {
     let initiator = Address::generate(&env);
 
     let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
-
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "nested flash loan must fail");

--- a/stellar-lend/contracts/lending/tests/reentrancy_guard_test.rs
+++ b/stellar-lend/contracts/lending/tests/reentrancy_guard_test.rs
@@ -82,7 +82,7 @@ impl DepositReentrant {
     ) -> Val {
         // `params` encodes the lending contract address to call back into.
         // We use env.invoke_contract to call deposit.
-        let lending_id = Address::from_string_bytes(&params);
+        let lending_id = Address::from_xdr(&env, &params);
         let user = Address::generate(&env);
         env.invoke_contract::<Val>(
             &lending_id,
@@ -111,7 +111,7 @@ impl WithdrawReentrant {
         _fee: i128,
         params: Bytes,
     ) -> Val {
-        let lending_id = Address::from_string_bytes(&params);
+        let lending_id = Address::from_xdr(&env, &params);
         let user = Address::generate(&env);
         env.invoke_contract::<Val>(
             &lending_id,
@@ -140,7 +140,7 @@ impl BorrowReentrant {
         _fee: i128,
         params: Bytes,
     ) -> Val {
-        let lending_id = Address::from_string_bytes(&params);
+        let lending_id = Address::from_xdr(&env, &params);
         let user = Address::generate(&env);
         env.invoke_contract::<Val>(
             &lending_id,
@@ -169,7 +169,7 @@ impl RepayReentrant {
         _fee: i128,
         params: Bytes,
     ) -> Val {
-        let lending_id = Address::from_string_bytes(&params);
+        let lending_id = Address::from_xdr(&env, &params);
         let user = Address::generate(&env);
         env.invoke_contract::<Val>(
             &lending_id,
@@ -198,7 +198,7 @@ impl LiquidateReentrant {
         _fee: i128,
         params: Bytes,
     ) -> Val {
-        let lending_id = Address::from_string_bytes(&params);
+        let lending_id = Address::from_xdr(&env, &params);
         let liquidator = Address::generate(&env);
         let borrower = Address::generate(&env);
         let debt_asset = Address::generate(&env);
@@ -237,7 +237,7 @@ impl NestedFlashReentrant {
         _fee: i128,
         params: Bytes,
     ) -> Val {
-        let lending_id = Address::from_string_bytes(&params);
+        let lending_id = Address::from_xdr(&env, &params);
         let receiver2 = Address::generate(&env);
         env.invoke_contract::<Val>(
             &lending_id,
@@ -268,7 +268,7 @@ fn test_deposit_blocked_during_flash_loan() {
     let (client, contract_id, asset) = setup(&env, 10_000);
     let receiver = env.register(DepositReentrant, ());
     let initiator = Address::generate(&env);
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
+    let params = Bytes::from_slice(&env, &contract_id.to_xdr(&env));
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "deposit during flash loan must fail");
@@ -286,7 +286,7 @@ fn test_withdraw_blocked_during_flash_loan() {
     let receiver = env.register(WithdrawReentrant, ());
     let initiator = Address::generate(&env);
 
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
+    let params = Bytes::from_slice(&env, &contract_id.to_xdr(&env));
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "withdraw during flash loan must fail");
@@ -305,7 +305,7 @@ fn test_borrow_blocked_during_flash_loan() {
     let receiver = env.register(BorrowReentrant, ());
     let initiator = Address::generate(&env);
 
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
+    let params = Bytes::from_slice(&env, &contract_id.to_xdr(&env));
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "borrow during flash loan must fail");
@@ -323,7 +323,7 @@ fn test_repay_blocked_during_flash_loan() {
     let receiver = env.register(RepayReentrant, ());
     let initiator = Address::generate(&env);
 
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
+    let params = Bytes::from_slice(&env, &contract_id.to_xdr(&env));
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "repay during flash loan must fail");
@@ -341,7 +341,7 @@ fn test_liquidate_blocked_during_flash_loan() {
     let receiver = env.register(LiquidateReentrant, ());
     let initiator = Address::generate(&env);
 
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
+    let params = Bytes::from_slice(&env, &contract_id.to_xdr(&env));
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "liquidate during flash loan must fail");
@@ -359,7 +359,7 @@ fn test_nested_flash_loan_blocked() {
     let receiver = env.register(NestedFlashReentrant, ());
     let initiator = Address::generate(&env);
 
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
+    let params = Bytes::from_slice(&env, &contract_id.to_xdr(&env));
 
     let result = client.try_flash_loan(&initiator, &receiver, &asset, &1_000_i128, &params);
     assert!(result.is_err(), "nested flash loan must fail");
@@ -377,7 +377,7 @@ fn test_operations_resume_after_blocked_reentry() {
     let receiver = env.register(BorrowReentrant, ());
     let initiator = Address::generate(&env);
 
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
+    let params = Bytes::from_slice(&env, &contract_id.to_xdr(&env));
 
 
     // Attempt reentrant borrow — fails.


### PR DESCRIPTION
## Summary

Fixes CI build failures caused by pre-existing syntax errors in main.

## Errors Fixed

### 1.  - Corrupted `liquidate` function

The `liquidate` function contained merged/duplicate code blocks that made it uncompilable:

**Removed:**
- Stale draft block calculating `threshold_bps` and `hf` before variables were defined (lines 1379-1383)
- Stale draft block calling non-existent `Self::get_close_factor_bps()` and `Self::get_liquidation_incentive_bps()` methods (lines 1401-1415)
- Injected `if supply_cap < 0` guard fragment in the middle of the dust guard
- Duplicated bad-debt event publish outside the `if residual > 0` block
- Orphaned else branch closing after the new_debt/new_col calculation

**Added:**
- Missing `let col_key = DataKey::Collateral(borrower.clone());` definition
- Missing `let debt = settled_position.principal;` definition  
- Missing `if debt == 0` early return check

### 2. `stellar-lend/contracts/lending/tests/reentrancy_guard_test.rs`

**Fixed:** Missing closing parenthesis on line 309 in `test_borrow_blocked_during_flash_loan`

```diff
-    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes()
+    let params = Bytes::from_slice(&env, contract_id.to_string().to_bytes());
```

## Root Cause

These errors existed on both `origin/main` and `upstream/main` before any recent PRs. They were not introduced by any specific commit — the liquidate function appears to have had a stale draft version merged into the canonical implementation during a previous merge conflict resolution.

## Verification

Compared the fixed code against commit `f1c54308` ("refactor: governable close-factor and liquidation incentive") which had a working version of the liquidate function.

## Testing

CI should now pass the build step. The logic changes restore the function to match its documented behavior and test coverage.