### PR TITLE
fix(multisig): actually cancel proposals in cancel_proposal()

### DIFF
--- a/stellar-lend/contracts/multisig/src/batch_execute_test.rs
+++ b/stellar-lend/contracts/multisig/src/batch_execute_test.rs
@@ -263,11 +263,9 @@ fn test_batch_execute_one_already_executed_rejected() {
     client.batch_execute(&signers.get(0).unwrap(), &ids, &hashes);
 }
 
-// The Cancelled-proposal guard is tested indirectly by the
-// `test_batch_execute_one_already_executed_rejected` test (same status-guard
-// code path). The `cancel_proposal` entrypoint has a pre-existing bug
-// (doesn't set Cancelled status), so a dedicated test cannot be reliably set
-// up without bypassing the public API.
+// The Cancelled-proposal guard in batch_execute is covered by the dedicated
+// cancel_proposal_test module, which exercises the full cancel → batch-reject
+// path end-to-end now that cancel_proposal correctly persists the status.
 
 // ---------------------------------------------------------------------------
 // Duplicate IDs

--- a/stellar-lend/contracts/multisig/src/cancel_proposal_test.rs
+++ b/stellar-lend/contracts/multisig/src/cancel_proposal_test.rs
@@ -125,6 +125,9 @@ fn test_cancel_already_cancelled_panics() {
 // ---------------------------------------------------------------------------
 
 /// A cancelled proposal must be rejected by `execute_proposal`.
+/// The proposal is cancelled while still Active (before quorum), so
+/// cancel_proposal succeeds, and a subsequent execute_proposal attempt
+/// panics with AlreadyCancelled.
 #[test]
 #[should_panic(expected = "AlreadyCancelled")]
 fn test_execute_cancelled_proposal_panics() {
@@ -140,14 +143,10 @@ fn test_execute_cancelled_proposal_panics() {
         &500u64,
     );
 
-    // Gather enough approvals to reach quorum.
-    client.approve_proposal(&signers.get(0).unwrap(), &id);
-    client.approve_proposal(&signers.get(1).unwrap(), &id);
-
-    // Cancel before executing.
+    // Cancel while still Active (before quorum is reached).
     client.cancel_proposal(&signers.get(0).unwrap(), &id);
 
-    // execute_proposal should panic with AlreadyCancelled.
+    // execute_proposal must reject a Cancelled proposal.
     client.execute_proposal(&signers.get(0).unwrap(), &id, &hash);
 }
 
@@ -180,6 +179,8 @@ fn test_cancel_proposal_non_signer_rejected() {
 // ---------------------------------------------------------------------------
 
 /// A cancelled proposal must be rejected by `batch_execute`.
+/// The proposal is cancelled while still Active so cancel_proposal succeeds.
+/// batch_execute then panics with AlreadyCancelled.
 #[test]
 #[should_panic(expected = "AlreadyCancelled")]
 fn test_batch_execute_cancelled_proposal_rejected() {
@@ -195,9 +196,7 @@ fn test_batch_execute_cancelled_proposal_rejected() {
         &500u64,
     );
 
-    // Reach quorum then cancel.
-    client.approve_proposal(&signers.get(0).unwrap(), &id);
-    client.approve_proposal(&signers.get(1).unwrap(), &id);
+    // Cancel while still Active (before quorum).
     client.cancel_proposal(&signers.get(0).unwrap(), &id);
 
     let mut ids = Vec::new(&env);

--- a/stellar-lend/contracts/multisig/src/cancel_proposal_test.rs
+++ b/stellar-lend/contracts/multisig/src/cancel_proposal_test.rs
@@ -1,0 +1,209 @@
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Bytes, Env, Vec};
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror the pattern used across the test suite)
+// ---------------------------------------------------------------------------
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn make_bytes(env: &Env, data: &[u8]) -> Bytes {
+    Bytes::from_slice(env, data)
+}
+
+/// Spin up a 3-of-2 multisig and return (contract_id, signers).
+fn setup_multisig(env: &Env) -> (Address, Vec<Address>) {
+    let contract_id = env.register(MultisigContract, ());
+    let client = MultisigContractClient::new(env, &contract_id);
+
+    let s1 = Address::generate(env);
+    let s2 = Address::generate(env);
+    let s3 = Address::generate(env);
+    let mut signers = Vec::new(env);
+    signers.push_back(s1.clone());
+    signers.push_back(s2.clone());
+    signers.push_back(s3.clone());
+
+    client.initialize(&signers, &2u32);
+    (contract_id, signers)
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+/// After a successful `cancel_proposal` call, `get_proposal` must return a
+/// proposal whose status is `ProposalStatus::Cancelled`.
+#[test]
+fn test_cancel_proposal_status_is_cancelled() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    let hash = make_bytes(&env, b"payload_hash");
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &500u64,
+    );
+
+    // Proposal should be Active before cancellation.
+    let before = client.get_proposal(&id);
+    assert_eq!(before.status, ProposalStatus::Active);
+
+    client.cancel_proposal(&signers.get(0).unwrap(), &id);
+
+    // Proposal must now be Cancelled in persistent storage.
+    let after = client.get_proposal(&id);
+    assert_eq!(
+        after.status,
+        ProposalStatus::Cancelled,
+        "proposal status must be Cancelled after cancel_proposal"
+    );
+}
+
+/// Any registered signer (not just the proposer) can cancel an active proposal.
+#[test]
+fn test_cancel_proposal_by_non_proposer_signer() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    let hash = make_bytes(&env, b"hash_x");
+    // s1 creates the proposal.
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &500u64,
+    );
+
+    // s2 (not the proposer) cancels it.
+    client.cancel_proposal(&signers.get(1).unwrap(), &id);
+
+    let p = client.get_proposal(&id);
+    assert_eq!(
+        p.status,
+        ProposalStatus::Cancelled,
+        "non-proposer signer must be able to cancel an active proposal"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency / double-cancel guard
+// ---------------------------------------------------------------------------
+
+/// Attempting to cancel an already-cancelled proposal must panic.
+#[test]
+#[should_panic(expected = "ProposalNotPassed")]
+fn test_cancel_already_cancelled_panics() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    let hash = make_bytes(&env, b"hash_y");
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &500u64,
+    );
+
+    client.cancel_proposal(&signers.get(0).unwrap(), &id);
+    // Second call must panic because status is no longer Active.
+    client.cancel_proposal(&signers.get(0).unwrap(), &id);
+}
+
+// ---------------------------------------------------------------------------
+// Interaction with execute_proposal
+// ---------------------------------------------------------------------------
+
+/// A cancelled proposal must be rejected by `execute_proposal`.
+#[test]
+#[should_panic(expected = "AlreadyCancelled")]
+fn test_execute_cancelled_proposal_panics() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    let hash = make_bytes(&env, b"hash_z");
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &500u64,
+    );
+
+    // Gather enough approvals to reach quorum.
+    client.approve_proposal(&signers.get(0).unwrap(), &id);
+    client.approve_proposal(&signers.get(1).unwrap(), &id);
+
+    // Cancel before executing.
+    client.cancel_proposal(&signers.get(0).unwrap(), &id);
+
+    // execute_proposal should panic with AlreadyCancelled.
+    client.execute_proposal(&signers.get(0).unwrap(), &id, &hash);
+}
+
+// ---------------------------------------------------------------------------
+// Access control
+// ---------------------------------------------------------------------------
+
+/// A caller who is not a registered signer must not be able to cancel.
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_cancel_proposal_non_signer_rejected() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    let hash = make_bytes(&env, b"hash_w");
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &500u64,
+    );
+
+    let outsider = Address::generate(&env);
+    client.cancel_proposal(&outsider, &id);
+}
+
+// ---------------------------------------------------------------------------
+// Interaction with batch_execute
+// ---------------------------------------------------------------------------
+
+/// A cancelled proposal must be rejected by `batch_execute`.
+#[test]
+#[should_panic(expected = "AlreadyCancelled")]
+fn test_batch_execute_cancelled_proposal_rejected() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    let hash = make_bytes(&env, b"hash_b");
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &500u64,
+    );
+
+    // Reach quorum then cancel.
+    client.approve_proposal(&signers.get(0).unwrap(), &id);
+    client.approve_proposal(&signers.get(1).unwrap(), &id);
+    client.cancel_proposal(&signers.get(0).unwrap(), &id);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(id);
+    let mut hashes = Vec::new(&env);
+    hashes.push_back(hash);
+
+    client.batch_execute(&signers.get(0).unwrap(), &ids, &hashes);
+}

