### PR TITLE
ci: run tests and linting on all workspace crates

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,51 +44,51 @@ jobs:
 
       - name: Check formatting
         run: |
-          cd stellar-lend/contracts/lending
+          cd stellar-lend
           cargo fmt -- --check
 
       - name: Run clippy
         run: |
-          cd stellar-lend/contracts/lending
-          cargo clippy --lib --all-features -- -D warnings -A deprecated -A dead_code -A unused-imports -A unused-attributes -A clippy::inconsistent-digit-grouping -A clippy::manual-range-contains -A clippy::unnecessary-cast -A clippy::too-many-arguments -A clippy::enum_variant_names
+          cd stellar-lend
+          cargo clippy --workspace --lib --all-features -- -D warnings -A deprecated -A dead_code -A unused-imports -A unused-attributes -A clippy::inconsistent-digit-grouping -A clippy::manual-range-contains -A clippy::unnecessary-cast -A clippy::too-many-arguments -A clippy::enum_variant_names
 
       - name: Build project
         run: |
-          cd stellar-lend/contracts/lending
-          cargo build --verbose
+          cd stellar-lend
+          cargo build --workspace --verbose
 
       - name: Run tests
         run: |
-          cd stellar-lend/contracts/lending
-          cargo test --lib --verbose
+          cd stellar-lend
+          cargo test --workspace --lib --verbose
 
       - name: Run integration tests
         run: |
-          cd stellar-lend/contracts/lending
-          cargo test --tests --verbose
+          cd stellar-lend
+          cargo test --workspace --tests --verbose
 
-      - name: Generate lending test report
+      - name: Generate workspace test report
         run: |
-          cd stellar-lend/contracts/lending
-          cargo test --lib --verbose -- --nocapture > lending_test_report.txt
-          cat lending_test_report.txt
+          cd stellar-lend
+          cargo test --workspace --lib --verbose -- --nocapture > workspace_test_report.txt
+          cat workspace_test_report.txt
 
       - name: Upload test report
         uses: actions/upload-artifact@v4
         with:
           name: test-reports
-          path: stellar-lend/contracts/lending/lending_test_report.txt
+          path: stellar-lend/workspace_test_report.txt
 
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --locked --version 0.31.0
 
       - name: Generate code coverage
         run: |
-          cd stellar-lend/contracts/lending
-          cargo tarpaulin --verbose --out Xml --packages stellarlend-lending --lib --exclude-files "**/indexing_system/**"
+          cd stellar-lend
+          cargo tarpaulin --verbose --out Xml --workspace --lib --exclude-files "**/indexing_system/**"
 
-      - name: Enforce lending crate coverage threshold
-        run: python3 scripts/enforce_coverage.py stellar-lend/contracts/lending/cobertura.xml --threshold 63.0 --overall-only
+      - name: Enforce workspace coverage threshold
+        run: python3 scripts/enforce_coverage.py stellar-lend/cobertura.xml --threshold 63.0 --overall-only
 
       - name: Install cargo-audit
         run: cargo install cargo-audit


### PR DESCRIPTION
Closes #1444 


This PR extends the existing `.github/workflows/ci-cd.yml` pipeline to test, build, and lint all crates within the repository workspace, rather than restricting operations solely to `stellar-lend/contracts/lending`. 

Prior to this change, crates such as `amm`, `multisig`, `vesting`, `hello-world`, `common`, and `cross_asset_test` were excluded from CI coverage, which allowed compile errors and lint warnings in these crates to go unnoticed.

### Technical Changes
*   **Workspace Execution Context**: Changed the `cd` commands in the CI workflow from `stellar-lend/contracts/lending` to the workspace root `stellar-lend`.
*   **Workspace-level Tooling Flags**: Added the `--workspace` flag to the following `cargo` operations:
    *   `cargo clippy`
    *   `cargo build`
    *   `cargo test` (both `--lib` and `--tests`)
    *   `cargo tarpaulin`
*   **Report Generation Fixes**: Adjusted output paths for `cargo test` report generation (`workspace_test_report.txt`) and `cargo tarpaulin` coverage artifacts (`stellar-lend/cobertura.xml`) to align with the new workspace root execution directory.

### Acceptance Criteria Verified
*   CI will now correctly fail on any PR that introduces a compile error, test failure, or unapproved lint in *any* workspace member (e.g. `contracts/amm` or `contracts/multisig`), resolving the blind spot in the build pipeline.