### PR TITLE
Wire events_test.rs into the build

### DIFF
--- a/stellar-lend/contracts/lending/src/events_test.rs
+++ b/stellar-lend/contracts/lending/src/events_test.rs
@@ -9,7 +9,7 @@
 //! - Events are emitted only after state mutations succeed
 //! - Edge cases (full repay, partial liquidation, cap boundaries) emit correct events
 
-use crate::{LendingContract, LendingContractClient};
+use crate::{DataKey, LendingContract, LendingContractClient};
 use crate::events::EVENT_SCHEMA_VERSION;
 use soroban_sdk::{
     testutils::{Address as _, Events},
@@ -375,11 +375,13 @@ fn test_event_emission_does_not_affect_operation_result() {
 
 #[test]
 fn test_deposit_at_cap_boundary_emits_event() {
-    let (env, client, admin, user) = setup();
+    let (env, client, _admin, user) = setup();
     
-    // Set a deposit cap
+    // Set a deposit cap directly via storage (no public set_deposit_cap on client)
     let cap = 1000_i128;
-    client.set_deposit_cap(&cap);
+    env.as_contract(&client.address, || {
+        env.storage().persistent().set(&DataKey::DepositCap, &cap);
+    });
     
     // Deposit exactly at cap
     let result = client.try_deposit(&user, &cap);

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -125,6 +125,8 @@ mod withdraw_reserve_test;
 mod upgrade_governance_test;
 #[cfg(test)]
 mod utilization_history_test;
+#[cfg(test)]
+mod events_test;
 use debt::{
     borrow_amount, cached_borrow_rate, effective_debt, load_debt, repay_amount, save_debt,
     DebtPosition, DEFAULT_APR_BPS,


### PR DESCRIPTION
- Add #[cfg(test)] mod events_test; to lib.rs test module block
- Fix events_test.rs: import DataKey and replace non-existent client.set_deposit_cap() with direct env.as_contract storage write

Closes #1533 