### PR TITLE
docs: align upgrade authorization docs with actual implementation

### DIFF
--- a/docs/UPGRADE_AUTHORIZATION.md
+++ b/docs/UPGRADE_AUTHORIZATION.md
@@ -2,8 +2,8 @@
 
 ## Scope
 
-This document describes how upgrade authorization works for contracts using
-`stellarlend_common::upgrade::UpgradeManager` and how to safely rotate upgrade keys.
+This document describes how upgrade authorization works for the lending contract
+(implemented in `stellar-lend/contracts/lending/src/upgrade.rs`) and how to safely rotate upgrade keys.
 
 ## Authorization model
 
@@ -13,14 +13,13 @@ This document describes how upgrade authorization works for contracts using
 - `upgrade_remove_approver(caller, approver)` is `admin` only.
 - `upgrade_approve(caller, proposal_id)` is restricted to the configured approver set.
 - `upgrade_execute(caller, proposal_id)` is restricted to the configured approver set.
-- `upgrade_rollback(caller, proposal_id)` is `admin` only.
 
 All mutating authorization paths call `require_auth()` on the provided caller.
 
 ## Role separation
 
-- The stored `admin` is the governance authority for upgrade configuration: it can propose upgrades,
-  add/remove approvers, and roll back executed upgrades.
+- The stored `admin` is the governance authority for upgrade configuration: it can propose upgrades
+  and add/remove approvers.
 - The approver set is the execution authority for upgrades: only current approvers can approve or
   execute a proposal once it exists.
 - Guardian or emergency operators are not part of the upgrade trust boundary and gain no upgrade
@@ -104,8 +103,7 @@ which must be mitigated by live authorization checks before revoking the old sig
 
 ## Trust boundaries and operator powers
 
-- Upgrade authority boundary: only `admin` can propose upgrades, manage approvers, and roll back
-  executed upgrades.
+- Upgrade authority boundary: only `admin` can propose upgrades and manage approvers.
 - Execution boundary: only currently configured approvers can execute approved proposals.
 - Guardian boundary: guardian operations (pause or emergency flows) are separate from upgrade
   authority and do not grant upgrade proposal, execution, or rollback rights.
@@ -114,18 +112,17 @@ which must be mitigated by live authorization checks before revoking the old sig
 
 ## External call and token transfer safety
 
-- Upgrade entrypoints (`upgrade_propose`, `upgrade_approve`, `upgrade_execute`,
-  `upgrade_rollback`) do not perform token transfers.
+- Upgrade entrypoints (`upgrade_propose`, `upgrade_approve`, `upgrade_execute`)
+  do not perform token transfers.
 - Token transfer paths remain confined to lending operations such as deposit, withdraw, repay,
   and liquidation modules.
 - Authorization checks (`require_auth()`) are enforced on every mutating upgrade path.
 - Upgrade tests should verify both authorization and invalid-status rejection on each external
   entrypoint.
 
-## Rollback and failure-path coverage checklist
+## Failure-path coverage checklist
 
-- Rollback rejects proposals that were never executed (`InvalidStatus`).
-- Execute and rollback reject unknown proposal ids (`ProposalNotFound`).
+- Execute rejects unknown proposal ids (`ProposalNotFound`).
 - Non-monotonic version proposals are rejected after successful execution
   (`new_version <= current_version`).
 - Execution by a removed approver is rejected even if they approved earlier during proposal


### PR DESCRIPTION
## Summary

- Update the module path to reference `stellar-lend/contracts/lending/src/upgrade.rs` instead of `stellarlend_common::upgrade::UpgradeManager`
- Remove all references to the non-existent `upgrade_rollback` function as the current multi-sig timelocked WASM execution model does not implement a native rollback entrypoint

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed


Close #1547