### PR TITLE
remove dead code: eliminate unused migration functions and borrower r…

### DIFF
--- a/stellar-lend/contracts/lending/src/borrow_index_test.rs
+++ b/stellar-lend/contracts/lending/src/borrow_index_test.rs
@@ -12,23 +12,21 @@
 //  5. O(1) debt computation via index ratio
 //  6. Index monotonicity (never decreases)
 //  7. Multi-position consistency (same global index)
-//  8. Migration of pre-index positions (snapshot == 0)
-//  9. Migration idempotency (second call returns 0)
-// 10. Index overflow guard
-// 11. Snapshot > current_index safety valve
-// 12. Repay updates snapshot
-// 13. Long-horizon index growth (10 years)
-// 14. get_borrow_index read-only view
-// 15. compute_debt_view read-only view
-// 16. MigrationCompleteEvent emission
+//  8. Index overflow guard
+//  9. Snapshot > current_index safety valve
+// 10. Repay updates snapshot
+// 11. Long-horizon index growth (10 years)
+// 12. get_borrow_index read-only view
+// 13. compute_debt_view read-only view
+// 14. MigrationCompleteEvent emission
 
 #[cfg(test)]
 mod borrow_index_tests {
     use crate::debt::{
-        accrue_index, compute_debt, load_borrow_index, load_debt, save_debt, touch_borrow_index,
-        DebtPosition, INDEX_SCALE,
+        accrue_index, compute_debt, load_borrow_index, load_debt, touch_borrow_index, DebtPosition,
+        INDEX_SCALE,
     };
-    use crate::{DataKey, LendingContract, LendingContractClient};
+    use crate::{LendingContract, LendingContractClient};
     use soroban_sdk::{
         testutils::{Address as _, Ledger, LedgerInfo},
         Address, Env,
@@ -272,114 +270,7 @@ mod borrow_index_tests {
     }
 
     // ----------------------------------------------------------------
-    // 8. Migration: pre-index positions (snapshot == 0) are back-filled
-    // ----------------------------------------------------------------
-
-    #[test]
-    fn test_migrate_positions_sets_snapshot_on_legacy_records() {
-        let (env, client, _admin, _user) = setup();
-
-        // Simulate a legacy DebtPosition with snapshot == 0 (pre-feature record).
-        let legacy_user = Address::generate(&env);
-        let contract_id = env.register(LendingContract, ());
-        env.as_contract(&contract_id, || {
-            let legacy_pos = DebtPosition {
-                principal: 50_000,
-                borrow_index_snapshot: 0, // pre-migration sentinel
-                last_update: 0,
-            };
-            save_debt(&env, &legacy_user, &legacy_pos);
-
-            // Also register this user in BorrowerList so migrate_positions finds it.
-            let mut list: soroban_sdk::Vec<Address> = env
-                .storage()
-                .instance()
-                .get(&DataKey::BorrowerList)
-                .unwrap_or_else(|| soroban_sdk::vec![&env]);
-            list.push_back(legacy_user.clone());
-            env.storage()
-                .instance()
-                .set(&DataKey::BorrowerList, &list);
-        });
-
-        // Fast-forward time so the index has grown before migration.
-        advance_time(&env, SECONDS_PER_YEAR);
-
-        // Use the original contract (set up in `setup`) for migrate_positions.
-        // We need a new env/contract pair that replicates the scenario cleanly.
-        let env2 = Env::default();
-        env2.mock_all_auths();
-        let id2 = env2.register(LendingContract, ());
-        let c2 = LendingContractClient::new(&env2, &id2);
-        let admin2 = Address::generate(&env2);
-        c2.initialize(&admin2);
-
-        // Manually inject a legacy position into contract 2's storage.
-        let legacy2 = Address::generate(&env2);
-        env2.as_contract(&id2, || {
-            let pos = DebtPosition {
-                principal: 50_000,
-                borrow_index_snapshot: 0,
-                last_update: 0,
-            };
-            save_debt(&env2, &legacy2, &pos);
-
-            let mut list: soroban_sdk::Vec<Address> = env2
-                .storage()
-                .instance()
-                .get(&DataKey::BorrowerList)
-                .unwrap_or_else(|| soroban_sdk::vec![&env2]);
-            list.push_back(legacy2.clone());
-            env2.storage()
-                .instance()
-                .set(&DataKey::BorrowerList, &list);
-        });
-
-        // Advance time so the index is > INDEX_SCALE at migration time.
-        let mut li = env2.ledger().get();
-        li.timestamp = li.timestamp.saturating_add(SECONDS_PER_YEAR);
-        env2.ledger().set(li);
-
-        let migrated = c2.migrate_positions();
-        assert_eq!(migrated, 1, "One legacy position should be migrated");
-
-        // After migration the snapshot should be > 0.
-        let pos_after = env2.as_contract(&id2, || load_debt(&env2, &legacy2));
-        assert!(
-            pos_after.borrow_index_snapshot > 0,
-            "Migrated position must have a non-zero snapshot"
-        );
-        assert!(
-            pos_after.borrow_index_snapshot >= INDEX_SCALE,
-            "Migrated snapshot must be >= INDEX_SCALE"
-        );
-    }
-
-    // ----------------------------------------------------------------
-    // 9. Migration idempotency: second call returns 0
-    // ----------------------------------------------------------------
-
-    #[test]
-    fn test_migrate_positions_idempotent() {
-        let (env, client, _admin, user) = setup();
-
-        // Create a real borrow (snapshot will already be set).
-        client.borrow(&user, &1_000);
-
-        // First migration — no legacy positions, should return 0.
-        let first = client.migrate_positions();
-        assert_eq!(
-            first, 0,
-            "No legacy positions: migrate_positions should return 0"
-        );
-
-        // Second migration — still 0.
-        let second = client.migrate_positions();
-        assert_eq!(second, 0, "Idempotent: second migration must return 0");
-    }
-
-    // ----------------------------------------------------------------
-    // 10. Index overflow guard
+    // 8. Index overflow guard
     // ----------------------------------------------------------------
 
     #[test]

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -2583,29 +2583,6 @@ fn extend_debt_ttl(env: &Env, user: &Address) {
     }
 }
 
-/// Append `user` to the `BorrowerList` stored in instance storage, if not
-/// already present.  This list is used by `migrate_positions` to iterate
-/// over all debt records.
-fn register_borrower(env: &Env, user: &Address) {
-    let mut list: soroban_sdk::Vec<Address> = env
-        .storage()
-        .instance()
-        .get(&DataKey::BorrowerList)
-        .unwrap_or_else(|| soroban_sdk::vec![env]);
-
-    // Linear scan is acceptable: the list is bounded by the number of unique
-    // borrowers and is read/written only on borrow (not every tx).
-    for i in 0..list.len() {
-        if list.get(i).unwrap() == *user {
-            return; // already registered
-        }
-    }
-    list.push_back(user.clone());
-    env.storage()
-        .instance()
-        .set(&DataKey::BorrowerList, &list);
-}
-
 fn pause_is_active(env: &Env, operation: PauseType) -> bool {
     let key = DataKey::PauseState(operation);
     env.storage()


### PR DESCRIPTION
closes #1501 

This PR removes dead migration-related code from the lending contract that referenced a non-existent storage key and was never wired into the current contract entrypoints.

What changed
Removed the unused register_borrower helper from the lending contract.
Removed obsolete borrow-index tests that exercised the old migrate_positions flow.
Kept the contract aligned with the currently implemented storage model and public interface.
Why
The removed code was stale and referenced [DataKey::BorrowerList](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which is not defined in the current contract. This cleanup avoids dead code and prevents confusion around an unimplemented migration path.

Verification
Editor diagnostics for the affected files report no errors.
The patch was reviewed with a repository diff to confirm only the intended cleanup was applied.
Notes
A full Cargo test run could not be executed in this environment because the Rust toolchain is not available on the PATH.