### PR TITLE
fix(lending): assert AssetParamsSetEvent includes supply_cap #1439

### DIFF
--- a/stellar-lend/contracts/lending/cross_asset.md
+++ b/stellar-lend/contracts/lending/cross_asset.md
@@ -142,7 +142,9 @@ Admin only function to configure an asset's parameters.
 - `liquidation_threshold`: Point at which the asset becomes eligible for liquidation (basis points).
 - `price_feed`: The oracle address providing the asset's price.
 - `debt_ceiling`: Total system-wide debt allowed for this asset.
-- **Event**: Emits `AssetParamsSetEvent`.
+- `borrow_cap`: Per-asset protocol borrow cap (`0` = uncapped).
+- `supply_cap`: Per-asset protocol supply / collateral cap (`0` = uncapped).
+- **Event**: Emits `AssetParamsSetEvent` with `asset`, `ltv_bps`, `liquidation_threshold_bps`, `debt_ceiling`, `borrow_cap`, and `supply_cap` so indexers can observe the full config without re-reading storage.
 
 ### `deposit_collateral_asset`
 Users can deposit any supported asset as collateral. This increases their total borrowing power based on the asset's USD value and its specific LTV.

--- a/stellar-lend/contracts/lending/src/cross_asset_test.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset_test.rs
@@ -1,5 +1,6 @@
 use super::*;
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::events::Event;
+use soroban_sdk::testutils::{Address as _, Events};
 
 fn setup() -> (
     Env,
@@ -71,6 +72,56 @@ fn test_set_asset_params_stores_and_reads() {
     assert_eq!(params.ltv_bps, 7500);
     assert_eq!(params.liquidation_threshold_bps, 8000);
     assert_eq!(params.debt_ceiling, 1_000_000_000_000i128);
+    assert_eq!(params.borrow_cap, 0);
+    assert_eq!(params.supply_cap, 0);
+}
+
+/// `AssetParamsSetEvent` must include `supply_cap` so off-chain indexers that
+/// consume events (without re-reading storage) observe the full asset config.
+///
+/// Regression guard for #1439.
+#[test]
+fn test_set_asset_params_emits_event_including_supply_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    let asset = env.register(MockAsset, ());
+    client.initialize(&admin);
+
+    let ltv_bps = 7500i128;
+    let liquidation_threshold_bps = 8000i128;
+    let debt_ceiling = 1_000_000_000_000i128;
+    let borrow_cap = 2_500_000i128;
+    let supply_cap = 5_000_000i128;
+
+    client.set_asset_params(
+        &admin,
+        &asset,
+        &ltv_bps,
+        &liquidation_threshold_bps,
+        &debt_ceiling,
+        &borrow_cap,
+        &supply_cap,
+    );
+
+    assert_eq!(
+        env.events().all(),
+        [AssetParamsSetEvent {
+            asset: asset.clone(),
+            ltv_bps,
+            liquidation_threshold_bps,
+            debt_ceiling,
+            borrow_cap,
+            supply_cap,
+        }
+        .to_xdr(&env, &cid)],
+        "AssetParamsSetEvent must carry supply_cap alongside all other params"
+    );
+
+    let stored = client.get_asset_params(&asset).unwrap();
+    assert_eq!(stored.supply_cap, supply_cap);
 }
 
 #[test]
@@ -86,6 +137,24 @@ fn test_set_asset_params_rejects_invalid_ltv() {
         &0i128,
     );
     assert!(matches!(res, Err(Ok(LendingError::InvalidAmount))));
+}
+
+#[test]
+fn test_set_asset_params_rejects_ltv_above_liquidation_threshold() {
+    let (_env, client, _id, admin, _user, asset_a, _asset_b) = setup();
+    let res = client.try_set_asset_params(
+        &admin,
+        &asset_a,
+        &9000i128, // LTV above liquidation threshold
+        &5000i128, // liquidation threshold
+        &1_000_000i128,
+        &0i128,
+        &0i128,
+    );
+    assert!(matches!(
+        res,
+        Err(Ok(LendingError::InvalidLiquidationParams))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Overview

This PR closes the acceptance gap for `AssetParamsSetEvent` so off-chain indexers that rely on emitted events (without re-reading contract storage) can observe the configured `supply_cap` for every asset configuration change. The event struct and publish path already carry `supply_cap`; this change adds regression coverage and docs so that field cannot silently regress.

## Related Issue

Closes #1439

## Changes

### 📡 Asset Params Event Coverage

* **[MODIFY]** `stellar-lend/contracts/lending/src/cross_asset_test.rs`
  * Added `test_set_asset_params_emits_event_including_supply_cap`.
  * Asserts the full `AssetParamsSetEvent` XDR payload includes `asset`, `ltv_bps`, `liquidation_threshold_bps`, `debt_ceiling`, `borrow_cap`, and `supply_cap`.
  * Confirms stored `AssetParams.supply_cap` matches the emitted event value.

* **[MODIFY]** `stellar-lend/contracts/lending/cross_asset.md`
  * Documented that `AssetParamsSetEvent` includes `borrow_cap` and `supply_cap` so indexers can observe the full asset config from events alone.

## Verification Results

```
cargo test -p stellarlend-lending --lib test_set_asset_params
✅ 6/6 passed (includes test_set_asset_params_emits_event_including_supply_cap)

cargo test -p stellarlend-lending --lib cross_asset_test
✅ 45/45 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| `AssetParamsSetEvent` struct includes `supply_cap` | ✅ Present in event type |
| `set_asset_params` publish call includes `supply_cap` | ✅ Included in event publish payload |
| New/updated test asserts emitted event fields including `supply_cap` | ✅ XDR equality assertion on full event |