### PR TITLE
fix(lending): reject ltv_bps > liquidation_threshold_bps in set_asset…

### DIFF
--- a/stellar-lend/contracts/lending/src/cross_asset_test.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_test.rs
@@ -89,6 +89,24 @@ fn test_set_asset_params_rejects_invalid_ltv() {
 }
 
 #[test]
+fn test_set_asset_params_rejects_ltv_above_liquidation_threshold() {
+    let (_env, client, _id, admin, _user, asset_a, _asset_b) = setup();
+    let res = client.try_set_asset_params(
+        &admin,
+        &asset_a,
+        &9000i128, // LTV above liquidation threshold
+        &5000i128, // liquidation threshold
+        &1_000_000i128,
+        &0i128,
+        &0i128,
+    );
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InvalidLiquidationParams))
+    ));
+}
+
+#[test]
 fn test_unconfigured_asset_returns_none() {
     let (_env, client, _id, _admin, _user, _asset_a, _asset_b) = setup();
     let unknown = Address::generate(&_env);

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -359,6 +359,9 @@ pub enum LendingError {
     SelfLiquidation = 2008,
     IsolationCeilingExceeded = 2009,
     InvalidIsolationCeiling = 2010,
+    /// `set_asset_params` called with `ltv_bps > liquidation_threshold_bps`,
+    /// which would let a user borrow up to the max LTV while already being
+    /// eligible for liquidation.
     InvalidLiquidationParams = 2011,
     InvalidLiquidationGracePeriod = 7003,
     LiquidationGracePeriodNotMet = 7004,
@@ -551,7 +554,6 @@ pub struct LendingContract;
 
 #[allow(clippy::too_many_arguments)]
 #[contractimpl]
-#[allow(clippy::too_many_arguments)]
 impl LendingContract {
     /// One-time contract initialization — sets the protocol admin and seeds
     /// the emergency state to [`EmergencyState::Normal`].
@@ -1531,9 +1533,8 @@ impl LendingContract {
             // Clamp: never seize more than the borrower's available collateral.
             let available_collateral = collateral;
             let mut final_seized = seized_collateral;
-            let mut shortfall = 0;
             if seized_collateral > available_collateral {
-                shortfall = seized_collateral
+                let shortfall = seized_collateral
                     .checked_sub(available_collateral)
                     .ok_or(LendingError::Overflow)?;
                 let insurance_drawn = draw_insurance(&env, shortfall)?;
@@ -1996,6 +1997,10 @@ impl LendingContract {
     /// Configure per-asset risk parameters.
     ///
     /// Only the protocol admin can call this.
+    /// `ltv_bps` must not exceed `liquidation_threshold_bps` — otherwise a
+    /// user could borrow up to the max LTV while already eligible for
+    /// liquidation. Returns [`LendingError::InvalidLiquidationParams`] when
+    /// violated.
     /// Emits an `AssetParamsSetEvent` on success.
     #[allow(clippy::too_many_arguments)]
     pub fn set_asset_params(
@@ -2018,6 +2023,9 @@ impl LendingContract {
         }
         if !(0..=10000).contains(&liquidation_threshold_bps) {
             return Err(LendingError::InvalidAmount);
+        }
+        if ltv_bps > liquidation_threshold_bps {
+            return Err(LendingError::InvalidLiquidationParams);
         }
         if debt_ceiling < 0 {
             return Err(LendingError::InvalidAmount);


### PR DESCRIPTION
 closed #1438 

set_asset_params validated ltv_bps and liquidation_threshold_bps were each within 0..=10000 individually, but never checked their relationship. An admin (or a buggy governance proposal) could set ltv_bps above liquidation_threshold_bps, letting a user borrow up to the configured LTV while already eligible for liquidation.

Reuse the existing (previously unused) LendingError::InvalidLiquidationParams variant for this case, and add test_set_asset_params_rejects_ltv_above_liquidation_threshold covering it.

Also fix two pre-existing, unrelated clippy errors under -D warnings that blocked clippy from running on this crate at all: a duplicated #[allow(clippy::too_many_arguments)] attribute on the LendingContract impl block, and an unused initial assignment to `shortfall` in liquidate_asset (the variable is only read inside the branch that assigns it).

Verified no regressions: full suite is 580 passed / 34 failed with this change vs. 579 passed / 34 failed without it (the +1 is the new test) -- same 34 pre-existing failures either way, none related to set_asset_params.

## Summary
