### PR TITLE
fix(lending): wire insurance_fund_test into lib.rs so tests actually run

### DIFF
--- a/stellar-lend/contracts/lending/src/insurance_fund_test.rs
+++ b/stellar-lend/contracts/lending/src/insurance_fund_test.rs
@@ -53,7 +53,7 @@ fn advance_ledger_time(env: &Env, seconds: u64) {
 
 #[test]
 fn test_configure_insurance_share_bounds() {
-    let (_env, client, _id, admin, _user, _liquidator, _debt_asset, _collateral_asset) = setup();
+    let (_env, client, _id, _admin, _user, _liquidator, _debt_asset, _collateral_asset) = setup();
 
     // Check default is 0
     assert_eq!(client.get_insurance_share(), 0);
@@ -77,7 +77,7 @@ fn test_configure_insurance_share_bounds() {
 
 #[test]
 fn test_admin_explicit_funding() {
-    let (_env, client, _id, admin, _user, _liquidator, _debt_asset, _collateral_asset) = setup();
+    let (_env, client, _id, _admin, _user, _liquidator, _debt_asset, _collateral_asset) = setup();
 
     assert_eq!(client.get_insurance_fund(), 0);
 
@@ -106,7 +106,7 @@ fn test_accrual_interest_split() {
 
     // Borrow 10,000 units
     let borrow_amount = 10_000i128;
-    client.borrow(&user, &borrow_amount).unwrap();
+    client.borrow(&user, &borrow_amount);
 
     // Advance time by exactly one year to accrue 5% interest (500 tokens)
     advance_ledger_time(&env, SECONDS_PER_YEAR);

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -55,6 +55,8 @@ mod granular_pause_ops_test;
 #[cfg(test)]
 mod health_factor_edge_test;
 #[cfg(test)]
+mod insurance_fund_test;
+#[cfg(test)]
 mod interest_drift_regression_test;
 #[cfg(test)]
 mod interest_ordering_time_test;


### PR DESCRIPTION
## Description

`insurance_fund_test.rs` existed in the source tree but was never declared as a module in `lib.rs`, so `cargo test -p stellarlend-lending` silently ignored it.

This PR adds the missing `#[cfg(test)] mod insurance_fund_test;` declaration and fixes two unused-variable warnings and a `.unwrap()` call on a non-`Result` return type that were surfaced when the file was first compiled as part of the crate.

## Changes
- Add `#[cfg(test)] mod insurance_fund_test;` to `lib.rs` test-module block
- Fix `admin` → `_admin` in two test functions
- Remove `.unwrap()` from `client.borrow()` call (returns `i128`, not `Result`)

Closes #1528