### PR TITLE
Replace .expect() with .ok_or(LendingError::Overflow)? in withdraw

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -109,6 +109,8 @@ mod self_liquidation_test;
 mod supply_rate_split_test;
 #[cfg(test)]
 mod effective_supply_rate_test;
+#[cfg(test)]
+mod withdraw_overflow_test;
 
 #[cfg(test)]
 mod utilization_history_test;
@@ -1058,25 +1060,27 @@ impl LendingContract {
         if amount > current {
             return Err(LendingError::InvalidAmount);
         }
-        let new_balance = current.checked_sub(amount).expect("withdraw: underflow");
+        let new_balance = current
+            .checked_sub(amount)
+            .ok_or(LendingError::Overflow)?;
         env.storage().persistent().set(&key, &new_balance);
         let total_deposits: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::TotalDeposits)
             .unwrap_or(0);
-        env.storage().persistent().set(
-            &DataKey::TotalDeposits,
-            &total_deposits
-                .checked_sub(amount)
-                .expect("withdraw: total deposits underflow"),
-        );
+        let new_total = total_deposits
+            .checked_sub(amount)
+            .ok_or(LendingError::Overflow)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalDeposits, &new_total);
         extend_collateral_ttl(&env, &user);
         
         // Emit withdraw event
         emit_withdraw(&env, &user, amount, new_balance);
         
-        new_balance
+        Ok(new_balance)
     }
 
     /// Set the configured valuation collateral asset for the legacy single-asset flows.

--- a/stellar-lend/contracts/lending/src/withdraw_overflow_test.rs
+++ b/stellar-lend/contracts/lending/src/withdraw_overflow_test.rs
@@ -1,0 +1,86 @@
+use crate::{DataKey, LendingContract, LendingContractClient, LendingError};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin, user)
+}
+
+/// Regression test: simulates TotalDeposits drift (corrupt state) to ensure
+/// withdraw returns LendingError::Overflow instead of panicking.
+///
+/// If TotalDeposits is somehow lower than the user's actual balance — due to
+/// a prior bug, storage corruption, or data migration issue — withdraw must
+/// detect the underflow via checked_sub and return an error gracefully.
+#[test]
+fn test_withdraw_with_total_deposits_drift_returns_overflow() {
+    let (env, client, _admin, user) = setup();
+
+    // Normal deposit: user deposits 500
+    client.deposit(&user, &500);
+
+    // Simulate corrupt state: manually set TotalDeposits to 400 (less than user's 500)
+    env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalDeposits, &400i128);
+    });
+
+    // Now user tries to withdraw their full 500
+    // This would underflow TotalDeposits (400 - 500 = negative)
+    let res = client.try_withdraw(&user, &500);
+
+    // Expected: LendingError::Overflow, not a panic
+    assert!(
+        matches!(res, Err(Ok(LendingError::Overflow))),
+        "Expected LendingError::Overflow for TotalDeposits underflow, got {:?}",
+        res
+    );
+
+    // Verify state was NOT partially updated — TotalDeposits should remain 400
+    let total: i128 = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TotalDeposits)
+            .unwrap_or(0)
+    });
+    assert_eq!(total, 400, "TotalDeposits must not be modified on error");
+}
+
+/// Ensure a normal valid withdrawal still works after the fix.
+#[test]
+fn test_withdraw_valid_amount_succeeds() {
+    let (_env, client, _admin, user) = setup();
+
+    client.deposit(&user, &1_000);
+    let remaining = client.withdraw(&user, &400);
+
+    assert_eq!(remaining, 600);
+}
+
+/// Regression test: user balance underflow
+/// If a user somehow tries to withdraw more than their balance
+/// (already caught by InvalidAmount), but this test ensures the checked_sub
+/// on the user balance also guards gracefully.
+#[test]
+fn test_withdraw_exceeds_user_balance_returns_invalid_amount() {
+    let (_env, client, _admin, user) = setup();
+
+    client.deposit(&user, &100);
+
+    // Trying to withdraw 101 should fail at the amount > current check
+    let res = client.try_withdraw(&user, &101);
+
+    // Expected: InvalidAmount (checked before checked_sub)
+    assert!(
+        matches!(res, Err(Ok(LendingError::InvalidAmount))),
+        "Expected InvalidAmount when withdrawing more than deposited, got {:?}",
+        res
+    );
+}


### PR DESCRIPTION
Replace .expect() with graceful LendingError::Overflow in withdraw
  
  LendingContract::withdraw used .expect() for two checked arithmetic operations while every other checked-arithmetic
  call in the same function already used .ok_or(LendingError::Overflow)?. This inconsistency meant that if
  TotalDeposits ever drifted out of sync with a user's actual balance — due to a prior accounting bug, a failed
  migration, or any other storage anomaly — the subtraction would underflow and abort the entire transaction with an
  opaque panic message rather than surfacing a structured error the caller can handle.
  
  Changes
  
  - current.checked_sub(amount).expect("withdraw: underflow") → .ok_or(LendingError::Overflow)?
  - total_deposits.checked_sub(amount).expect("withdraw: total deposits underflow") → .ok_or(LendingError::Overflow)?
  
  Both paths now propagate LendingError::Overflow through the Result return type, consistent with every other
  arithmetic guard in the function.
  
  Why it matters
  
  A panic in a Soroban contract aborts the entire transaction with no structured error code. Callers — whether other
  contracts, SDKs, or front-ends — cannot distinguish an overflow from any other failure. Returning
  LendingError::Overflow lets integrators handle the condition gracefully, emit a meaningful error to users, and avoid
  silent data inconsistencies going unnoticed.
  
  Tests added (withdraw_overflow_test.rs)
  
  - test_withdraw_with_total_deposits_drift_returns_overflow — directly simulates the drift scenario: deposits 500,
  manually sets TotalDeposits to 400 in storage, then asserts that a full 500 withdrawal returns
  LendingError::Overflow rather than panicking, and that storage is left unmodified
  - test_withdraw_valid_amount_succeeds — confirms normal withdrawals are unaffected by the change
  - test_withdraw_exceeds_user_balance_returns_invalid_amount — confirms the existing amount > current guard still
  fires before the arithmetic path

▸ Closes #1430 
