### PR TITLE
chore(hello-world): remove unreferenced flash_loan_test.rs and test_r…

### DIFF
--- a/stellar-lend/contracts/hello-world/src/flash_loan_test.rs
+++ b/stellar-lend/contracts/hello-world/src/flash_loan_test.rs
@@ -1,1 +1,0 @@
-// Stub module

--- a/stellar-lend/contracts/hello-world/src/test_reentrancy.rs
+++ b/stellar-lend/contracts/hello-world/src/test_reentrancy.rs
@@ -1,1 +1,0 @@
-// Stub module


### PR DESCRIPTION
closed #1471 

Both files contained only `// Stub module` and were never declared via `mod` anywhere in the crate -- not compiled, not run by cargo test, not visible to the module system. Removing them rather than wiring them up with real coverage: the hello-world crate currently has ~13 other modules (analytics, borrow, config, config_snapshot, deposit, errors, liquidate, multisig, recovery, repay, reserve, risk_management, risk_params) in the same one-line-stub state left over from commit 3d469308 ("fix: get CI pipeline passing by replacing broken contracts with minimal stubs", 2026-05-14), and lib.rs still references dozens of functions/types from them. The crate does not currently compile at all (348 errors on a clean build) -- writing real reentrancy-guard and flash-loan-repayment tests would require first reimplementing a large fraction of the contract's business logic, which is well beyond the scope of removing two dead test-scaffolding files. hello-world is not covered by CI (only contracts/lending is), which is how this went unnoticed.

