### PR TITLE
fix: correct get_admin documentation and implement try_get_admin

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -70,9 +70,9 @@ The protocol has a single super-admin whose address is stored under
 `DataKey::Admin`. The admin has clearance for all privileged operations listed
 above.
 
-`get_admin()` returns `Result<Address, LendingError>` — a `NotInitialized`
-error signals that `initialize` has not been called. Callers should use
-`try_get_admin()` if the contract may be uninitialized.
+`get_admin()` returns `Address` and panics if `initialize` has not been called.
+Callers should use `try_get_admin()` if the contract may be uninitialized,
+which returns `Option<Address>`.
 
 ---
 

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -581,6 +581,10 @@ impl LendingContract {
         env.storage().instance().get(&DataKey::Admin).unwrap()
     }
 
+    pub fn try_get_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Admin)
+    }
+
     /// Returns the accumulated protocol bad debt.
     pub fn get_bad_debt(env: Env) -> i128 {
         env.storage()


### PR DESCRIPTION
## Summary

- Updated `docs/admin.md` to correctly reflect that `get_admin()` returns
  an `Address` and panics if the contract is uninitialized.
- Implemented the missing `try_get_admin()` method in `LendingContract` 
  (`stellar-lend/contracts/lending/src/lib.rs`), which returns `Option<Address>` 
  to provide a safe, panic-free way to query the admin address as originally 
  suggested by the documentation.

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed


Close #1545