### PR TITLE
Fix/1539 bad debt docs update

### DIFF
--- a/docs/PROJECT_SUMMARY.md
+++ b/docs/PROJECT_SUMMARY.md
@@ -162,12 +162,12 @@ The project maintains an extensive test suite with **>95% coverage target** for 
 - `deposit_collateral(user, asset, amount)` → `Result<(), BorrowError>`
 
 ### View Functions (Read-Only)
-- `get_user_position(user)` → `UserPositionSummary`
+- `get_position(user)` / `get_user_position(user)` → `PositionSummary`
 - `get_health_factor(user)` → `i128`
 - `get_collateral_value(user)` → `i128`
 - `get_debt_value(user)` → `i128`
 - `get_max_liquidatable_amount(user)` → `i128`
-- `get_liquidation_incentive_amount(repay_amount)` → `i128`
+- `get_liquidation_incentive_bps()` → `i128`
 - `get_emergency_state()` → `EmergencyState`
 - `get_performance_stats()` → `Vec<u64>`
 - `get_price(asset)` → `Result<i128, OracleError>`

--- a/docs/VIEW_SCHEMA_VERSIONING_POLICY.md
+++ b/docs/VIEW_SCHEMA_VERSIONING_POLICY.md
@@ -8,7 +8,7 @@ This document outlines the versioning policy for the `get_user_position` view fu
 
 ### Schema Stability Guarantee
 
-The `UserPositionSummary` struct and all individual view functions (`get_collateral_balance`, `get_debt_balance`, `get_collateral_value`, `get_debt_value`, `get_health_factor`, `get_max_liquidatable_amount`, `get_liquidation_incentive_amount`) are considered **schema v1** and must remain stable across all contract upgrades.
+The `UserPositionSummary` struct and all individual view functions (`get_collateral_balance`, `get_debt_balance`, `get_collateral_value`, `get_debt_value`, `get_health_factor`, `get_max_liquidatable_amount`, `get_liquidation_incentive_bps`) are considered **schema v1** and must remain stable across all contract upgrades.
 
 ### Versioning Rules
 

--- a/stellar-lend/contracts/lending/bad_debt_accounting.md
+++ b/stellar-lend/contracts/lending/bad_debt_accounting.md
@@ -121,7 +121,7 @@ or `LendingError::ReservesNegative`).
 | I-3 | `total_borrows >= 0` | `assert_market_invariants` |
 | I-4 | `total_deposits >= 0` | `assert_market_invariants` |
 | I-5 | `total_deposits - total_borrows + reserves - bad_debt >= 0` _(nominal solvency)_ | logged, not aborted |
-| I-6 | After write-off: `user.borrowed == 0` | `record_bad_debt` |
+| I-6 | After write-off: `user.borrowed == 0` | `liquidate` |
 
 **Note on I-5:** When `bad_debt > reserves`, the protocol is nominally insolvent —
 depositors bear an economic loss equal to `bad_debt - reserves`.  This is an
@@ -130,25 +130,22 @@ in degraded mode.  Governance recovers solvency by topping up reserves.
 
 ---
 
-## 4. Write-Off Flow
+## 4. Bad-Debt Recording and Write-Off Flow
 
 ```
-liquidate()  ──or──  emergency_liquidate()
+liquidate()
         │
-        │  collateral fully seized, residual > 0?
+        │  collateral fully seized, shortfall > insurance?
         │
         ▼
-record_bad_debt(user, asset, residual, collateral_seized)
+Inline Bad-Debt Recording (inside liquidate)
         │
-        ├─ 1. Zero user.borrow                      [I-6]
-        ├─ 2. Decrement market.total_borrows
-        ├─ 3. reserve_cover = min(residual, reserves)
-        ├─ 4. market.reserves -= reserve_cover      [I-2]
-        ├─ 5. written_off = residual - reserve_cover
-        ├─ 6. market.bad_debt += written_off        [I-1]
-        ├─ 7. Store per-user audit record
-        ├─ 8. assert_market_invariants()
-        └─ 9. Persist market state
+        ├─ 1. Calculate shortfall = seized_collateral - available_collateral
+        ├─ 2. Draw insurance cover = min(shortfall, insurance_fund)
+        ├─ 3. residual = shortfall - insurance_drawn
+        ├─ 4. Increase market bad_debt accumulators += residual   [I-1]
+        ├─ 5. Decrement debt and available collateral
+        └─ 6. Emit bad_debt event
 ```
 
 ---
