### PR TITLE
Fix 1527 wire zero amount test

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -558,8 +558,8 @@ impl LendingContract {
     ///
     /// # Errors
     /// - [`LendingError::AlreadyInitialized`] if `initialize` has already
-    ///   been called on this contract instance.  The second call is a no-op
-    ///   and the existing admin is **not** replaced.
+    ///   been called on this contract instance. This returns a typed error
+    ///   rather than panicking.
     ///
     /// # Security
     /// `initialize` is the *only* entry point that may be called before the

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -3583,3 +3583,5 @@ pub(crate) mod test {
 }
 #[cfg(test)]
 mod initialization_guard_test;
+#[cfg(test)]
+mod zero_amount_semantics_test;

--- a/stellar-lend/contracts/lending/src/zero_amount_semantics_test.rs
+++ b/stellar-lend/contracts/lending/src/zero_amount_semantics_test.rs
@@ -31,21 +31,21 @@ fn setup() -> (Env, LendingContractClient<'static>, Address) {
 fn deposit_zero_returns_invalid_amount() {
     let (_env, client, user) = setup();
     let res = client.try_deposit(&user, &0);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
 fn deposit_negative_returns_invalid_amount() {
     let (_env, client, user) = setup();
     let res = client.try_deposit(&user, &-1);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
 fn deposit_large_negative_returns_invalid_amount() {
     let (_env, client, user) = setup();
     let res = client.try_deposit(&user, &i128::MIN);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn withdraw_zero_returns_invalid_amount() {
     let (_env, client, user) = setup();
     client.deposit(&user, &200);
     let res = client.try_withdraw(&user, &0);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
@@ -90,7 +90,7 @@ fn withdraw_negative_returns_invalid_amount() {
     let (_env, client, user) = setup();
     client.deposit(&user, &200);
     let res = client.try_withdraw(&user, &-50);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn withdraw_large_negative_returns_invalid_amount() {
     let (_env, client, user) = setup();
     client.deposit(&user, &200);
     let res = client.try_withdraw(&user, &i128::MIN);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
@@ -133,26 +133,27 @@ fn withdraw_negative_does_not_mutate_collateral() {
 fn borrow_zero_returns_invalid_amount() {
     let (_env, client, user) = setup();
     let res = client.try_borrow(&user, &0);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
 fn borrow_negative_returns_invalid_amount() {
     let (_env, client, user) = setup();
     let res = client.try_borrow(&user, &-1);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
 fn borrow_large_negative_returns_invalid_amount() {
     let (_env, client, user) = setup();
     let res = client.try_borrow(&user, &i128::MIN);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
 fn borrow_zero_does_not_mutate_debt() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
     let before = client.get_position(&user).debt;
 
@@ -165,6 +166,7 @@ fn borrow_zero_does_not_mutate_debt() {
 #[test]
 fn borrow_negative_does_not_mutate_debt() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
     let before = client.get_position(&user).debt;
 
@@ -182,7 +184,7 @@ fn borrow_negative_with_min_borrow_set_returns_invalid_amount_not_below_minimum(
     // set a minimum borrow of 50 — negative amounts must still hit InvalidAmount
     client.set_min_borrow(&50);
     let res = client.try_borrow(&user, &-1);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 /// Zero borrow must return InvalidAmount even when min_borrow is also zero,
@@ -192,7 +194,7 @@ fn borrow_zero_with_min_borrow_zero_returns_invalid_amount() {
     let (_env, client, user) = setup();
     // min_borrow defaults to 0; a zero amount must still be rejected
     let res = client.try_borrow(&user, &0);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 // ---------------------------------------------------------------------------
@@ -202,30 +204,34 @@ fn borrow_zero_with_min_borrow_zero_returns_invalid_amount() {
 #[test]
 fn repay_zero_returns_invalid_amount() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
     let res = client.try_repay(&user, &0);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
 fn repay_negative_returns_invalid_amount() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
     let res = client.try_repay(&user, &-1);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
 fn repay_large_negative_returns_invalid_amount() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
     let res = client.try_repay(&user, &i128::MIN);
-    assert_eq!(res, Ok(Err(LendingError::InvalidAmount)));
+    assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
 }
 
 #[test]
 fn repay_zero_does_not_mutate_debt() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
     let before = client.get_position(&user).debt;
 
@@ -238,6 +244,7 @@ fn repay_zero_does_not_mutate_debt() {
 #[test]
 fn repay_negative_does_not_mutate_debt() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
     let before = client.get_position(&user).debt;
 
@@ -250,9 +257,10 @@ fn repay_negative_does_not_mutate_debt() {
 #[test]
 fn repay_exact_reduces_debt_to_zero() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
 
-    let remaining = client.repay(&user, &100).unwrap();
+    let remaining = client.repay(&user, &100);
 
     assert_eq!(remaining, 0);
     assert_eq!(client.get_position(&user).debt, 0);
@@ -261,9 +269,10 @@ fn repay_exact_reduces_debt_to_zero() {
 #[test]
 fn repay_overpay_clamps_debt_to_zero() {
     let (_env, client, user) = setup();
+    client.deposit(&user, &200);
     client.borrow(&user, &100);
 
-    let remaining = client.repay(&user, &150).unwrap();
+    let remaining = client.repay(&user, &150);
 
     assert_eq!(remaining, 0);
     assert_eq!(client.get_position(&user).debt, 0);
@@ -273,7 +282,7 @@ fn repay_overpay_clamps_debt_to_zero() {
 fn repay_with_no_debt_returns_zero() {
     let (_env, client, user) = setup();
 
-    let remaining = client.repay(&user, &50).unwrap();
+    let remaining = client.repay(&user, &50);
 
     assert_eq!(remaining, 0);
     assert_eq!(client.get_position(&user).debt, 0);


### PR DESCRIPTION
## Summary

Closes #1527 

- Declares `zero_amount_semantics_test` as a test module in `lib.rs` so that its tests compile and run during test execution.
- Fixes compilation issues in `zero_amount_semantics_test.rs` by correcting client error assertions (`matches!(res, Err(Ok(LendingError::InvalidAmount)))`) and removing invalid `.unwrap()` calls on `repay()`.

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [x] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [x] Zero/negative/boundary values tested for numeric inputs
- [x] `cargo test` passes — no new failures beyond the known baseline

### Invariants
- [x] Skip (No functional changes introduced)

### Upgrade safety
- [x] Skip (No storage / signature changes)

### Monitoring / events
- [x] Skip (No event changes)

### Security notes
- [x] Skip (Test refactoring only)

### Docs
- [x] Skip (Test refactoring only)

### CI
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] No secrets or key material committed
