### PR TITLE
Fix/multisig reinit guard

### DIFF
--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -86,6 +86,7 @@ pub enum MultisigError {
     InvalidTtl = 13,
     BatchSizeExceeded = 14,
     DuplicateProposalId = 15,
+    AlreadyInitialized = 16,
 }
 
 /// Maximum number of proposals that can be executed in a single
@@ -108,7 +109,10 @@ impl MultisigContract {
     /// * `env`       – Soroban environment.
     /// * `signers`   – Initial list of authorised signers.
     /// * `threshold` – Minimum number of approvals required to pass a proposal.
-    pub fn initialize(env: Env, signers: Vec<Address>, threshold: u32) {
+    pub fn initialize(env: Env, signers: Vec<Address>, threshold: u32) -> Result<(), MultisigError> {
+        if env.storage().persistent().has(&MultisigDataKey::Signers) {
+            return Err(MultisigError::AlreadyInitialized);
+        }
         if threshold == 0 || threshold as usize > signers.len() as usize {
             panic!("InvalidThreshold");
         }
@@ -121,6 +125,7 @@ impl MultisigContract {
         env.storage()
             .persistent()
             .set(&MultisigDataKey::ProposalCount, &0u64);
+        Ok(())
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`MultisigContract::initialize()` wrote `Signers`, `Threshold`, and `ProposalCount` unconditionally, with no check before overwriting. Anyone able to invoke `initialize` a second time after deployment could silently replace the entire signer set and threshold, retroactively bypassing every subsequent `require_signer` check.

## Changes

- Added an `AlreadyInitialized` error variant to `MultisigError`.
- Added a storage check for `MultisigDataKey::Signers` at the top of `initialize()`. If it already exists, the function returns `Err(MultisigError::AlreadyInitialized)` instead of overwriting.
- Changed `initialize()` return type from `()` to `Result<(), MultisigError>` to match the lending contract pattern.

## Verification

- `cargo check -p stellarlend-multisig` passes.
- 29/30 tests pass; the 1 failure (`test_cancel_proposal_sets_cancelled_status`) is a pre-existing bug in `cancel_proposal` unrelated to this change.

Closes #1424