@@ -179,16 +176,15 @@ When governance triggers an emergency shutdown:
 1. Global shutdown flag is set — new borrows and deposits are rejected.
 2. Every specified market is **frozen** (same effect for deposits/borrows).
 3. **Liquidations remain open** so bad debt can still be cleared.
-4. `emergency_liquidate()` bypasses the close factor — the full position is
-   liquidated in a single call.
+4. `liquidate()` remains available so positions can still be liquidated.
 
 ### Shutdown accounting example
 
 | Step | Action | Result |
 |------|--------|--------|
 | 1 | Borrower has 1 ETH @ $500 collateral, 1000 USDC debt | shortfall = $500 |
-| 2 | `emergency_liquidate()` seizes 1 ETH → $500 value | collateral_seized = 1 ETH |
-| 3 | `record_bad_debt(residual=$500)` | reserve_cover = min($500, reserves) |
+| 2 | `liquidate()` seizes 1 ETH → $500 value | collateral_seized = 1 ETH |
+| 3 | Bad debt recorded inline (`residual=$500`) | reserve_cover = min($500, reserves) |
 | 4 | reserves = 0 → written_off = $500 | market.bad_debt += $500 |
 | 5 | User borrow zeroed | [I-6] satisfied |
 | 6 | Governance tops up $500 reserves | bad_debt → 0 |
@@ -222,7 +218,7 @@ Liquidation call 1:  repay 1000 USDC (50% close factor)
 Liquidation call 2:  repay 1000 USDC
   seized = min(1.35 ETH, 0.65 ETH) = 0.65 ETH ($520 value)
   residual = $1000 − $520 = $480
