### PR TITLE
Fix: wire borrow_index_test module into lib.rs

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -27,6 +27,8 @@ mod bad_debt_write_off_test;
 #[cfg(test)]
 mod borrow_health_factor_test;
 #[cfg(test)]
+mod borrow_index_test;
+#[cfg(test)]
 mod borrow_rate_cache_equiv_test;
 #[cfg(test)]
 mod cross_asset_e2e_test;


### PR DESCRIPTION
Fixes #1525

`stellar-lend/contracts/lending/src/borrow_index_test.rs` was a real test file covering the global borrow-index accrual mechanism, but it was never declared as a module in `lib.rs`. Rust silently ignores undeclared `.rs` files, so `cargo test -p stellarlend-lending` never compiled or ran any of its assertions.

## Change
Added `#[cfg(test)] mod borrow_index_test;` to lib.rs's test-module block, in alphabetical order between `borrow_health_factor_test` and `borrow_rate_cache_equiv_test`, matching the existing convention for the ~90 other test modules declared there.

## Note
Could not run `cargo test` locally due to an unrelated MSVC linker configuration issue on this machine (missing Windows SDK libs on the linker path) — this affects the whole crate, not this change. Please confirm via CI that the test module compiles and its assertions pass.