### PR TITLE
fix(lending): document initialize AlreadyInitialized typed error

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -558,8 +558,8 @@ impl LendingContract {
     ///
     /// # Errors
     /// - [`LendingError::AlreadyInitialized`] if `initialize` has already
-    ///   been called on this contract instance.  The second call is a no-op
-    ///   and the existing admin is **not** replaced.
+    ///   been called on this contract instance. This returns a typed error
+    ///   rather than panicking.
     ///
     /// # Security
     /// `initialize` is the *only* entry point that may be called before the


### PR DESCRIPTION
## Summary

Closes #1497 

- Refines documentation on `LendingContract::initialize` to explicitly document that it returns the typed `LendingError::AlreadyInitialized` error instead of panicking on re-initialization.

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [x] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

### Functional tests
- [x] `cargo test` passes — no new failures beyond the known baseline

### Invariants
- [x] Skip (No functional changes introduced)

### Upgrade safety
- [x] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events
- [x] Skip (No event changes)

### Security notes
- [x] Skip (No functional or logical changes)

### Docs
- [x] Public functions have a doc comment (error codes, params, return)

### CI
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] No secrets or key material committed
