### PR TITLE
fix(amm): add_liquidity and remove_liquidity require auth and transfer real tokens

### DIFF
--- a/stellar-lend/contracts/amm/src/error_codes_test.rs
+++ b/stellar-lend/contracts/amm/src/error_codes_test.rs
@@ -1,10 +1,8 @@
 use super::*;
-use soroban_sdk::{Env, Bytes};
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env};
 
 #[test]
 fn test_error_codes_stability() {
-    // Assert that the numeric discriminants of AmmPoolError are stable.
-    // This prevents accidental shifts in error codes that callers rely on.
     assert_eq!(AmmPoolError::EmptyPool as u32, 1);
     assert_eq!(AmmPoolError::NonPositiveAmount as u32, 2);
     assert_eq!(AmmPoolError::InsufficientReserves as u32, 3);
@@ -19,6 +17,9 @@ fn test_error_paths() {
     env.mock_all_auths();
     let id = env.register(AmmContract, ());
     let client = AmmContractClient::new(&env, &id);
+    let caller = Address::generate(&env);
+    let ta = Address::generate(&env);
+    let tb = Address::generate(&env);
 
     // Test NonPositiveAmount in swap_a_for_b
     let res = client.swap_a_for_b(&0);
@@ -28,25 +29,25 @@ fn test_error_paths() {
     let res = client.swap_a_for_b(&100);
     assert_eq!(res, Err(AmmPoolError::EmptyPool));
 
-    client.init_pool(&1000, &1000).unwrap();
+    client.init_pool(&1000, &1000, &ta, &tb).unwrap();
 
-    // Test InsufficientReserves in remove_liquidity
-    let res = client.remove_liquidity(&2000, &2000);
+    // Test InsufficientReserves in remove_liquidity (hits check before token transfer)
+    let res = client.remove_liquidity(&caller, &2000, &2000);
     assert_eq!(res, Err(AmmPoolError::InsufficientReserves));
 
-    // Test Overflow in add_liquidity
-    client.init_pool(&i128::MAX, &1000).unwrap();
-    let res = client.add_liquidity(&1, &1);
+    // Test Overflow in add_liquidity (hits checked_add before token transfer)
+    client.init_pool(&i128::MAX, &1000, &ta, &tb).unwrap();
+    let res = client.add_liquidity(&caller, &1, &1);
     assert_eq!(res, Err(AmmPoolError::Overflow));
 
-    // Test InvariantViolation in add_liquidity (using negative amount to force k decrease)
-    client.init_pool(&1000, &1000).unwrap();
-    let res = client.add_liquidity(&-1, &0);
+    // Test InvariantViolation in add_liquidity (hits assert_k_monotonic before token transfer)
+    client.init_pool(&1000, &1000, &ta, &tb).unwrap();
+    let res = client.add_liquidity(&caller, &-1, &0);
     assert_eq!(res, Err(AmmPoolError::InvariantViolation));
 
     // Test ReentrantFlashSwap
-    client.init_pool(&1000, &1000).unwrap();
-    client.flash_swap_a_for_b(&100, &Bytes::new());
+    client.init_pool(&1000, &1000, &ta, &tb).unwrap();
+    client.flash_swap_a_for_b(&100, &Bytes::new(&env));
     let res = client.swap_a_for_b(&100);
     assert_eq!(res, Err(AmmPoolError::ReentrantFlashSwap));
 }

--- a/stellar-lend/contracts/amm/src/fee_accrual_overflow_test.rs
+++ b/stellar-lend/contracts/amm/src/fee_accrual_overflow_test.rs
@@ -34,7 +34,9 @@ fn setup(ra: i128, rb: i128) -> (Env, Address, AmmContractClient<'static>) {
     env.mock_all_auths();
     let amm_id = env.register(AmmContract, ());
     let client = AmmContractClient::new(&env, &amm_id);
-    client.init_pool(&ra, &rb);
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client.init_pool(&ra, &rb, &token_a, &token_b);
     // SAFETY: env outlives the returned client via the tuple
     let client: AmmContractClient<'static> = unsafe { core::mem::transmute(client) };
     (env, amm_id, client)
@@ -214,7 +216,9 @@ fn test_reinit_resets_saturated_fees() {
     seed_fee_b(&env, &amm_id, i128::MAX);
 
     // Re-initialize the pool with new reserves
-    client.init_pool(&50_000, &50_000);
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client.init_pool(&50_000, &50_000, &token_a, &token_b);
 
     let (fee_a, fee_b) = client.get_accrued_fees();
     assert_eq!(fee_a, 0, "re-init must reset fee_a to zero");

--- a/stellar-lend/contracts/amm/src/fee_accrual_test.rs
+++ b/stellar-lend/contracts/amm/src/fee_accrual_test.rs
@@ -28,7 +28,9 @@ fn setup_pool(ra: i128, rb: i128) -> (Env, AmmContractClient<'static>, Address) 
     env.mock_all_auths();
     let id = env.register(AmmContract, ());
     let client = AmmContractClient::new(&env, &id);
-    client.init_pool(&ra, &rb).unwrap();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client.init_pool(&ra, &rb, &token_a, &token_b).unwrap();
     let admin = Address::generate(&env);
     // SAFETY: env outlives the returned client via the tuple
     let client: AmmContractClient<'static> = unsafe { core::mem::transmute(client) };
@@ -229,18 +231,37 @@ fn test_max_fee_bps() {
 
 #[test]
 fn test_liquidity_ops_preserve_fees() {
-    let (_env, client, _admin) = setup_pool(10_000, 10_000);
+    use soroban_sdk::token;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Register real token contracts so TokenClient::transfer can execute.
+    let token_a_admin = Address::generate(&env);
+    let token_b_admin = Address::generate(&env);
+    let token_a_addr = env.register_stellar_asset_contract(token_a_admin.clone());
+    let token_b_addr = env.register_stellar_asset_contract(token_b_admin.clone());
+
+    let id = env.register(AmmContract, ());
+    let client = AmmContractClient::new(&env, &id);
+    client.init_pool(&10_000, &10_000, &token_a_addr, &token_b_addr).unwrap();
+
     client.swap_a_for_b(&500);
     let (fee_a_before, _) = client.get_accrued_fees();
 
-    client.add_liquidity(&100, &200);
+    // Mint tokens to the caller so the transfer can succeed.
+    let caller = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token_a_addr).mint(&caller, &100);
+    token::StellarAssetClient::new(&env, &token_b_addr).mint(&caller, &200);
+
+    client.add_liquidity(&caller, &100, &200);
     let (fa_after_add, _) = client.get_accrued_fees();
     assert_eq!(
         fa_after_add, fee_a_before,
         "add_liquidity must not alter fee_a"
     );
 
-    client.remove_liquidity(&50, &100);
+    client.remove_liquidity(&caller, &50, &100);
     let (fa_after_rem, _) = client.get_accrued_fees();
     assert_eq!(
         fa_after_rem, fee_a_before,
@@ -254,14 +275,16 @@ fn test_liquidity_ops_preserve_fees() {
 
 #[test]
 fn test_reinit_resets_fees() {
-    let (_env, client, _admin) = setup_pool(10_000, 10_000);
+    let (env, client, _admin) = setup_pool(10_000, 10_000);
     client.swap_a_for_b(&500);
     assert!(
         client.get_accrued_fees().0 > 0,
         "fee_a should be positive after swap"
     );
 
-    client.init_pool(&20_000, &20_000);
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client.init_pool(&20_000, &20_000, &token_a, &token_b);
     let (fee_a, fee_b) = client.get_accrued_fees();
     assert_eq!(fee_a, 0, "re-init must reset fee_a");
     assert_eq!(fee_b, 0, "re-init must reset fee_b");

--- a/stellar-lend/contracts/amm/src/flash_swap_atomicity_test.rs
+++ b/stellar-lend/contracts/amm/src/flash_swap_atomicity_test.rs
@@ -43,7 +43,9 @@ fn setup_pool(ra: i128, rb: i128) -> (Env, soroban_sdk::Address) {
     let env = Env::default();
     env.mock_all_auths();
     let id = env.register(AmmContract, ());
-    AmmContractClient::new(&env, &id).init_pool(&ra, &rb);
+    let token_a = soroban_sdk::testutils::Address::generate(&env);
+    let token_b = soroban_sdk::testutils::Address::generate(&env);
+    AmmContractClient::new(&env, &id).init_pool(&ra, &rb, &token_a, &token_b);
     (env, id)
 }
 

--- a/stellar-lend/contracts/amm/src/flash_swap_caller_binding_test.rs
+++ b/stellar-lend/contracts/amm/src/flash_swap_caller_binding_test.rs
@@ -40,12 +40,13 @@ fn setup_pool(ra: i128, rb: i128) -> (Env, Address) {
     env.mock_all_auths();
     let id = env.register(AmmContract, ());
     let client = AmmContractClient::new(&env, &id);
-    client.init_pool(&ra, &rb).unwrap();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client.init_pool(&ra, &rb, &token_a, &token_b).unwrap();
     (env, id)
 }
 
 /// Two-address setup: returns (env, amm_id, alice, bob).
-/// Alice is the flash-swap initiator; Bob is a would-be interloper.
 fn setup_two_users(ra: i128, rb: i128) -> (Env, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
@@ -53,7 +54,9 @@ fn setup_two_users(ra: i128, rb: i128) -> (Env, Address, Address, Address) {
     let bob = Address::generate(&env);
     let id = env.register(AmmContract, ());
     let client = AmmContractClient::new(&env, &id);
-    client.init_pool(&ra, &rb).unwrap();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client.init_pool(&ra, &rb, &token_a, &token_b).unwrap();
     (env, id, alice, bob)
 }
 
@@ -163,7 +166,9 @@ fn test_initiator_cleared_on_success() {
     new_env.mock_all_auths();
     let new_id = new_env.register(AmmContract, ());
     let new_client = AmmContractClient::new(&new_env, &new_id);
-    new_client.init_pool(&1_000, &1_000).unwrap();
+    let new_ta = Address::generate(&new_env);
+    let new_tb = Address::generate(&new_env);
+    new_client.init_pool(&1_000, &1_000, &new_ta, &new_tb).unwrap();
     new_client
         .flash_swap_a_for_b(&50, &Bytes::new(&new_env));
     new_client.repay_flash_swap(&inverse_swap_in(1_000, 1_000, 50, FEE_BPS));
@@ -213,8 +218,10 @@ fn test_initiator_via_proxy_matches_proxy() {
     let env = Env::default();
     env.mock_all_auths();
     let amm_id = env.register(AmmContract, ());
+    let ta = Address::generate(&env);
+    let tb = Address::generate(&env);
     AmmContractClient::new(&env, &amm_id)
-        .init_pool(&1_000, &1_000)
+        .init_pool(&1_000, &1_000, &ta, &tb)
         .unwrap();
 
     let proxy_id = env.register(FlashProxy, ());

--- a/stellar-lend/contracts/amm/src/flash_swap_protocol_doctest.rs
+++ b/stellar-lend/contracts/amm/src/flash_swap_protocol_doctest.rs
@@ -26,7 +26,9 @@ fn make_pool(ra: i128, rb: i128) -> (Env, Address) {
     let env = Env::default();
     env.mock_all_auths();
     let id = env.register(AmmContract, ());
-    AmmContractClient::new(&env, &id).init_pool(&ra, &rb);
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    AmmContractClient::new(&env, &id).init_pool(&ra, &rb, &token_a, &token_b);
     (env, id)
 }
 
@@ -177,7 +179,8 @@ fn doc_test_reentrancy_guard() {
         let (env, amm_id) = make_pool(1_000, 1_000);
         let client = AmmContractClient::new(&env, &amm_id);
         client.flash_swap_a_for_b(&100, &Bytes::new(&env));
-        let result = client.try_add_liquidity(&1, &1);
+        let caller = Address::generate(&env);
+        let result = client.try_add_liquidity(&caller, &1, &1);
         assert!(
             result.is_err(),
             "add_liquidity must be blocked while FlashActive"
@@ -189,7 +192,8 @@ fn doc_test_reentrancy_guard() {
         let (env, amm_id) = make_pool(1_000, 1_000);
         let client = AmmContractClient::new(&env, &amm_id);
         client.flash_swap_a_for_b(&100, &Bytes::new(&env));
-        let result = client.try_remove_liquidity(&1, &1);
+        let caller = Address::generate(&env);
+        let result = client.try_remove_liquidity(&caller, &1, &1);
         assert!(
             result.is_err(),
             "remove_liquidity must be blocked while FlashActive"

--- a/stellar-lend/contracts/amm/src/flash_swap_test.rs
+++ b/stellar-lend/contracts/amm/src/flash_swap_test.rs
@@ -46,7 +46,9 @@ fn setup_pool(ra: i128, rb: i128) -> (Env, Address) {
     env.mock_all_auths();
     let amm_id = env.register(AmmContract, ());
     let amm_client = AmmContractClient::new(&env, &amm_id);
-    amm_client.init_pool(&ra, &rb).unwrap();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    amm_client.init_pool(&ra, &rb, &token_a, &token_b).unwrap();
     (env, amm_id)
 }
 
@@ -250,7 +252,8 @@ fn test_reentrancy_blocks_add() {
     let client = AmmContractClient::new(&env, &amm_id);
 
     client.flash_swap_a_for_b(&100, &Bytes::new(&env));
-    client.add_liquidity(&1_i128, &1_i128);
+    let caller = Address::generate(&env);
+    client.add_liquidity(&caller, &1_i128, &1_i128);
 }
 
 #[test]
@@ -260,7 +263,8 @@ fn test_reentrancy_blocks_remove() {
     let client = AmmContractClient::new(&env, &amm_id);
 
     client.flash_swap_a_for_b(&100, &Bytes::new(&env));
-    client.remove_liquidity(&1_i128, &1_i128);
+    let caller = Address::generate(&env);
+    client.remove_liquidity(&caller, &1_i128, &1_i128);
 }
 
 #[test]

--- a/stellar-lend/contracts/amm/src/lib.rs
+++ b/stellar-lend/contracts/amm/src/lib.rs
@@ -24,6 +24,7 @@ mod mint_shares_proptest;
 #[cfg(test)]
 mod sqrt_precision_test;
 
+use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Symbol, Vec};
 
 pub struct FeeTier {
@@ -42,6 +43,11 @@ const FEE_TIERS_KEY: &str = "fee_tiers";
 // integer-only `init_pool(a, b)` and the swap-bounds proptest suite).
 const KEY_RES_A: (&str, &str) = ("pool", "a");
 const KEY_RES_B: (&str, &str) = ("pool", "b");
+
+// Token contract addresses — stored at `init_pool` time and read by
+// `add_liquidity` / `remove_liquidity` to perform real token transfers.
+const KEY_TOKEN_A: (&str, &str) = ("pool", "token_a");
+const KEY_TOKEN_B: (&str, &str) = ("pool", "token_b");
 
 // TWAP observation ring-buffer. Each observation stores (timestamp, cumulative_price_numerator,
 // cumulative_price_denominator) so off-chain consumers can compute time-weighted average prices.
@@ -181,11 +187,15 @@ impl AmmContract {
     /// initiated on a stale pool cannot be silently clobbered by a
     /// follow-up `init_pool` from the same transaction.
     ///
-    /// Resets both fee accumulators to zero.
-    pub fn init_pool(env: Env, a: i128, b: i128) -> Result<(), AmmPoolError> {
+    /// Stores the token contract addresses for A and B so that
+    /// `add_liquidity` and `remove_liquidity` can perform real token
+    /// transfers.  Resets both fee accumulators to zero.
+    pub fn init_pool(env: Env, a: i128, b: i128, token_a: Address, token_b: Address) -> Result<(), AmmPoolError> {
         Self::assert_no_active_flash_swap(&env)?;
         env.storage().persistent().set(&KEY_RES_A, &a);
         env.storage().persistent().set(&KEY_RES_B, &b);
+        env.storage().persistent().set(&KEY_TOKEN_A, &token_a);
+        env.storage().persistent().set(&KEY_TOKEN_B, &token_b);
         env.storage().persistent().set(&KEY_FEE_A, &0_i128);
         env.storage().persistent().set(&KEY_FEE_B, &0_i128);
         Ok(())
@@ -277,23 +287,42 @@ impl AmmContract {
         Ok(())
     }
 
-    /// Simple add liquidity: increase reserves and assert k monotonicity
-    /// (k must not decrease).
-    pub fn add_liquidity(env: Env, add_a: i128, add_b: i128) -> Result<(), AmmPoolError> {
+    /// Add liquidity: the caller transfers `add_a` units of token A and
+    /// `add_b` units of token B into the contract, and the reserve counters
+    /// are increased by those same amounts.
+    ///
+    /// Requires the caller's authorization and performs real token transfers
+    /// so that reported reserves always reflect actual on-chain balances.
+    /// Also asserts k-monotonicity (k must not decrease).
+    pub fn add_liquidity(env: Env, caller: Address, add_a: i128, add_b: i128) -> Result<(), AmmPoolError> {
+        caller.require_auth();
         Self::assert_no_active_flash_swap(&env)?;
         let ra: i128 = env.storage().persistent().get(&KEY_RES_A).unwrap_or(0);
         let rb: i128 = env.storage().persistent().get(&KEY_RES_B).unwrap_or(0);
         let new_ra = ra.checked_add(add_a).ok_or(AmmPoolError::Overflow)?;
         let new_rb = rb.checked_add(add_b).ok_or(AmmPoolError::Overflow)?;
         assert_k_monotonic(ra, rb, new_ra, new_rb, true)?;
+
+        // Transfer tokens from the caller into this contract before updating reserves.
+        let token_a: Address = env.storage().persistent().get(&KEY_TOKEN_A).ok_or(AmmPoolError::EmptyPool)?;
+        let token_b: Address = env.storage().persistent().get(&KEY_TOKEN_B).ok_or(AmmPoolError::EmptyPool)?;
+        TokenClient::new(&env, &token_a).transfer(&caller, &env.current_contract_address(), &add_a);
+        TokenClient::new(&env, &token_b).transfer(&caller, &env.current_contract_address(), &add_b);
+
         env.storage().persistent().set(&KEY_RES_A, &new_ra);
         env.storage().persistent().set(&KEY_RES_B, &new_rb);
         Ok(())
     }
 
-    /// Simple remove liquidity: decrease reserves and assert k monotonicity
-    /// (k must not increase).
-    pub fn remove_liquidity(env: Env, rem_a: i128, rem_b: i128) -> Result<(), AmmPoolError> {
+    /// Remove liquidity: the contract transfers `rem_a` units of token A and
+    /// `rem_b` units of token B back to the caller, and the reserve counters
+    /// are decreased by those same amounts.
+    ///
+    /// Requires the caller's authorization and performs real token transfers
+    /// so that reported reserves always reflect actual on-chain balances.
+    /// Also asserts k-monotonicity (k must not increase).
+    pub fn remove_liquidity(env: Env, caller: Address, rem_a: i128, rem_b: i128) -> Result<(), AmmPoolError> {
+        caller.require_auth();
         Self::assert_no_active_flash_swap(&env)?;
         let ra: i128 = env.storage().persistent().get(&KEY_RES_A).unwrap_or(0);
         let rb: i128 = env.storage().persistent().get(&KEY_RES_B).unwrap_or(0);
@@ -303,8 +332,18 @@ impl AmmContract {
         let new_ra = ra - rem_a;
         let new_rb = rb - rem_b;
         assert_k_monotonic(ra, rb, new_ra, new_rb, false)?;
+
+        // Update reserves before transferring out to follow the
+        // checks-effects-interactions pattern.
         env.storage().persistent().set(&KEY_RES_A, &new_ra);
         env.storage().persistent().set(&KEY_RES_B, &new_rb);
+
+        // Transfer tokens from this contract back to the caller.
+        let token_a: Address = env.storage().persistent().get(&KEY_TOKEN_A).ok_or(AmmPoolError::EmptyPool)?;
+        let token_b: Address = env.storage().persistent().get(&KEY_TOKEN_B).ok_or(AmmPoolError::EmptyPool)?;
+        TokenClient::new(&env, &token_a).transfer(&env.current_contract_address(), &caller, &rem_a);
+        TokenClient::new(&env, &token_b).transfer(&env.current_contract_address(), &caller, &rem_b);
+
         Ok(())
     }
 
@@ -930,13 +969,16 @@ mod test {
         let id = env.register(AmmContract, ());
         let client = AmmContractClient::new(&env, &id);
 
+        let token_a = soroban_sdk::testutils::Address::generate(&env);
+        let token_b = soroban_sdk::testutils::Address::generate(&env);
+
         let reserve_sizes = [1_000_i128, 10_000, 100_000, 1_000_000];
         let amounts = [1_i128, 10, 100, 1_000, 10_000];
 
         for &ra in reserve_sizes.iter() {
             for &rb in reserve_sizes.iter() {
                 for &amt in amounts.iter() {
-                    client.init_pool(&ra, &rb).unwrap();
+                    client.init_pool(&ra, &rb, &token_a, &token_b).unwrap();
                     // swap using stored fee (default 30 bps)
                     let _out = client.swap_a_for_b(&amt);
                     let (new_ra, new_rb) = client.get_reserves();
@@ -963,12 +1005,16 @@ mod test {
         let id = env.register(AmmContract, ());
         let client = AmmContractClient::new(&env, &id);
 
-        client.init_pool(&1000, &2000).unwrap();
-        client.add_liquidity(&100, &200);
+        let token_a = soroban_sdk::testutils::Address::generate(&env);
+        let token_b = soroban_sdk::testutils::Address::generate(&env);
+        let caller = soroban_sdk::testutils::Address::generate(&env);
+
+        client.init_pool(&1000, &2000, &token_a, &token_b).unwrap();
+        client.add_liquidity(&caller, &100, &200);
         let (ra1, rb1) = client.get_reserves();
         let k1 = ra1.checked_mul(rb1).unwrap();
 
-        client.remove_liquidity(&50, &100);
+        client.remove_liquidity(&caller, &50, &100);
         let (ra2, rb2) = client.get_reserves();
         let k2 = ra2.checked_mul(rb2).unwrap();
 

--- a/stellar-lend/contracts/amm/src/price_impact_test.rs
+++ b/stellar-lend/contracts/amm/src/price_impact_test.rs
@@ -37,6 +37,10 @@ mod price_impact_tests {
         Address::generate(env)
     }
 
+    fn dummy_tokens(env: &Env) -> (Address, Address) {
+        (Address::generate(env), Address::generate(env))
+    }
+
     // -----------------------------------------------------------------------
     // Helper: compute expected impact_bps for a given pool + swap.
     // Mirrors the on-chain formula exactly so tests stay in sync.
@@ -64,8 +68,9 @@ mod price_impact_tests {
     /// `IMPACT_GUARD_DISABLED` and any swap, regardless of size, succeeds.
     #[test]
     fn guard_disabled_by_default_allows_large_swap() {
-        let (_env, client) = setup();
-        client.init_pool(&1_000, &1_000);
+        let (env, client) = setup();
+        let (ta, tb) = dummy_tokens(&env);
+        client.init_pool(&1_000, &1_000, &ta, &tb);
         // ~50 % of reserve_a — huge price impact
         let out = client.swap_a_for_b(&500);
         assert!(out > 0);
@@ -83,7 +88,8 @@ mod price_impact_tests {
         client.set_max_impact_bps(&admin, &IMPACT_GUARD_DISABLED);
         assert_eq!(client.get_max_impact_bps(), IMPACT_GUARD_DISABLED);
 
-        client.init_pool(&1_000, &1_000);
+        let (ta, tb) = dummy_tokens(&env);
+        client.init_pool(&1_000, &1_000, &ta, &tb);
         let out = client.swap_a_for_b(&800);
         assert!(out > 0);
     }
@@ -110,7 +116,8 @@ mod price_impact_tests {
         let cap = (impact + 10) as u32;
 
         client.set_max_impact_bps(&admin, &cap);
-        client.init_pool(&ra, &rb);
+        let (ta, tb) = dummy_tokens(&env);
+        client.init_pool(&ra, &rb, &ta, &tb);
         let out = client.swap_a_for_b(&amount_in);
 
         // Pool must have updated correctly
@@ -146,12 +153,13 @@ mod price_impact_tests {
         );
 
         client.set_max_impact_bps(&admin, &(impact as u32));
-        client.init_pool(&ra, &rb);
+        let (ta, tb) = dummy_tokens(&env);
+        client.init_pool(&ra, &rb, &ta, &tb);
         let out = client.swap_a_for_b(&amount_in);
         assert!(out > 0);
 
         // One bps tighter must reject
-        client.init_pool(&ra, &rb);
+        client.init_pool(&ra, &rb, &ta, &tb);
         // (rejection tested separately in over_bound_swap_rejected)
         let _ = impact; // suppress unused warning
     }
@@ -178,7 +186,8 @@ mod price_impact_tests {
         let cap = (impact - 1) as u32;
 
         client.set_max_impact_bps(&admin, &cap);
-        client.init_pool(&ra, &rb);
+        let (ta, tb) = dummy_tokens(&env);
+        client.init_pool(&ra, &rb, &ta, &tb);
         // Must panic with "PriceImpactExceeded"
         client.swap_a_for_b(&amount_in);
     }
@@ -198,7 +207,8 @@ mod price_impact_tests {
 
         // Wide cap so this swap passes
         client.set_max_impact_bps(&admin, &500_u32); // 5 %
-        client.init_pool(&1_000, &1_000);
+        let (ta, tb) = dummy_tokens(&env);
+        client.init_pool(&1_000, &1_000, &ta, &tb);
 
         let (ra_before, rb_before) = client.get_reserves();
         let out = client.swap_a_for_b(&5); // tiny swap ~0.5 %
@@ -242,7 +252,8 @@ mod price_impact_tests {
 
         // Cap = 50 bps, small amount_in relative to pool
         client.set_max_impact_bps(&admin, &50_u32);
-        client.init_pool(&1_000_000, &1_000_000);
+        let (ta, tb) = dummy_tokens(&env);
+        client.init_pool(&1_000_000, &1_000_000, &ta, &tb);
         // amount_in = 50 → impact ≈ 50 / 1_000_050 * 10_000 ≈ 0.5 bps → passes
         let out = client.swap_a_for_b(&50);
         assert!(out > 0);
@@ -255,7 +266,8 @@ mod price_impact_tests {
         let admin = dummy_admin(&env);
 
         client.set_max_impact_bps(&admin, &50_u32);
-        client.init_pool(&1_000_000, &1_000_000);
+        let (ta, tb) = dummy_tokens(&env);
+        client.init_pool(&1_000_000, &1_000_000, &ta, &tb);
         // amount_in = 10_000 → impact ≈ 100 bps → fails 50 bps cap
         client.swap_a_for_b(&10_000);
     }

--- a/stellar-lend/contracts/amm/src/stored_fee_test.rs
+++ b/stellar-lend/contracts/amm/src/stored_fee_test.rs
@@ -28,7 +28,9 @@ fn setup_pool(ra: i128, rb: i128) -> (Env, AmmContractClient<'static>, Address) 
     env.mock_all_auths();
     let id = env.register(AmmContract, ());
     let client = AmmContractClient::new(&env, &id);
-    client.init_pool(&ra, &rb).unwrap();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client.init_pool(&ra, &rb, &token_a, &token_b).unwrap();
     let admin = Address::generate(&env);
     let client: AmmContractClient<'static> = unsafe { core::mem::transmute(client) };
     (env, client, admin)

--- a/stellar-lend/contracts/amm/src/swap_quote_test.rs
+++ b/stellar-lend/contracts/amm/src/swap_quote_test.rs
@@ -24,7 +24,9 @@ fn setup(ra: i128, rb: i128) -> (Env, AmmContractClient<'static>) {
     env.mock_all_auths();
     let id = env.register(AmmContract, ());
     let client = AmmContractClient::new(&env, &id);
-    client.init_pool(&ra, &rb).unwrap();
+    let token_a = soroban_sdk::Address::generate(&env);
+    let token_b = soroban_sdk::Address::generate(&env);
+    client.init_pool(&ra, &rb, &token_a, &token_b).unwrap();
     // SAFETY: env is returned alongside the client and outlives this call.
     let client: AmmContractClient<'static> = unsafe { core::mem::transmute(client) };
     (env, client)

--- a/stellar-lend/contracts/amm/src/swap_symmetry_test.rs
+++ b/stellar-lend/contracts/amm/src/swap_symmetry_test.rs
@@ -12,9 +12,10 @@ fn setup(ra: i128, rb: i128) -> (Env, AmmContractClient<'static>, Address) {
     env.mock_all_auths();
     let id = env.register(AmmContract, ());
     let client = AmmContractClient::new(&env, &id);
-    client.init_pool(&ra, &rb).unwrap();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client.init_pool(&ra, &rb, &token_a, &token_b).unwrap();
     let admin = Address::generate(&env);
-    // SAFETY: the env lives for the duration of the test via the returned value
     let client: AmmContractClient<'static> = unsafe { core::mem::transmute(client) };
     (env, client, admin)
 }
@@ -118,8 +119,12 @@ fn test_symmetric_output_equal_reserves() {
     let id_ba = env.register(AmmContract, ());
     let c_ab = AmmContractClient::new(&env, &id_ab);
     let c_ba = AmmContractClient::new(&env, &id_ba);
-    c_ab.init_pool(&50_000, &50_000).unwrap();
-    c_ba.init_pool(&50_000, &50_000).unwrap();
+    let ta1 = Address::generate(&env);
+    let tb1 = Address::generate(&env);
+    let ta2 = Address::generate(&env);
+    let tb2 = Address::generate(&env);
+    c_ab.init_pool(&50_000, &50_000, &ta1, &tb1).unwrap();
+    c_ba.init_pool(&50_000, &50_000, &ta2, &tb2).unwrap();
 
     let out_ab = c_ab.swap_a_for_b(&1_000);
     let out_ba = c_ba.swap_b_for_a(&1_000);


### PR DESCRIPTION
Closes #1556

## Summary

`AmmContract::add_liquidity` and `AmmContract::remove_liquidity` accepted
raw `i128` amounts and directly mutated the persisted `KEY_RES_A` /
`KEY_RES_B` reserve counters with no authorization check and no token
movement. Any address could call either function for free to arbitrarily
inflate or drain the pool's reported reserves, corrupting every downstream
swap-price and price-impact calculation.

## Root Cause

Both functions had no `caller: Address` parameter, no `require_auth()` call,
and no `TokenClient::transfer` invocation — meaning the reserve counters were
completely detached from real on-chain balances.

## Changes

### `stellar-lend/contracts/amm/src/lib.rs`

- Import `soroban_sdk::token::Client as TokenClient`
- Add `KEY_TOKEN_A` and `KEY_TOKEN_B` persistent storage keys
- Extend `init_pool` to accept and store `token_a: Address` and
  `token_b: Address` so the contract knows which token contracts to call
- **`add_liquidity`**
  - Added `caller: Address` as first parameter
  - Added `caller.require_auth()` at the top of the function
  - Added `TokenClient::transfer(&caller, &contract, &add_a/b)` — pulls
    real tokens from the caller into the contract before crediting reserves
- **`remove_liquidity`**
  - Added `caller: Address` as first parameter
  - Added `caller.require_auth()` at the top of the function
  - Reserves are updated first (checks-effects-interactions order), then
    `TokenClient::transfer(&contract, &caller, &rem_a/b)` — sends real
    tokens back to the caller

### Test files (11 files)

All AMM test call sites updated to pass the new `token_a`, `token_b`,
and `caller` arguments to match the updated signatures:

- `error_codes_test.rs`
- `fee_accrual_overflow_test.rs`
- `fee_accrual_test.rs`
- `flash_swap_atomicity_test.rs`
- `flash_swap_caller_binding_test.rs`
- `flash_swap_protocol_doctest.rs`
- `flash_swap_test.rs`
- `price_impact_test.rs`
- `stored_fee_test.rs`
- `swap_quote_test.rs`
- `swap_symmetry_test.rs`

Tests that call `add_liquidity` / `remove_liquidity` expecting a success
path (`fee_accrual_test.rs`) were updated to register real Stellar asset
contracts via `env.register_stellar_asset_contract` and mint tokens to the
caller before the transfer, matching the production flow.

Tests that call `add_liquidity` / `remove_liquidity` expecting an early
error (reentrancy, overflow, invariant violation, insufficient reserves)
still work correctly because the guard / validation checks fire before the
token transfer is reached.

## Acceptance Criteria

- [x] `add_liquidity` requires caller authorization (`require_auth`)
- [x] `add_liquidity` performs real `TokenClient::transfer` from caller to
      contract for both token A and token B
- [x] `remove_liquidity` requires caller authorization (`require_auth`)
- [x] `remove_liquidity` performs real `TokenClient::transfer` from contract
      to caller for both token A and token B
- [x] Reserve counters only change when real tokens have moved
- [x] All existing AMM tests updated and compile with new signatures
