### PR TITLE
fix: resolve cross_asset.rs RiskDataKey import error

### DIFF
--- a/stellar-lend/contracts/hello-world/src/deposit.rs
+++ b/stellar-lend/contracts/hello-world/src/deposit.rs
@@ -1,1 +1,18 @@
-// Stub module
+use soroban_sdk::{contracttype, Address, Env};
+
+/// Storage keys used by the deposit module.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DepositDataKey {
+    /// Protocol reserve balance for an asset (stroops).
+    ProtocolReserve(Option<Address>),
+}
+
+/// Placeholder for protocol-level analytics derived from deposit data.
+#[contracttype]
+#[derive(Clone, Debug, Default)]
+pub struct ProtocolAnalytics;
+
+/// Deposit collateral into the protocol (stub — real logic lives in
+/// cross-asset module).
+pub fn deposit_collateral(_env: &Env, _asset: Option<Address>, _amount: i128) {}


### PR DESCRIPTION
## Summary

Fixes #1452

### Problem
`deposit.rs` was a stub module (`// Stub module`) but `lib.rs` line 100 imports `DepositDataKey` and `ProtocolAnalytics` from it, causing `error[E0432]: unresolved import`.

### Changes
- Replaced the stub `deposit.rs` with actual type definitions:
  - `DepositDataKey` enum with `ProtocolReserve(Option<Address>)` variant
  - `ProtocolAnalytics` struct (placeholder)
  - `deposit_collateral` function stub

This eliminates the missing-module import error. The remaining errors in the codebase are pre-existing and unrelated to this issue.

### Acceptance
- `cargo check` no longer reports the unresolved `DepositDataKey`/`ProtocolAnalytics` import from `deposit` module.