--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -369,10 +369,12 @@ impl MultisigContract {
         caller.require_auth();
         Self::require_signer(&env, &caller);
 
-        let proposal = Self::fetch_proposal(&env, id);
+        let mut proposal = Self::fetch_proposal(&env, id);
         if proposal.status != ProposalStatus::Active {
             panic!("ProposalNotPassed");
         }
+        proposal.status = ProposalStatus::Cancelled;
+        Self::save_proposal(&env, &proposal);
     }
 
     /// Return the current approval threshold.
@@ -529,3 +531,6 @@ mod execution_router_test;
 
 #[cfg(test)]
 mod batch_execute_test;
+
+#[cfg(test)]
+mod cancel_proposal_test;


### PR DESCRIPTION
closes #1564

sumaary

Problem

MultisigContract::cancel_proposal (stellar-lend/contracts/multisig/src/lib.rs, ~line 351) authenticates the caller, loads the proposal, and panics if its status isn't Active — but stops there. It never sets proposal.status = ProposalStatus::Cancelled and never calls Self::save_proposal(&env, &proposal).

As a result, the function is a silent no-op for every input that passes its guards: the proposal stays Active in storage exactly as it was before the call. A caller who believes they've cancelled a proposal has not — the call succeeds with no error, but nothing changes. This means there's currently no way to cancel a malicious or stale proposal through the public API, even though the function exists and appears to work.

Fix
After the existing auth check and Active-status guard, set proposal.status = ProposalStatus::Cancelled.
Persist the change with Self::save_proposal(&env, &proposal).
Testing
Added a test that creates a proposal, calls cancel_proposal, and asserts get_proposal returns ProposalStatus::Cancelled.
Verified existing tests around proposal state transitions (e.g. rejecting cancellation of non-Active proposals) still pass.
Impact

Restores the intended behavior of cancel_proposal: proposals can now actually be cancelled, closing the gap where a stale or malicious proposal could not be removed from the active set despite the API suggesting otherwise.