### PR TITLE
fix(governance): use vote_token balance for weighted voting and proposal_threshold gate (Closes #1480)

### DIFF
--- a/stellar-lend/contracts/hello-world/src/governance.rs
+++ b/stellar-lend/contracts/hello-world/src/governance.rs
@@ -119,6 +119,15 @@ pub fn create_proposal(
         return Err(GovernanceError::Unauthorized);
     }
 
+    // Non-admin proposers must hold at least proposal_threshold vote tokens.
+    if proposer != config.admin {
+        let token = soroban_sdk::token::TokenClient::new(env, &config.vote_token);
+        let balance = token.balance(&proposer);
+        if balance < config.proposal_threshold {
+            return Err(GovernanceError::Unauthorized);
+        }
+    }
+
     let counter: u64 = env
         .storage()
         .instance()
@@ -267,7 +276,8 @@ pub fn vote(
     }
 
     // Record the vote.
-    let weight = 1i128; // One-person-one-vote for simplicity.
+    let token = soroban_sdk::token::TokenClient::new(env, &config.vote_token);
+    let weight = token.balance(&voter);
     let vote_info = VoteInfo {
         voter: voter.clone(),
         vote_type,


### PR DESCRIPTION
Closes #1480

## Summary

`GovernanceConfig` stores `vote_token` and `proposal_threshold` but they are never used.

- `vote()` hardcodes `let weight = 1i128;` — ignores vote_token entirely
- `create_proposal()` never checks proposer balance against `proposal_threshold`

## Fix

### vote() — token-weighted voting
Replace hardcoded weight=1 with `TokenClient::balance(&voter)` so voting power is proportional to vote_token holdings.

### create_proposal() — proposal threshold gate
Non-admin proposers must hold at least `config.proposal_threshold` vote tokens. Admin bypasses the check (can create proposals regardless of token holdings).