### PR TITLE
vesting: verify vested_at overflow fallback is not a live bug (#1569)

### DIFF
--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -96,6 +96,9 @@ impl Grant {
         // into quotient and remainder:
         // total_amount = q * duration_secs + r
         // elapsed * total_amount / duration_secs = elapsed * q + (elapsed * r) / duration_secs
+        //
+        // Note (#1569): this partitioned form never performs an unchecked total_amount * elapsed
+        // multiplication, so there is no overflow fallback path that could fabricate 100% vesting.
         let principal = self.total_amount as u128;
         let elapsed_u128 = elapsed as u128;
         let duration_u128 = self.duration_secs as u128;


### PR DESCRIPTION
Closes #1569

## Summary

The reported concern was that `Grant::vested_at` in `stellar-lend/contracts/vesting/src/lib.rs` computed vesting as:

```rust
(self.total_amount as u64).checked_mul(elapsed)
    .map(|v| (v / self.duration_secs) as i128)
    .unwrap_or(self.total_amount)
```

where an overflow in `total_amount * elapsed` would fall back to `unwrap_or(self.total_amount)` — silently granting 100% vesting instead of failing safe.

On inspection, the current `vested_at` implementation on `main` does **not** contain this pattern. It instead computes vesting via partitioned `u128` arithmetic that avoids the overflow-prone multiplication entirely:

```rust
let principal = self.total_amount as u128;
let elapsed_u128 = elapsed as u128;
let duration_u128 = self.duration_secs as u128;

let q = principal / duration_u128;
let r = principal % duration_u128;

let val1 = elapsed_u128 * q;
let val2 = (elapsed_u128 * r) / duration_u128;

let vested = val1 + val2;
```

Since `elapsed < duration_secs` is already guaranteed by the early return above, and `total_amount`/`duration_secs` are used directly as `u128` (not truncated to `u64`), there is no `checked_mul`/`unwrap_or` fallback path, and no scenario where an overflow could fabricate full vesting. No `checked_mul` or `unwrap_or(self.total_amount)` occurs anywhere in the file.

This PR is a no-op with respect to behavior — it adds a short comment documenting why this code path is safe, so future readers don't have to re-derive it, and closes out the issue.

## Test plan

- [x] Confirmed via `grep` that no `checked_mul` or `unwrap_or(self.total_amount)` pattern exists in `stellar-lend/contracts/vesting/src/lib.rs`
- [x] Manually re-derived that the partitioned `u128` formula cannot overflow for any `u64` `total_amount`/`elapsed`/`duration_secs` combination
- No functional test changes needed since no functional code changed