### PR TITLE
test: add clamp_rate floor/ceiling tests with docs

### DIFF
--- a/stellar-lend/contracts/hello-world/docs/CLAMP_RATE_TESTS.md
+++ b/stellar-lend/contracts/hello-world/docs/CLAMP_RATE_TESTS.md
@@ -1,0 +1,25 @@
+# Clamp-rate tests
+
+The clamp helper in the interest-rate module is intentionally simple: it should preserve values already inside a configured band and collapse anything outside to the nearest boundary. The new tests cover the primary edge cases that matter for reviewers and downstream callers.
+
+## Why these tests exist
+
+`clamp_rate` is the last step in borrow-rate calculation, so its behaviour directly shapes the effective rate seen by users. The tests document the contract's expected semantics for:
+
+- values below the floor,
+- values above the ceiling,
+- in-band values that should pass through unchanged,
+- equal bounds that collapse to a single value, and
+- inverted bounds that receive a defensive result.
+
+## Worked example
+
+Given a floor of `500` and a ceiling of `1_000`:
+
+- `250` becomes `500` because it is below the lower bound.
+- `1_500` becomes `1_000` because it is above the upper bound.
+- `750` stays `750` because it already fits the inclusive range.
+
+## Edge-case notes
+
+When the floor and ceiling are equal, the helper resolves to that single shared value. When the floor is greater than the ceiling, the current implementation defensively returns the upper bound because the clamp is expressed as a lower-bound max and upper-bound min operation.

--- a/stellar-lend/contracts/hello-world/src/clamp_rate_test.rs
+++ b/stellar-lend/contracts/hello-world/src/clamp_rate_test.rs
@@ -1,0 +1,33 @@
+#![cfg(test)]
+
+use crate::interest_rate::clamp_rate;
+
+/// Returns the configured floor for values below the lower bound.
+#[test]
+fn clamp_rate_returns_the_floor_for_values_below_it() {
+    assert_eq!(clamp_rate(250, 500, 1_000), 500);
+}
+
+/// Returns the configured ceiling for values above the upper bound.
+#[test]
+fn clamp_rate_returns_the_ceiling_for_values_above_it() {
+    assert_eq!(clamp_rate(1_500, 500, 1_000), 1_000);
+}
+
+/// Leaves in-band values unchanged when they already fit the configured range.
+#[test]
+fn clamp_rate_passes_through_in_band_values() {
+    assert_eq!(clamp_rate(750, 500, 1_000), 750);
+}
+
+/// Collapses to the single shared bound when the floor and ceiling are identical.
+#[test]
+fn clamp_rate_collapses_to_the_shared_boundary_when_bounds_match() {
+    assert_eq!(clamp_rate(3_000, 2_500, 2_500), 2_500);
+}
+
+/// Defensively returns the upper bound when the floor is greater than the ceiling.
+#[test]
+fn clamp_rate_defensively_returns_the_upper_bound_for_inverted_bounds() {
+    assert_eq!(clamp_rate(750, 1_200, 900), 900);
+}

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -66,6 +66,8 @@ mod bridge_fee_test;
 mod amm_integration_test;
 
 #[cfg(test)]
+mod clamp_rate_test;
+#[cfg(test)]
 mod cross_asset_decimals_test;
 #[cfg(test)]
 mod rate_clamp_test;


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed



Closes #1238