### PR TITLE
lending: return Result from compute_borrow_rate instead of panicking

### DIFF
--- a/stellar-lend/contracts/lending/src/debt.rs
+++ b/stellar-lend/contracts/lending/src/debt.rs
@@ -106,6 +106,12 @@ impl From<&'static str> for DebtError {
     }
 }
 
+impl From<rate_model::RateModelError> for DebtError {
+    fn from(_: rate_model::RateModelError) -> Self {
+        DebtError::Overflow
+    }
+}
+
 impl From<RoundingError> for DebtError {
     fn from(_: RoundingError) -> Self {
         DebtError::Overflow
@@ -567,7 +573,7 @@ pub(crate) fn try_compute_borrow_rate_from_snapshot(
 
     let rate_bps = match &snapshot.params {
         Some(p) => {
-            let target_rate = rate_model::compute_borrow_rate(utilization_bps, p);
+            let target_rate = rate_model::compute_borrow_rate(utilization_bps, p)?;
             crate::rate_model::update_and_get_rate(env, target_rate, p)
         }
         None => DEFAULT_APR_BPS,

--- a/stellar-lend/contracts/lending/src/rate_model.rs
+++ b/stellar-lend/contracts/lending/src/rate_model.rs
@@ -77,6 +77,13 @@ impl Default for RateParams {
     }
 }
 
+/// Errors that can occur during borrow-rate computation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RateModelError {
+    /// An intermediate arithmetic operation overflowed.
+    Overflow,
+}
+
 /// Computes the target borrow rate given utilization and rate model parameters.
 ///
 /// Implements a two-slope piecewise linear model with a kink point. Below the kink,
@@ -114,7 +121,12 @@ impl Default for RateParams {
 ///
 /// # Returns
 ///
-/// The computed borrow rate in basis points, clamped to `[params.rate_floor_bps, params.rate_ceiling_bps]`.
+/// `Ok(rate_bps)` — the computed borrow rate in basis points, clamped to
+/// `[params.rate_floor_bps, params.rate_ceiling_bps]`.
+///
+/// `Err(RateModelError::Overflow)` — if any intermediate arithmetic product
+/// overflows `i128`.  Callers should propagate this as a typed error rather
+/// than allowing the transaction to abort.
 ///
 /// # Examples
 ///
@@ -125,40 +137,40 @@ impl Default for RateParams {
 /// - At 100% utilization: `3,700 bps` (maximum non-ceiling-limited rate)
 ///
 /// See [`RATE_MODEL.md`](./RATE_MODEL.md) for detailed curve sketch and additional worked examples.
-///
-/// # Panics
-///
-/// Panics if checked arithmetic overflows (which should not occur with valid utilization
-/// values and reasonable parameter ranges).
-pub fn compute_borrow_rate(utilization_bps: i128, params: &RateParams) -> i128 {
+pub fn compute_borrow_rate(
+    utilization_bps: i128,
+    params: &RateParams,
+) -> Result<i128, RateModelError> {
     let pre_kink_rate = params
         .base_rate_bps
         .checked_add(
             utilization_bps
                 .min(params.kink_utilization_bps)
                 .checked_mul(params.multiplier_bps)
-                .unwrap()
+                .ok_or(RateModelError::Overflow)?
                 .checked_div(BPS_DENOM)
-                .unwrap(),
+                .ok_or(RateModelError::Overflow)?,
         )
-        .unwrap();
+        .ok_or(RateModelError::Overflow)?;
 
     let raw_rate = if utilization_bps > params.kink_utilization_bps {
         let excess = utilization_bps
             .checked_sub(params.kink_utilization_bps)
-            .unwrap();
+            .ok_or(RateModelError::Overflow)?;
         let jump = excess
             .checked_mul(params.jump_multiplier_bps)
-            .unwrap()
+            .ok_or(RateModelError::Overflow)?
             .checked_div(BPS_DENOM)
-            .unwrap();
-        pre_kink_rate.checked_add(jump).unwrap()
+            .ok_or(RateModelError::Overflow)?;
+        pre_kink_rate
+            .checked_add(jump)
+            .ok_or(RateModelError::Overflow)?
     } else {
         pre_kink_rate
     };
-    raw_rate
+    Ok(raw_rate
         .max(params.rate_floor_bps)
-        .min(params.rate_ceiling_bps)
+        .min(params.rate_ceiling_bps))
 }
 
 #[contracttype]
@@ -267,4 +279,56 @@ pub fn update_and_get_rate(env: &Env, target_rate: i128, params: &RateParams) ->
         .instance()
         .set(&RateModelKey::LastRateLedger, &current_ledger);
     clamped_rate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Normal inputs should still produce the expected rate without error.
+    #[test]
+    fn test_compute_borrow_rate_normal() {
+        let params = RateParams::default();
+        // At 80% utilization (kink), rate = base + kink * multiplier / BPS_DENOM
+        // = 100 + 8000 * 2000 / 10000 = 100 + 1600 = 1700 bps
+        let rate = compute_borrow_rate(8_000, &params).unwrap();
+        assert_eq!(rate, 1_700);
+    }
+
+    /// An extremely large multiplier_bps combined with a large utilization_bps
+    /// causes an i128 overflow in the intermediate product.  The function must
+    /// return Err(RateModelError::Overflow) instead of panicking.
+    #[test]
+    fn test_compute_borrow_rate_overflow_returns_error() {
+        let params = RateParams {
+            // Use i128::MAX for multiplier — multiplying any positive
+            // utilization by this will overflow.
+            multiplier_bps: i128::MAX,
+            ..RateParams::default()
+        };
+        let result = compute_borrow_rate(1, &params);
+        assert_eq!(
+            result,
+            Err(RateModelError::Overflow),
+            "Expected Overflow error for out-of-range params, got {:?}",
+            result
+        );
+    }
+
+    /// jump_multiplier_bps overflows when utilization is above the kink.
+    #[test]
+    fn test_compute_borrow_rate_jump_overflow_returns_error() {
+        let params = RateParams {
+            jump_multiplier_bps: i128::MAX,
+            ..RateParams::default()
+        };
+        // Utilization above kink triggers the jump branch.
+        let result = compute_borrow_rate(9_000, &params);
+        assert_eq!(
+            result,
+            Err(RateModelError::Overflow),
+            "Expected Overflow error in jump branch, got {:?}",
+            result
+        );
+    }
 }


### PR DESCRIPTION
Replace the five .unwrap() calls on checked arithmetic in rate_model::compute_borrow_rate with .ok_or(RateModelError::Overflow)? and change the return type from i128 to Result<i128, RateModelError>.

A new RateModelError enum is introduced in rate_model.rs to avoid a circular dependency with DebtError. DebtError gains a From<RateModelError> impl so the single call site in debt::try_compute_borrow_rate_from_snapshot can propagate the error with ? without any boilerplate.

Previously an admin-configured multiplier_bps or jump_multiplier_bps large enough to cause an intermediate i128 overflow would abort the entire transaction with a raw arithmetic panic. The caller now receives DebtError::Overflow and can handle or surface it cleanly.

Three new unit tests are added to rate_model::tests:
- test_compute_borrow_rate_normal: sanity-checks the default params
- test_compute_borrow_rate_overflow_returns_error: multiplier_bps = i128::MAX triggers Err(RateModelError::Overflow)
- test_compute_borrow_rate_jump_overflow_returns_error: same for the post-kink jump branch

Closes #1433

## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
