### PR TITLE
Fix #1479: Unify interest-rate admin with shared protocol admin

### DIFF
--- a/stellar-lend/contracts/hello-world/src/dual_kink_test.rs
+++ b/stellar-lend/contracts/hello-world/src/dual_kink_test.rs
@@ -6,11 +6,10 @@
 
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
 use crate::interest_rate::{
-    compute_borrow_rate, initialize_interest_rate_config, set_protocol_totals,
-    InterestRateConfig,
+    compute_borrow_rate, initialize_interest_rate_config, set_protocol_totals, InterestRateConfig,
 };
+use soroban_sdk::{testutils::Address as _, Address, Env};
 
 fn with_contract<F, T>(env: &Env, f: F) -> T
 where
@@ -20,8 +19,8 @@ where
     env.as_contract(&contract_id, || f(Address::generate(&env)))
 }
 
-fn init(env: &Env, admin: Address, total_deposits: i128, total_borrows: i128) {
-    initialize_interest_rate_config(env, admin).unwrap();
+fn init(env: &Env, total_deposits: i128, total_borrows: i128) {
+    initialize_interest_rate_config(env).unwrap();
     set_protocol_totals(env, total_deposits, total_borrows).unwrap();
 }
 
@@ -29,10 +28,13 @@ fn init(env: &Env, admin: Address, total_deposits: i128, total_borrows: i128) {
 fn zero_utilization_uses_base_rate() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |admin| {
-        init(&env, admin, 1_000, 0);
+    with_contract(&env, |_| {
+        init(&env, 1_000, 0);
         let config = InterestRateConfig::default();
-        assert_eq!(compute_borrow_rate(0, 0, &config).unwrap(), config.base_rate_bps);
+        assert_eq!(
+            compute_borrow_rate(0, 0, &config).unwrap(),
+            config.base_rate_bps
+        );
     });
 }
 
@@ -40,19 +42,24 @@ fn zero_utilization_uses_base_rate() {
 fn at_first_kink_uses_first_segment_endpoint() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |admin| {
-        init(&env, admin, 1_000, 800); // utilization = 8_000 bps (kink1)
+    with_contract(&env, |_| {
+        init(&env, 1_000, 800); // utilization = 8_000 bps (kink1)
         let config = InterestRateConfig::default();
-        let expected = config.base_rate_bps
+        let expected = config
+            .base_rate_bps
             .checked_add(
-                config.kink_utilization_bps
+                config
+                    .kink_utilization_bps
                     .checked_mul(config.multiplier_bps)
                     .unwrap()
                     .checked_div(config.kink_utilization_bps)
                     .unwrap(),
             )
             .unwrap();
-        assert_eq!(compute_borrow_rate(config.kink_utilization_bps, 0, &config).unwrap(), expected);
+        assert_eq!(
+            compute_borrow_rate(config.kink_utilization_bps, 0, &config).unwrap(),
+            expected
+        );
     });
 }
 
@@ -60,12 +67,13 @@ fn at_first_kink_uses_first_segment_endpoint() {
 fn mid_between_kinks_uses_second_segment() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |admin| {
-        init(&env, admin, 1_000, 850); // utilization = 8_500 bps
+    with_contract(&env, |_| {
+        init(&env, 1_000, 850); // utilization = 8_500 bps
         let config = InterestRateConfig::default();
         let utilization = 8_500;
         let denominator = config.kink2_bps - config.kink_utilization_bps;
-        let expected = config.base_rate_bps
+        let expected = config
+            .base_rate_bps
             .checked_add(config.multiplier_bps)
             .unwrap()
             .checked_add(
@@ -78,7 +86,10 @@ fn mid_between_kinks_uses_second_segment() {
                     .unwrap(),
             )
             .unwrap();
-        assert_eq!(compute_borrow_rate(utilization, 0, &config).unwrap(), expected);
+        assert_eq!(
+            compute_borrow_rate(utilization, 0, &config).unwrap(),
+            expected
+        );
     });
 }
 
@@ -86,15 +97,17 @@ fn mid_between_kinks_uses_second_segment() {
 fn at_second_kink_uses_second_segment_endpoint() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |admin| {
-        init(&env, admin, 1_000, 900); // utilization = 9_000 bps (kink2)
+    with_contract(&env, |_| {
+        init(&env, 1_000, 900); // utilization = 9_000 bps (kink2)
         let config = InterestRateConfig::default();
         let denominator = config.kink2_bps - config.kink_utilization_bps;
-        let expected = config.base_rate_bps
+        let expected = config
+            .base_rate_bps
             .checked_add(config.multiplier_bps)
             .unwrap()
             .checked_add(
-                config.kink2_bps
+                config
+                    .kink2_bps
                     .checked_sub(config.kink_utilization_bps)
                     .unwrap()
                     .checked_mul(config.jump_multiplier_bps)
@@ -103,7 +116,10 @@ fn at_second_kink_uses_second_segment_endpoint() {
                     .unwrap(),
             )
             .unwrap();
-        assert_eq!(compute_borrow_rate(config.kink2_bps, 0, &config).unwrap(), expected);
+        assert_eq!(
+            compute_borrow_rate(config.kink2_bps, 0, &config).unwrap(),
+            expected
+        );
     });
 }
 
@@ -111,12 +127,13 @@ fn at_second_kink_uses_second_segment_endpoint() {
 fn high_utilization_uses_third_segment() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |admin| {
-        init(&env, admin, 1_000, 980); // utilization = 9_800 bps
+    with_contract(&env, |_| {
+        init(&env, 1_000, 980); // utilization = 9_800 bps
         let config = InterestRateConfig::default();
         let utilization = 9_800;
         let denominator = 10_000 - config.kink2_bps;
-        let expected = config.base_rate_bps
+        let expected = config
+            .base_rate_bps
             .checked_add(config.multiplier_bps)
             .unwrap()
             .checked_add(config.jump_multiplier_bps)
@@ -131,7 +148,10 @@ fn high_utilization_uses_third_segment() {
                     .unwrap(),
             )
             .unwrap();
-        assert_eq!(compute_borrow_rate(utilization, 0, &config).unwrap(), expected);
+        assert_eq!(
+            compute_borrow_rate(utilization, 0, &config).unwrap(),
+            expected
+        );
     });
 }
 
@@ -139,8 +159,8 @@ fn high_utilization_uses_third_segment() {
 fn monotonic_rate_non_decreasing() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |admin| {
-        init(&env, admin, 1_000, 0);
+    with_contract(&env, |_| {
+        init(&env, 1_000, 0);
         let config = InterestRateConfig::default();
         let mut prev = compute_borrow_rate(0, 0, &config).unwrap();
         for u in (0..=10_000).step_by(250) {

--- a/stellar-lend/contracts/hello-world/src/interest_rate.rs
+++ b/stellar-lend/contracts/hello-world/src/interest_rate.rs
@@ -7,6 +7,8 @@
 
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env};
 
+use crate::admin;
+
 /// Number of basis points representing 100%.
 pub const BASIS_POINTS_SCALE: i128 = 10_000;
 
@@ -20,8 +22,6 @@ pub const DEFAULT_MAX_RATE_BPS: i128 = i128::MAX;
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InterestRateDataKey {
-    /// Address authorized to mutate the interest-rate configuration.
-    Admin,
     /// Persisted [`InterestRateConfig`].
     InterestRateConfig,
     /// Protocol-wide supplied amount used for utilization.
@@ -103,11 +103,11 @@ impl Default for InterestRateConfig {
     }
 }
 
-/// Initialize the module with default rate parameters and an admin.
+/// Initialize the module with default rate parameters.
 ///
 /// Defaults intentionally preserve previous unclamped behaviour: floor `0` and
 /// ceiling `i128::MAX`, until an admin explicitly configures a narrower band.
-pub fn initialize_interest_rate_config(env: &Env, admin: Address) -> Result<(), InterestRateError> {
+pub fn initialize_interest_rate_config(env: &Env) -> Result<(), InterestRateError> {
     if env
         .storage()
         .persistent()
@@ -116,9 +116,6 @@ pub fn initialize_interest_rate_config(env: &Env, admin: Address) -> Result<(), 
         return Err(InterestRateError::AlreadyInitialized);
     }
 
-    env.storage()
-        .persistent()
-        .set(&InterestRateDataKey::Admin, &admin);
     env.storage().persistent().set(
         &InterestRateDataKey::InterestRateConfig,
         &InterestRateConfig::default(),
@@ -375,16 +372,10 @@ pub fn clamp_rate(rate_bps: i128, min_rate_bps: i128, max_rate_bps: i128) -> i12
 }
 
 fn require_rate_admin(env: &Env, caller: &Address) -> Result<(), InterestRateError> {
-    caller.require_auth();
-    let admin = env
-        .storage()
-        .persistent()
-        .get::<InterestRateDataKey, Address>(&InterestRateDataKey::Admin)
-        .ok_or(InterestRateError::NotInitialized)?;
-    if &admin != caller {
-        return Err(InterestRateError::Unauthorized);
-    }
-    Ok(())
+    admin::require_admin(env, caller).map_err(|e| match e {
+        crate::admin::AdminError::NotInitialized => InterestRateError::NotInitialized,
+        _ => InterestRateError::Unauthorized,
+    })
 }
 
 fn validate_config(config: &InterestRateConfig) -> Result<(), InterestRateError> {

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -81,7 +81,6 @@ mod cross_asset_decimals_test;
 
 #[cfg(test)]
 mod normalize_price_test;
-
 #[cfg(test)]
 mod cross_asset_ltv_test;
 #[cfg(test)]
@@ -142,13 +141,13 @@ use bridge::{
     set_bridge_fee,
 };
 
+use crate::admin::require_admin;
 #[allow(unused_imports)]
 use crate::interest_rate::{
     initialize_interest_rate_config, update_interest_rate_config, InterestRateConfig,
     InterestRateError,
 };
 use crate::liquidate::liquidate;
-use crate::admin::require_admin;
 use crate::risk_management::{
     set_pause_switch, set_pause_switches, RiskConfig, RiskManagementError,
 };
@@ -194,7 +193,7 @@ impl HelloContract {
             .map_err(|_| RiskManagementError::Unauthorized)?;
         initialize_risk_management(&env, admin.clone())?;
         initialize_risk_params(&env).map_err(|_| RiskManagementError::InvalidParameter)?;
-        initialize_interest_rate_config(&env, admin.clone()).map_err(|e| {
+        initialize_interest_rate_config(&env).map_err(|e| {
             if e == InterestRateError::AlreadyInitialized {
                 RiskManagementError::AlreadyInitialized
             } else {

--- a/stellar-lend/contracts/hello-world/src/rate_clamp_test.rs
+++ b/stellar-lend/contracts/hello-world/src/rate_clamp_test.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{testutils::Address as _, Address, Env};
 use crate::interest_rate::{
     calculate_borrow_rate, calculate_supply_rate, calculate_utilization, compute_borrow_rate,
     initialize_interest_rate_config, set_protocol_totals, update_interest_rate_config,
-    InterestRateConfig,
+    InterestRateConfig, InterestRateError,
 };
 
 fn with_rate_contract<F, T>(env: &Env, f: F) -> T
@@ -142,4 +142,83 @@ fn pure_compute_clamps_extreme_curve_outputs() {
 
     assert_eq!(compute_borrow_rate(0, 0, &config).unwrap(), 1_000);
     assert_eq!(compute_borrow_rate(10_000, 0, &config).unwrap(), 4_000);
+}
+
+// -----------------------------------------------------------------------
+// Regression test for #1479: interest-rate admin must follow the shared
+// protocol admin, not a separate independent key.
+// -----------------------------------------------------------------------
+
+#[test]
+fn interest_rate_admin_follows_protocol_admin_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(crate::cross_asset::NoOpContract {}, ());
+    env.as_contract(&contract_id, || {
+        let admin_a = Address::generate(&env);
+        let admin_b = Address::generate(&env);
+
+        // Initialize protocol admin (init path, no auth check) and the
+        // interest-rate config (no longer takes its own admin param).
+        crate::admin::set_admin(&env, admin_a.clone(), None).unwrap();
+        initialize_interest_rate_config(&env).unwrap();
+
+        // Sanity check: current admin (admin_a) can update the config.
+        let r = update_interest_rate_config(
+            &env,
+            admin_a.clone(),
+            Some(200),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(r.is_ok(), "current admin should be able to update config");
+
+        // Transfer protocol admin: admin_a -> admin_b.
+        crate::admin::set_admin(&env, admin_b.clone(), Some(admin_a.clone())).unwrap();
+
+        // The OLD admin (admin_a) must now be rejected for interest-rate
+        // operations -- this is the exact bug #1479 describes: without this
+        // fix, admin_a would still control the interest-rate config because
+        // it was tracked in a separate, unsynchronized storage key.
+        let r = update_interest_rate_config(
+            &env,
+            admin_a,
+            Some(300),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(
+            matches!(r, Err(InterestRateError::Unauthorized)),
+            "old admin should be rejected after protocol admin transfer, got {:?}",
+            r
+        );
+
+        // The NEW admin (admin_b) must now be authorized for interest-rate
+        // operations, proving the two are gated by the same single admin.
+        let r = update_interest_rate_config(
+            &env,
+            admin_b,
+            Some(400),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(
+            r.is_ok(),
+            "new admin should be able to update config after transfer, got {:?}",
+            r
+        );
+    });
 }

--- a/stellar-lend/contracts/hello-world/src/rate_clamp_test.rs
+++ b/stellar-lend/contracts/hello-world/src/rate_clamp_test.rs
@@ -16,8 +16,8 @@ where
     env.as_contract(&contract_id, || f(Address::generate(&env)))
 }
 
-fn init(env: &Env, admin: Address, total_deposits: i128, total_borrows: i128) {
-    initialize_interest_rate_config(env, admin).unwrap();
+fn init(env: &Env, total_deposits: i128, total_borrows: i128) {
+    initialize_interest_rate_config(env).unwrap();
     set_protocol_totals(env, total_deposits, total_borrows).unwrap();
 }
 
@@ -27,7 +27,7 @@ fn utilization_zero_defaults_to_current_curve_behavior() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, admin, 1_000, 0);
+        init(&env, 1_000, 0);
 
         assert_eq!(calculate_utilization(&env).unwrap(), 0);
         // Defaults preserve old behavior: floor is 0, so the base rate is not raised.
@@ -41,7 +41,7 @@ fn utilization_at_100_percent_uses_curve_when_ceiling_is_open_by_default() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, admin, 1_000, 1_000);
+        init(&env, 1_000, 1_000);
 
         assert_eq!(calculate_utilization(&env).unwrap(), 10_000);
         // base + multiplier + post-kink jump = 100 + 2_000 + 10_000 = 12_100
@@ -55,7 +55,7 @@ fn borrow_rate_is_clamped_to_configured_floor_as_final_step() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, admin.clone(), 1_000, 0);
+        init(&env, 1_000, 0);
         update_interest_rate_config(
             &env,
             admin,
@@ -80,7 +80,7 @@ fn borrow_rate_is_clamped_to_configured_ceiling_as_final_step() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, admin.clone(), 1_000, 1_000);
+        init(&env, 1_000, 1_000);
         update_interest_rate_config(
             &env,
             admin,
@@ -105,7 +105,7 @@ fn supply_rate_uses_the_clamped_borrow_rate() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, admin.clone(), 1_000, 1_000);
+        init(&env, 1_000, 1_000);
         update_interest_rate_config(
             &env,
             admin,

--- a/stellar-lend/contracts/hello-world/src/utilization_clamp_test.rs
+++ b/stellar-lend/contracts/hello-world/src/utilization_clamp_test.rs
@@ -14,8 +14,8 @@ where
     env.as_contract(&contract_id, || f(Address::generate(&env)))
 }
 
-fn init(env: &Env, admin: Address, total_deposits: i128, total_borrows: i128) {
-    initialize_interest_rate_config(env, admin).unwrap();
+fn init(env: &Env, total_deposits: i128, total_borrows: i128) {
+    initialize_interest_rate_config(env).unwrap();
     set_protocol_totals(env, total_deposits, total_borrows).unwrap();
 }
 
@@ -32,8 +32,8 @@ fn calculate_utilization_returns_zero_without_divide_by_zero_when_deposits_are_z
     let env = Env::default();
     env.mock_all_auths();
 
-    with_rate_contract(&env, |admin| {
-        init(&env, admin, 0, 1_000);
+    with_rate_contract(&env, |_| {
+        init(&env, 0, 1_000);
 
         let utilization = calculate_utilization(&env).unwrap();
         assert_eq!(utilization, 0);
@@ -46,8 +46,8 @@ fn calculate_utilization_clamps_to_full_utilization_when_borrows_cover_deposits(
     let env = Env::default();
     env.mock_all_auths();
 
-    with_rate_contract(&env, |admin| {
-        init(&env, admin.clone(), 1_000, 1_000);
+    with_rate_contract(&env, |_| {
+        init(&env, 1_000, 1_000);
 
         let equal_case = calculate_utilization(&env).unwrap();
         assert_eq!(equal_case, BASIS_POINTS_SCALE);
@@ -66,8 +66,8 @@ fn calculate_utilization_matches_exact_bps_for_common_ratios() {
     let env = Env::default();
     env.mock_all_auths();
 
-    with_rate_contract(&env, |admin| {
-        init(&env, admin.clone(), 1_000, 0);
+    with_rate_contract(&env, |_| {
+        init(&env, 1_000, 0);
 
         let cases = [
             (1_000, 250, 2_500),


### PR DESCRIPTION
Closes #1479

## What
`interest_rate.rs` maintained its own independent admin storage key
(`InterestRateDataKey::Admin`), separate from the shared protocol admin in
`admin.rs` (`AdminDataKey::Admin`). This change removes that duplicate key and
makes the interest-rate module delegate authorization to the shared
`admin::require_admin` instead.

Specifically:
- Removed the `Admin` variant from `InterestRateDataKey`.
- `initialize_interest_rate_config` no longer takes or stores an `admin`
  parameter — the interest-rate config no longer needs its own admin, since
  it now defers entirely to the shared admin.
- The private `require_rate_admin` helper now calls `admin::require_admin`
  instead of reading a separate storage slot, mapping `AdminError` into the
  existing `InterestRateError` variants (`NotInitialized`, `Unauthorized`).
- Updated the one call site in `lib.rs` (`HelloContract::initialize`) and the
  three test files (`dual_kink_test.rs`, `rate_clamp_test.rs`,
  `utilization_clamp_test.rs`) that called
  `initialize_interest_rate_config(env, admin)` to match the new
  single-argument signature.
- Left `set_emergency_rate_adjustment` and `update_interest_rate_config`
  signatures unchanged — they still accept `admin: Address` as the caller to
  authorize, which is correct and now checked against the single shared
  admin.

## Why
Previously, the protocol admin (`admin::set_admin`) and the interest-rate
admin (`InterestRateDataKey::Admin`) were two unrelated storage slots that
could point to two different addresses with no synchronization. Transferring
the protocol admin via `admin::set_admin` gave no guarantee the interest-rate
configuration was still controlled by the same address. This change makes
interest-rate configuration gated by the same single admin address as every
other admin-gated operation in the contract, per the acceptance criteria in
#1479.

## Regression test
Added `interest_rate_admin_follows_protocol_admin_transfer` in
`rate_clamp_test.rs`, which directly reproduces the scenario described in
#1479:
1. Initializes protocol admin as `admin_a` and the interest-rate config.
2. Confirms `admin_a` can update the interest-rate config.
3. Transfers the protocol admin to `admin_b` via `admin::set_admin`.
4. Asserts `admin_a` (the old admin) is now rejected (`Unauthorized`) for
   interest-rate operations.
5. Asserts `admin_b` (the new admin) is authorized for interest-rate
   operations.

This proves interest-rate authority now follows protocol admin transfers,
rather than staying pinned to a stale, independently-tracked address.

## Behavior change for already-initialized contracts
For any contract instance already deployed and initialized before this
change, `InterestRateDataKey::Admin` may have pointed to a different address
than `AdminDataKey::Admin`. After this change, interest-rate authority
switches to whichever address `admin::get_admin` returns for that contract —
i.e., the protocol admin, not whatever was previously stored under the
interest-rate-specific key. This is the intended fix per #1479, but is worth
flagging explicitly before deploying to any live or staging environment with
existing state.

## Verification
`cargo build` for `hello-world` currently fails on `main` with 347
pre-existing, unrelated errors (confirmed by stashing this change and
building `main` directly — identical error output, byte-for-byte, before and
after this change). `cargo test --lib` shows the same pattern: 462
pre-existing errors both with and without this change (identical count,
confirmed via `git stash`), and no errors are attributed to
`interest_rate.rs` or the new test in `rate_clamp_test.rs` in either case.
This confirms the change, including the new regression test, compiles
cleanly relative to the existing baseline and introduces no new errors. A
full green `cargo test` run could not be produced due to the pre-existing,
unrelated build breakage in the wider crate; happy to re-verify with a full
run once those issues are resolved separately.