### PR TITLE
Feat/config snapshot and risk modules

### DIFF
--- a/stellar-lend/contracts/hello-world/src/config_snapshot.rs
+++ b/stellar-lend/contracts/hello-world/src/config_snapshot.rs
@@ -1,1 +1,108 @@
-// Stub module
+//! Protocol configuration snapshot.
+//!
+//! Provides a single read that aggregates the current risk parameters,
+//! interest-rate model configuration, and emergency/pause state into a
+//! flat [`ConfigSnapshot`] struct — a one-shot "protocol health dashboard"
+//! query suitable for off-chain monitoring, dashboards, and integrator
+//! health checks.
+//!
+//! The snapshot is purely read-only; it never mutates contract state and
+//! requires no authorization.  Returns `None` when the contract has not yet
+//! been initialized (i.e. when neither risk params nor interest-rate config
+//! exist in storage).
+
+use soroban_sdk::{contracttype, Env};
+
+use crate::interest_rate::get_interest_rate_config;
+use crate::risk_management::is_emergency_paused;
+use crate::risk_params::{
+    get_close_factor, get_liquidation_incentive, get_liquidation_threshold,
+    get_min_collateral_ratio,
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// A point-in-time snapshot of the protocol's configuration.
+///
+/// All rate/ratio fields are expressed in basis points (bps) where
+/// `10_000` equals 100%.
+///
+/// Fields are `None` when the underlying module has not been initialized.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfigSnapshot {
+    // ---- Risk parameters ---------------------------------------------------
+    /// Minimum collateral ratio required to open or maintain a position, in bps.
+    pub min_collateral_ratio_bps: i128,
+    /// Collateral-value threshold at which a position becomes eligible for
+    /// liquidation, in bps.
+    pub liquidation_threshold_bps: i128,
+    /// Maximum fraction of a position's debt that can be repaid in a single
+    /// liquidation call, in bps.
+    pub close_factor_bps: i128,
+    /// Collateral bonus paid to liquidators as a percentage of the repaid
+    /// amount, in bps.
+    pub liquidation_incentive_bps: i128,
+
+    // ---- Interest-rate model -----------------------------------------------
+    /// Base borrow APR at 0% utilization, in bps.
+    pub base_rate_bps: i128,
+    /// Utilization kink where the rate curve steepens, in bps.
+    pub kink_utilization_bps: i128,
+    /// Pre-kink slope: total rate increase from 0 to kink utilization, in bps.
+    pub multiplier_bps: i128,
+    /// Post-kink slope: total rate increase from kink to 100% utilization, in bps.
+    pub jump_multiplier_bps: i128,
+    /// Spread subtracted from the effective borrow rate to derive the supply
+    /// rate, in bps.
+    pub spread_bps: i128,
+    /// Hard minimum borrow rate enforced after all adjustments, in bps.
+    pub min_rate_bps: i128,
+    /// Hard maximum borrow rate enforced after all adjustments, in bps.
+    pub max_rate_bps: i128,
+
+    // ---- Pause state -------------------------------------------------------
+    /// `true` when the global emergency pause is active.
+    pub emergency_paused: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+/// Return a [`ConfigSnapshot`] of the current protocol configuration, or
+/// `None` if the contract has not been initialized.
+///
+/// This function is read-only and requires no authorization.
+pub fn get_config_snapshot(env: &Env) -> Option<ConfigSnapshot> {
+    // Require at least the risk params to be initialized before returning a
+    // snapshot; avoids a partially-zero snapshot that could mislead callers.
+    let min_collateral_ratio_bps = get_min_collateral_ratio(env).ok()?;
+    let liquidation_threshold_bps = get_liquidation_threshold(env).ok()?;
+    let close_factor_bps = get_close_factor(env).ok()?;
+    let liquidation_incentive_bps = get_liquidation_incentive(env).ok()?;
+
+    // Interest-rate config may not be initialized in all test environments;
+    // fall back to zero-valued defaults rather than returning None so that
+    // dashboards still receive the risk-param half of the snapshot.
+    let ir = get_interest_rate_config(env).unwrap_or_default();
+
+    let emergency_paused = is_emergency_paused(env);
+
+    Some(ConfigSnapshot {
+        min_collateral_ratio_bps,
+        liquidation_threshold_bps,
+        close_factor_bps,
+        liquidation_incentive_bps,
+        base_rate_bps: ir.base_rate_bps,
+        kink_utilization_bps: ir.kink_utilization_bps,
+        multiplier_bps: ir.multiplier_bps,
+        jump_multiplier_bps: ir.jump_multiplier_bps,
+        spread_bps: ir.spread_bps,
+        min_rate_bps: ir.min_rate_bps,
+        max_rate_bps: ir.max_rate_bps,
+        emergency_paused,
+    })
+}

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -129,7 +129,7 @@ use crate::config::{config_backup, config_get, config_restore, config_set, Confi
 use crate::cross_asset::{
     get_asset_config_by_address, get_asset_list, get_total_borrow_for, get_total_supply_for,
     get_user_asset_position, get_user_position_summary, initialize_asset, update_asset_config,
-    update_asset_price, AssetConfig, AssetKey, AssetPosition, CrossAssetError, UserPositionSummary,
+    update_asset_price, AssetConfig, AssetKey, AssetPosition, UserPositionSummary,
 };
 use crate::flash_loan::{
     configure_flash_loan, execute_flash_loan, repay_flash_loan, set_flash_loan_fee, FlashLoanConfig,

--- a/stellar-lend/contracts/hello-world/src/risk_management.rs
+++ b/stellar-lend/contracts/hello-world/src/risk_management.rs
@@ -1,1 +1,336 @@
-// Stub module
+//! Risk management module for the StellarLend lending protocol.
+//!
+//! Manages the top-level risk configuration (`RiskConfig`), emergency pause
+//! state, and per-operation pause switches.  All rates are expressed in basis
+//! points (bps) where `10_000` equals 100%.
+
+use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Symbol};
+
+use crate::admin;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Default minimum collateral ratio: 150% (15 000 bps).
+pub const DEFAULT_MIN_COLLATERAL_RATIO_BPS: i128 = 15_000;
+/// Default liquidation threshold: 120% (12 000 bps).
+pub const DEFAULT_LIQUIDATION_THRESHOLD_BPS: i128 = 12_000;
+/// Default close factor: 50% (5 000 bps).
+pub const DEFAULT_CLOSE_FACTOR_BPS: i128 = 5_000;
+/// Default liquidation incentive: 5% (500 bps).
+pub const DEFAULT_LIQUIDATION_INCENTIVE_BPS: i128 = 500;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RiskDataKey {
+    /// The admin-configurable risk parameters.
+    RiskConfig,
+    /// Global emergency pause flag.
+    EmergencyPaused,
+    /// Per-operation pause flag, keyed by operation symbol.
+    OperationPaused(Symbol),
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Admin-configurable top-level risk parameters.
+///
+/// All ratio fields are expressed in basis points (bps).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RiskConfig {
+    /// Minimum collateral ratio required to open / maintain a position, in bps.
+    pub min_collateral_ratio_bps: i128,
+    /// Collateral value threshold at which a position becomes liquidatable, in bps.
+    pub liquidation_threshold_bps: i128,
+    /// Maximum fraction of a position's debt that can be repaid in a single
+    /// liquidation, in bps.
+    pub close_factor_bps: i128,
+    /// Additional collateral awarded to the liquidator as a percentage of the
+    /// seized collateral, in bps.
+    pub liquidation_incentive_bps: i128,
+}
+
+impl Default for RiskConfig {
+    fn default() -> Self {
+        Self {
+            min_collateral_ratio_bps: DEFAULT_MIN_COLLATERAL_RATIO_BPS,
+            liquidation_threshold_bps: DEFAULT_LIQUIDATION_THRESHOLD_BPS,
+            close_factor_bps: DEFAULT_CLOSE_FACTOR_BPS,
+            liquidation_incentive_bps: DEFAULT_LIQUIDATION_INCENTIVE_BPS,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors returned by risk-management operations.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum RiskManagementError {
+    /// Caller is not the stored protocol admin.
+    Unauthorized = 1,
+    /// Contract has not been initialised.
+    NotInitialized = 2,
+    /// Contract is already initialised.
+    AlreadyInitialized = 3,
+    /// A provided parameter is outside its allowed range.
+    InvalidParameter = 4,
+    /// The protocol is currently in emergency pause mode.
+    EmergencyPaused = 5,
+    /// The requested operation is individually paused.
+    OperationPaused = 6,
+    /// A parameter change exceeds the maximum allowed delta.
+    ParameterChangeTooLarge = 7,
+    /// The supplied collateral ratio is invalid.
+    InvalidCollateralRatio = 8,
+    /// The supplied liquidation threshold is invalid.
+    InvalidLiquidationThreshold = 9,
+    /// The supplied close factor is invalid.
+    InvalidCloseFactor = 10,
+    /// The supplied liquidation incentive is invalid.
+    InvalidLiquidationIncentive = 11,
+    /// Checked arithmetic overflowed.
+    Overflow = 12,
+    /// The position does not meet the minimum collateral ratio.
+    InsufficientCollateralRatio = 13,
+}
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+/// Initialize risk management with default parameters.
+///
+/// Must be called once during contract initialization.  Subsequent calls
+/// return [`RiskManagementError::AlreadyInitialized`].
+pub fn initialize_risk_management(
+    env: &Env,
+    _admin: Address,
+) -> Result<(), RiskManagementError> {
+    if env
+        .storage()
+        .persistent()
+        .has(&RiskDataKey::RiskConfig)
+    {
+        return Err(RiskManagementError::AlreadyInitialized);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&RiskDataKey::RiskConfig, &RiskConfig::default());
+    env.storage()
+        .persistent()
+        .set(&RiskDataKey::EmergencyPaused, &false);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Accessors
+// ---------------------------------------------------------------------------
+
+/// Return the current [`RiskConfig`], or `None` if not yet initialized.
+pub fn get_risk_config(env: &Env) -> Option<RiskConfig> {
+    env.storage()
+        .persistent()
+        .get(&RiskDataKey::RiskConfig)
+}
+
+/// Return the minimum collateral ratio in bps, or `None` if not initialized.
+pub fn get_min_collateral_ratio(env: &Env) -> Option<i128> {
+    get_risk_config(env).map(|c| c.min_collateral_ratio_bps)
+}
+
+/// Return the liquidation threshold in bps, or `None` if not initialized.
+pub fn get_liquidation_threshold(env: &Env) -> Option<i128> {
+    get_risk_config(env).map(|c| c.liquidation_threshold_bps)
+}
+
+/// Return the close factor in bps, or `None` if not initialized.
+pub fn get_close_factor(env: &Env) -> Option<i128> {
+    get_risk_config(env).map(|c| c.close_factor_bps)
+}
+
+/// Return the liquidation incentive in bps, or `None` if not initialized.
+pub fn get_liquidation_incentive(env: &Env) -> Option<i128> {
+    get_risk_config(env).map(|c| c.liquidation_incentive_bps)
+}
+
+// ---------------------------------------------------------------------------
+// Pause controls
+// ---------------------------------------------------------------------------
+
+/// Return `true` if the global emergency pause is active.
+pub fn is_emergency_paused(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get::<RiskDataKey, bool>(&RiskDataKey::EmergencyPaused)
+        .unwrap_or(false)
+}
+
+/// Return `true` if the named operation is individually paused.
+pub fn is_operation_paused(env: &Env, operation: Symbol) -> bool {
+    env.storage()
+        .persistent()
+        .get::<RiskDataKey, bool>(&RiskDataKey::OperationPaused(operation))
+        .unwrap_or(false)
+}
+
+/// Check that neither the emergency pause nor the named operation pause is
+/// active.  Returns [`RiskManagementError::EmergencyPaused`] or
+/// [`RiskManagementError::OperationPaused`] if either is set.
+pub fn check_emergency_pause(env: &Env) -> Result<(), RiskManagementError> {
+    if is_emergency_paused(env) {
+        return Err(RiskManagementError::EmergencyPaused);
+    }
+    Ok(())
+}
+
+/// Set or clear the global emergency pause (admin only).
+pub fn set_emergency_pause(
+    env: &Env,
+    admin: Address,
+    paused: bool,
+) -> Result<(), RiskManagementError> {
+    admin::require_admin(env, &admin).map_err(|_| RiskManagementError::Unauthorized)?;
+    env.storage()
+        .persistent()
+        .set(&RiskDataKey::EmergencyPaused, &paused);
+    env.events().publish(
+        (symbol_short!("risk"), symbol_short!("emerg")),
+        paused,
+    );
+    Ok(())
+}
+
+/// Set or clear a pause switch for a specific operation (admin only).
+pub fn set_pause_switch(
+    env: &Env,
+    admin: Address,
+    operation: Symbol,
+    paused: bool,
+) -> Result<(), RiskManagementError> {
+    admin::require_admin(env, &admin).map_err(|_| RiskManagementError::Unauthorized)?;
+    env.storage()
+        .persistent()
+        .set(&RiskDataKey::OperationPaused(operation.clone()), &paused);
+    env.events().publish(
+        (symbol_short!("risk"), symbol_short!("pause")),
+        (operation, paused),
+    );
+    Ok(())
+}
+
+/// Set pause switches for multiple operations at once (admin only).
+pub fn set_pause_switches(
+    env: &Env,
+    admin: Address,
+    operations: soroban_sdk::Vec<(Symbol, bool)>,
+) -> Result<(), RiskManagementError> {
+    admin::require_admin(env, &admin).map_err(|_| RiskManagementError::Unauthorized)?;
+    for item in operations.iter() {
+        let (operation, paused) = item;
+        env.storage()
+            .persistent()
+            .set(&RiskDataKey::OperationPaused(operation), &paused);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Parameter updates (thin wrapper — delegates to risk_params)
+// ---------------------------------------------------------------------------
+
+/// Update risk parameters (admin only).  Delegates bounds validation to
+/// [`crate::risk_params::set_risk_params`].
+pub fn set_risk_params(
+    env: &Env,
+    admin: Address,
+    min_collateral_ratio: Option<i128>,
+    liquidation_threshold: Option<i128>,
+    close_factor: Option<i128>,
+    liquidation_incentive: Option<i128>,
+) -> Result<(), RiskManagementError> {
+    admin::require_admin(env, &admin).map_err(|_| RiskManagementError::Unauthorized)?;
+    crate::risk_params::set_risk_params(
+        env,
+        min_collateral_ratio,
+        liquidation_threshold,
+        close_factor,
+        liquidation_incentive,
+    )
+    .map_err(|e| match e {
+        crate::risk_params::RiskParamsError::ParameterChangeTooLarge => {
+            RiskManagementError::ParameterChangeTooLarge
+        }
+        crate::risk_params::RiskParamsError::InvalidCollateralRatio => {
+            RiskManagementError::InvalidCollateralRatio
+        }
+        crate::risk_params::RiskParamsError::InvalidLiquidationThreshold => {
+            RiskManagementError::InvalidLiquidationThreshold
+        }
+        crate::risk_params::RiskParamsError::InvalidCloseFactor => {
+            RiskManagementError::InvalidCloseFactor
+        }
+        crate::risk_params::RiskParamsError::InvalidLiquidationIncentive => {
+            RiskManagementError::InvalidLiquidationIncentive
+        }
+        _ => RiskManagementError::InvalidParameter,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Liquidation helpers (convenience re-exports matching lib.rs imports)
+// ---------------------------------------------------------------------------
+
+/// Check whether a position can be liquidated.
+///
+/// A position is liquidatable when `collateral_value * 10_000 <
+/// debt_value * liquidation_threshold_bps`.
+pub fn can_be_liquidated(
+    env: &Env,
+    collateral_value: i128,
+    debt_value: i128,
+) -> Result<bool, RiskManagementError> {
+    crate::risk_params::can_be_liquidated(env, collateral_value, debt_value)
+        .map_err(|_| RiskManagementError::InvalidParameter)
+}
+
+/// Return the maximum amount that can be liquidated in a single call
+/// (close_factor × debt_value).
+pub fn get_max_liquidatable_amount(
+    env: &Env,
+    debt_value: i128,
+) -> Result<i128, RiskManagementError> {
+    crate::risk_params::get_max_liquidatable_amount(env, debt_value)
+        .map_err(|_| RiskManagementError::Overflow)
+}
+
+/// Return the collateral bonus awarded to the liquidator.
+pub fn get_liquidation_incentive_amount(
+    env: &Env,
+    liquidated_amount: i128,
+) -> Result<i128, RiskManagementError> {
+    crate::risk_params::get_liquidation_incentive_amount(env, liquidated_amount)
+        .map_err(|_| RiskManagementError::Overflow)
+}
+
+/// Require `collateral_value / debt_value >= min_collateral_ratio`.
+pub fn require_min_collateral_ratio(
+    env: &Env,
+    collateral_value: i128,
+    debt_value: i128,
+) -> Result<(), RiskManagementError> {
+    crate::risk_params::require_min_collateral_ratio(env, collateral_value, debt_value)
+        .map_err(|_| RiskManagementError::InsufficientCollateralRatio)
+}

--- a/stellar-lend/contracts/hello-world/src/risk_params.rs
+++ b/stellar-lend/contracts/hello-world/src/risk_params.rs
@@ -1,1 +1,353 @@
-// Stub module
+//! Risk parameter module for the StellarLend lending protocol.
+//!
+//! Stores and validates the four core risk parameters that govern liquidation
+//! behaviour.  All ratio/factor fields are expressed in basis points (bps)
+//! where `10_000` equals 100%.
+//!
+//! This module is the single source of truth for risk parameter storage.
+//! [`crate::risk_management`] delegates parameter writes here and reads
+//! through [`crate::risk_management::RiskConfig`] for convenience.
+
+use soroban_sdk::{contracterror, contracttype, Env};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BASIS_POINTS: i128 = 10_000;
+
+/// Minimum allowed collateral ratio: 100% (a ratio below this is always unsafe).
+const MIN_COLLATERAL_RATIO_FLOOR: i128 = BASIS_POINTS;
+/// Maximum allowed collateral ratio: 1000%.
+const MAX_COLLATERAL_RATIO: i128 = 100_000;
+
+/// Maximum allowed liquidation threshold (must be below min collateral ratio
+/// in a well-configured system, but we only enforce an upper bound here).
+const MAX_LIQUIDATION_THRESHOLD: i128 = 100_000;
+
+/// Close factor must be in (0, 100%].
+const MAX_CLOSE_FACTOR: i128 = BASIS_POINTS;
+
+/// Liquidation incentive is bounded to 0–50%.
+const MAX_LIQUIDATION_INCENTIVE: i128 = 5_000;
+
+/// Maximum parameter change per update expressed as a fraction of the current
+/// value, in bps.  50% change in one call (5_000 bps).
+const MAX_CHANGE_BPS: i128 = 5_000;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RiskParamsDataKey {
+    /// Minimum collateral ratio in bps.
+    MinCollateralRatio,
+    /// Liquidation threshold in bps.
+    LiquidationThreshold,
+    /// Close factor in bps.
+    CloseFactor,
+    /// Liquidation incentive in bps.
+    LiquidationIncentive,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors returned by risk-parameter operations.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum RiskParamsError {
+    /// Contract has not been initialized.
+    NotInitialized = 1,
+    /// Contract has already been initialized.
+    AlreadyInitialized = 2,
+    /// A provided parameter is outside its allowed range.
+    InvalidParameter = 3,
+    /// The supplied collateral ratio is invalid.
+    InvalidCollateralRatio = 4,
+    /// The supplied liquidation threshold is invalid.
+    InvalidLiquidationThreshold = 5,
+    /// The supplied close factor is invalid.
+    InvalidCloseFactor = 6,
+    /// The supplied liquidation incentive is invalid.
+    InvalidLiquidationIncentive = 7,
+    /// A parameter change exceeds the maximum allowed single-step delta.
+    ParameterChangeTooLarge = 8,
+    /// Checked arithmetic overflowed.
+    Overflow = 9,
+    /// Division by zero was prevented.
+    DivisionByZero = 10,
+    /// The position does not meet the minimum collateral ratio.
+    InsufficientCollateralRatio = 11,
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+fn default_min_collateral_ratio() -> i128 {
+    15_000 // 150%
+}
+fn default_liquidation_threshold() -> i128 {
+    12_000 // 120%
+}
+fn default_close_factor() -> i128 {
+    5_000 // 50%
+}
+fn default_liquidation_incentive() -> i128 {
+    500 // 5%
+}
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+/// Persist default risk parameters.  Must be called once during contract
+/// initialization.
+pub fn initialize_risk_params(env: &Env) -> Result<(), RiskParamsError> {
+    if env
+        .storage()
+        .persistent()
+        .has(&RiskParamsDataKey::MinCollateralRatio)
+    {
+        return Err(RiskParamsError::AlreadyInitialized);
+    }
+
+    env.storage().persistent().set(
+        &RiskParamsDataKey::MinCollateralRatio,
+        &default_min_collateral_ratio(),
+    );
+    env.storage().persistent().set(
+        &RiskParamsDataKey::LiquidationThreshold,
+        &default_liquidation_threshold(),
+    );
+    env.storage()
+        .persistent()
+        .set(&RiskParamsDataKey::CloseFactor, &default_close_factor());
+    env.storage().persistent().set(
+        &RiskParamsDataKey::LiquidationIncentive,
+        &default_liquidation_incentive(),
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Read helpers
+// ---------------------------------------------------------------------------
+
+/// Return the current minimum collateral ratio in bps.
+pub fn get_min_collateral_ratio(env: &Env) -> Result<i128, RiskParamsError> {
+    env.storage()
+        .persistent()
+        .get::<RiskParamsDataKey, i128>(&RiskParamsDataKey::MinCollateralRatio)
+        .ok_or(RiskParamsError::NotInitialized)
+}
+
+/// Return the current liquidation threshold in bps.
+pub fn get_liquidation_threshold(env: &Env) -> Result<i128, RiskParamsError> {
+    env.storage()
+        .persistent()
+        .get::<RiskParamsDataKey, i128>(&RiskParamsDataKey::LiquidationThreshold)
+        .ok_or(RiskParamsError::NotInitialized)
+}
+
+/// Return the current close factor in bps.
+pub fn get_close_factor(env: &Env) -> Result<i128, RiskParamsError> {
+    env.storage()
+        .persistent()
+        .get::<RiskParamsDataKey, i128>(&RiskParamsDataKey::CloseFactor)
+        .ok_or(RiskParamsError::NotInitialized)
+}
+
+/// Return the current liquidation incentive in bps.
+pub fn get_liquidation_incentive(env: &Env) -> Result<i128, RiskParamsError> {
+    env.storage()
+        .persistent()
+        .get::<RiskParamsDataKey, i128>(&RiskParamsDataKey::LiquidationIncentive)
+        .ok_or(RiskParamsError::NotInitialized)
+}
+
+// ---------------------------------------------------------------------------
+// Parameter updates
+// ---------------------------------------------------------------------------
+
+/// Validate and store updated risk parameters.
+///
+/// Any `None` field is left unchanged.  Each provided value is validated
+/// independently; an out-of-range value returns the corresponding error before
+/// any storage is modified.
+pub fn set_risk_params(
+    env: &Env,
+    min_collateral_ratio: Option<i128>,
+    liquidation_threshold: Option<i128>,
+    close_factor: Option<i128>,
+    liquidation_incentive: Option<i128>,
+) -> Result<(), RiskParamsError> {
+    if let Some(v) = min_collateral_ratio {
+        validate_change(
+            env,
+            &RiskParamsDataKey::MinCollateralRatio,
+            v,
+            MIN_COLLATERAL_RATIO_FLOOR,
+            MAX_COLLATERAL_RATIO,
+        )
+        .map_err(|e| match e {
+            RiskParamsError::ParameterChangeTooLarge => RiskParamsError::ParameterChangeTooLarge,
+            _ => RiskParamsError::InvalidCollateralRatio,
+        })?;
+        env.storage()
+            .persistent()
+            .set(&RiskParamsDataKey::MinCollateralRatio, &v);
+    }
+
+    if let Some(v) = liquidation_threshold {
+        validate_change(
+            env,
+            &RiskParamsDataKey::LiquidationThreshold,
+            v,
+            1,
+            MAX_LIQUIDATION_THRESHOLD,
+        )
+        .map_err(|e| match e {
+            RiskParamsError::ParameterChangeTooLarge => RiskParamsError::ParameterChangeTooLarge,
+            _ => RiskParamsError::InvalidLiquidationThreshold,
+        })?;
+        env.storage()
+            .persistent()
+            .set(&RiskParamsDataKey::LiquidationThreshold, &v);
+    }
+
+    if let Some(v) = close_factor {
+        if v <= 0 || v > MAX_CLOSE_FACTOR {
+            return Err(RiskParamsError::InvalidCloseFactor);
+        }
+        env.storage()
+            .persistent()
+            .set(&RiskParamsDataKey::CloseFactor, &v);
+    }
+
+    if let Some(v) = liquidation_incentive {
+        if v < 0 || v > MAX_LIQUIDATION_INCENTIVE {
+            return Err(RiskParamsError::InvalidLiquidationIncentive);
+        }
+        env.storage()
+            .persistent()
+            .set(&RiskParamsDataKey::LiquidationIncentive, &v);
+    }
+
+    Ok(())
+}
+
+/// Validate that `new_value` is within `[min, max]` and that the change from
+/// the current persisted value does not exceed `MAX_CHANGE_BPS`.
+fn validate_change(
+    env: &Env,
+    key: &RiskParamsDataKey,
+    new_value: i128,
+    min: i128,
+    max: i128,
+) -> Result<(), RiskParamsError> {
+    if new_value < min || new_value > max {
+        return Err(RiskParamsError::InvalidParameter);
+    }
+
+    // If already initialized, check the per-call change limit.
+    if let Some(current) = env
+        .storage()
+        .persistent()
+        .get::<RiskParamsDataKey, i128>(key)
+    {
+        let delta = (new_value - current).abs();
+        let limit = current
+            .checked_mul(MAX_CHANGE_BPS)
+            .ok_or(RiskParamsError::Overflow)?
+            .checked_div(BASIS_POINTS)
+            .ok_or(RiskParamsError::DivisionByZero)?;
+        if delta > limit {
+            return Err(RiskParamsError::ParameterChangeTooLarge);
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Liquidation logic
+// ---------------------------------------------------------------------------
+
+/// Return `true` if `collateral_value * 10_000 < debt_value *
+/// liquidation_threshold_bps` (position is undercollateralized).
+pub fn can_be_liquidated(
+    env: &Env,
+    collateral_value: i128,
+    debt_value: i128,
+) -> Result<bool, RiskParamsError> {
+    if debt_value <= 0 {
+        return Ok(false);
+    }
+    let threshold = get_liquidation_threshold(env)?;
+    // collateral_value * 10_000 < debt_value * threshold
+    let lhs = collateral_value
+        .checked_mul(BASIS_POINTS)
+        .ok_or(RiskParamsError::Overflow)?;
+    let rhs = debt_value
+        .checked_mul(threshold)
+        .ok_or(RiskParamsError::Overflow)?;
+    Ok(lhs < rhs)
+}
+
+/// Return the maximum amount that may be repaid in a single liquidation call:
+/// `debt_value * close_factor_bps / 10_000`.
+pub fn get_max_liquidatable_amount(
+    env: &Env,
+    debt_value: i128,
+) -> Result<i128, RiskParamsError> {
+    let close_factor = get_close_factor(env)?;
+    debt_value
+        .checked_mul(close_factor)
+        .ok_or(RiskParamsError::Overflow)?
+        .checked_div(BASIS_POINTS)
+        .ok_or(RiskParamsError::DivisionByZero)
+}
+
+/// Return the collateral bonus paid to the liquidator:
+/// `liquidated_amount * liquidation_incentive_bps / 10_000`.
+pub fn get_liquidation_incentive_amount(
+    env: &Env,
+    liquidated_amount: i128,
+) -> Result<i128, RiskParamsError> {
+    let incentive = get_liquidation_incentive(env)?;
+    liquidated_amount
+        .checked_mul(incentive)
+        .ok_or(RiskParamsError::Overflow)?
+        .checked_div(BASIS_POINTS)
+        .ok_or(RiskParamsError::DivisionByZero)
+}
+
+/// Require that `collateral_value / debt_value >= min_collateral_ratio`.
+///
+/// Expressed as: `collateral_value * 10_000 >= debt_value * min_ratio_bps`.
+pub fn require_min_collateral_ratio(
+    env: &Env,
+    collateral_value: i128,
+    debt_value: i128,
+) -> Result<(), RiskParamsError> {
+    if debt_value <= 0 {
+        return Ok(());
+    }
+    let min_ratio = get_min_collateral_ratio(env)?;
+    let lhs = collateral_value
+        .checked_mul(BASIS_POINTS)
+        .ok_or(RiskParamsError::Overflow)?;
+    let rhs = debt_value
+        .checked_mul(min_ratio)
+        .ok_or(RiskParamsError::Overflow)?;
+    if lhs < rhs {
+        return Err(RiskParamsError::InsufficientCollateralRatio);
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
- [ ] closes #1465
