### PR TITLE
Fix vesting double claim

### DIFF
--- a/stellar-lend/contracts/hello-world/src/config.rs
+++ b/stellar-lend/contracts/hello-world/src/config.rs
@@ -1,1 +1,0 @@
-// Stub module

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -28,7 +28,6 @@ pub mod amm_twap;
 pub mod analytics;
 pub mod borrow;
 pub mod bridge;
-pub mod config;
 pub mod config_snapshot;
 pub mod cross_asset;
 pub mod deposit;
@@ -125,7 +124,6 @@ use crate::analytics::{
     AnalyticsError, ProtocolReport, UserReport,
 };
 use crate::bridge::{BridgeConfig, BridgeError};
-use crate::config::{config_backup, config_get, config_restore, config_set, ConfigError};
 use crate::cross_asset::{
     get_asset_config_by_address, get_asset_list, get_total_borrow_for, get_total_supply_for,
     get_user_asset_position, get_user_position_summary, initialize_asset, update_asset_config,
@@ -812,43 +810,6 @@ impl HelloContract {
     /// Get configuration of a specific bridge.
     pub fn get_bridge_config(env: Env, network_id: u32) -> Result<BridgeConfig, BridgeError> {
         bridge::get_bridge_config(&env, network_id)
-    }
-
-    // ============================================================================
-    // Config Methods
-    // ============================================================================
-
-    /// Set a configuration value (admin only).
-    pub fn config_set(
-        env: Env,
-        caller: Address,
-        key: soroban_sdk::Symbol,
-        value: soroban_sdk::Val,
-    ) -> Result<(), ConfigError> {
-        config_set(&env, caller, key, value)
-    }
-
-    /// Get a configuration value.
-    pub fn config_get(env: Env, key: soroban_sdk::Symbol) -> Option<soroban_sdk::Val> {
-        config_get(&env, key)
-    }
-
-    /// Backup configuration parameters (admin only).
-    pub fn config_backup(
-        env: Env,
-        caller: Address,
-        keys: soroban_sdk::Vec<soroban_sdk::Symbol>,
-    ) -> Result<soroban_sdk::Vec<(soroban_sdk::Symbol, soroban_sdk::Val)>, ConfigError> {
-        config_backup(&env, caller, keys)
-    }
-
-    /// Restore configuration parameters (admin only).
-    pub fn config_restore(
-        env: Env,
-        caller: Address,
-        backup: soroban_sdk::Vec<(soroban_sdk::Symbol, soroban_sdk::Val)>,
-    ) -> Result<(), ConfigError> {
-        config_restore(&env, caller, backup)
     }
 
     // ============================================================================

--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -87,6 +87,7 @@ pub enum MultisigError {
     BatchSizeExceeded = 14,
     DuplicateProposalId = 15,
     AlreadyInitialized = 16,
+    ProposalIdOverflow = 17,
 }
 
 /// Maximum number of proposals that can be executed in a single
@@ -163,17 +164,17 @@ impl MultisigContract {
             .set(&MultisigDataKey::Proposal(proposal.id), proposal);
     }
 
-    fn next_proposal_id(env: &Env) -> u64 {
+    fn next_proposal_id(env: &Env) -> Result<u64, MultisigError> {
         let count: u64 = env
             .storage()
             .persistent()
             .get(&MultisigDataKey::ProposalCount)
             .unwrap_or(0);
-        let new_count = count + 1;
+        let new_count = count.checked_add(1).ok_or(MultisigError::ProposalIdOverflow)?;
         env.storage()
             .persistent()
             .set(&MultisigDataKey::ProposalCount, &new_count);
-        count
+        Ok(count)
     }
 
     fn action_kind_symbol(env: &Env, action: &ProposalAction) -> Symbol {
@@ -212,7 +213,7 @@ impl MultisigContract {
             return Err(MultisigError::InvalidTtl);
         }
 
-        let id = Self::next_proposal_id(&env);
+        let id = Self::next_proposal_id(&env)?;
         let expires_at = (env.ledger().sequence() as u64).saturating_add(ttl_ledgers);
 
         let proposal = Proposal {

--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -169,10 +169,22 @@ impl VestingContract {
         if total_amount <= 0 || duration_secs == 0 {
             return Err(VestingError::InvalidGrant);
         }
+
+        let claimed_amount = env
+            .storage()
+            .persistent()
+            .get(&VestingKey::Grant(grantee.clone()))
+            .map(|g: Grant| if !g.revoked { g.claimed_amount } else { 0 })
+            .unwrap_or(0);
+
+        if total_amount < claimed_amount {
+            return Err(VestingError::InvalidGrant);
+        }
+
         let grant = Grant {
             grantee: grantee.clone(),
             total_amount,
-            claimed_amount: 0,
+            claimed_amount,
             start_ts,
             cliff_secs,
             duration_secs,


### PR DESCRIPTION
closes #1568
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