-  record_bad_debt(residual=$480)
+  liquidate() records bad debt inline (residual=$480)
 ```
 
 ---
@@ -247,7 +243,7 @@ Liquidation call 2:  repay 1000 USDC
 ### Re-entrancy
 - All state writes are committed atomically in Soroban's transaction model.
   There is no external call between reading and writing state in
-  `record_bad_debt`, so re-entrancy is structurally impossible.
+  `liquidate` or `write_off_bad_debt`, so re-entrancy is structurally impossible.
 
 ### Oracle manipulation
 - A manipulated oracle price could make a healthy position appear unhealthy
@@ -316,7 +312,7 @@ _Entrypoint added in feature/bad-debt-write-off._
 
 ### 11.1 Purpose
 
-`record_bad_debt` causes `bad_debt` to grow monotonically. Without a
+Liquidations resulting in unrecovered debt cause `bad_debt` to grow monotonically. Without a
 resolution path, the protocol remains nominally insolvent indefinitely.
 `write_off_bad_debt(amount)` provides the governed, auditable mechanism to
 clear recorded bad debt against available backstops.

--- a/stellar-lend/contracts/lending/src/health_factor_edge_test.rs
+++ b/stellar-lend/contracts/lending/src/health_factor_edge_test.rs
@@ -21,8 +21,12 @@ fn assert_health_factor_consistency(
     expected: i128,
 ) {
     let position = client.get_position(user);
+    let user_position = client.get_user_position(user);
     let health_factor = client.get_health_factor(user);
 
+    assert_eq!(position.collateral, user_position.collateral);
+    assert_eq!(position.debt, user_position.debt);
+    assert_eq!(position.health_factor, user_position.health_factor);
     assert_eq!(position.health_factor, expected);
     assert_eq!(health_factor, expected);
 }

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -1927,6 +1927,11 @@ impl LendingContract {
         }
     }
 
+    /// Alias for [`Self::get_position`] for API compatibility.
+    pub fn get_user_position(env: Env, user: Address) -> PositionSummary {
+        Self::get_position(env, user)
+    }
+
     /// Get the health factor for a user. Read-only view.
     /// Computed as: `(collateral * LIQUIDATION_THRESHOLD_BPS) / debt`
     /// Returns `HEALTH_FACTOR_NO_DEBT` sentinel if user has no debt.

--- a/stellar-lend/contracts/lending/views.md
+++ b/stellar-lend/contracts/lending/views.md
@@ -6,9 +6,12 @@ This document describes the view functions for user collateral value, debt value
 
 | Function | Description |
 |----------|-------------|
-| `get_position` | Returns full position summary (collateral, effective debt, health factor). |
+| Function | Description |
+|----------|-------------|
+| `get_position` | Returns full position summary (collateral, effective debt, health factor). Thin alias: `get_user_position`. |
 | `get_health_factor` | Health factor (scaled 10000 = 1.0). |
 | `get_debt_position` | Returns debt position struct (principal + last_update). |
+| `get_liquidation_incentive_bps` | Returns configured liquidation incentive in basis points (e.g. 1000 = 10%). |
 
 ---
 
@@ -17,6 +20,7 @@ This document describes the view functions for user collateral value, debt value
 - **Purpose:** Returns the user's position summary: raw collateral balance, effective debt (principal + accrued interest), and health factor.
 - **Read-only:** Yes. Extends TTL for active positions.
 - **Returns:** `PositionSummary { collateral: i128, debt: i128, health_factor: i128 }`. Zero-valued fields if the user has no position.
+- **Alias:** `get_user_position(user: Address)` is available as a thin alias for API and frontend compatibility.
 - **Health factor formula:** `(collateral * LIQUIDATION_THRESHOLD_BPS) / debt` with `LIQUIDATION_THRESHOLD_BPS = 8000` (80%).
 - **Special health factor values:**
   - No debt: returns `HEALTH_FACTOR_NO_DEBT` (100_000_000), meaning "healthy".
@@ -59,6 +63,14 @@ The `health_factor_edge_test` suite pins both `get_position().health_factor` and
 
 ---
 
+## 4. `get_liquidation_incentive_bps() -> i128`
+
+- **Purpose:** Returns the configured liquidation incentive in basis points applied during liquidations.
+- **Read-only:** Yes.
+- **Returns:** Configured basis points (`i128`), defaulting to `1000` (10%) when unset.
+
+---
+
 ## Security Assumptions
 
 1. **No state change:** All view functions only read storage. They do not modify protocol or user state beyond TTL extension.
@@ -83,7 +95,7 @@ weakened without an explicit, audited change.
 
 ### G1. Summary–getter consistency
 
-`get_user_position(user)` must return field-for-field exactly what the
+`get_position(user)` (or alias `get_user_position(user)`) must return field-for-field exactly what the
 individual getters return for the same `user` at the same ledger height:
 
 - `summary.collateral_balance == get_collateral_balance(user)`
@@ -122,9 +134,8 @@ ceiling rounding or float math will break the invariant suite.
 
 ### G6. Liquidation-incentive monotonicity
 
-`get_liquidation_incentive_amount(repay)` is monotonic non-decreasing in
-`repay`. Negative or zero `repay` always yields `0`. This forbids a future
-incentive curve that liquidators could game by splitting repayments.
+`get_liquidation_incentive_bps()` returns non-negative liquidation incentive basis points.
+Configured incentive rates produce non-decreasing bonus collateral in liquidation calculations.
 
 ### G7. Independence across users
 


### PR DESCRIPTION
closes #1539
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
