### PR TITLE
feat(lending): emit events for set_min_borrow/set_max_move_bps/set_max_flash_bps/set_collateral_asset

### DIFF
--- a/stellar-lend/contracts/lending/src/events_test.rs
+++ b/stellar-lend/contracts/lending/src/events_test.rs
@@ -407,6 +407,226 @@ fn test_deposit_at_cap_boundary_emits_event() {
     }
 }
 
+// -----------------------------------------------------------------------
+// Admin-setter event tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_set_min_borrow_emits_event() {
+    let (env, client, _admin, _user) = setup();
+    let min_borrow = 100_i128;
+    client.set_min_borrow(&min_borrow);
+
+    let events = env.events().all();
+    let min_borrow_events: SdkVec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
+                let topics: SdkVec<Val> = topics;
+                if let Some(first) = topics.get(0) {
+                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
+                        return symbol == Symbol::new(&env, "MinBorrowSetEvent");
+                    }
+                }
+            }
+            false
+        })
+        .collect();
+
+    assert_eq!(
+        min_borrow_events.len(),
+        1,
+        "Should emit exactly one MinBorrowSetEvent"
+    );
+}
+
+#[test]
+fn test_set_min_borrow_event_zero() {
+    let (env, client, _admin, _user) = setup();
+    client.set_min_borrow(&0);
+
+    let events = env.events().all();
+    let min_borrow_events: SdkVec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
+                let topics: SdkVec<Val> = topics;
+                if let Some(first) = topics.get(0) {
+                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
+                        return symbol == Symbol::new(&env, "MinBorrowSetEvent");
+                    }
+                }
+            }
+            false
+        })
+        .collect();
+
+    assert_eq!(min_borrow_events.len(), 1);
+}
+
+#[test]
+fn test_set_max_move_bps_emits_event() {
+    let (env, client, _admin, _user) = setup();
+    let max_move_bps = 500_i128;
+    client.set_max_move_bps(&max_move_bps);
+
+    let events = env.events().all();
+    let max_move_events: SdkVec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
+                let topics: SdkVec<Val> = topics;
+                if let Some(first) = topics.get(0) {
+                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
+                        return symbol == Symbol::new(&env, "MaxMoveBpsSetEvent");
+                    }
+                }
+            }
+            false
+        })
+        .collect();
+
+    assert_eq!(
+        max_move_events.len(),
+        1,
+        "Should emit exactly one MaxMoveBpsSetEvent"
+    );
+}
+
+#[test]
+fn test_set_max_move_bps_at_boundary_emits_event() {
+    let (env, client, _admin, _user) = setup();
+    client.set_max_move_bps(&0);
+    let events = env.events().all();
+    let max_move_events: SdkVec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
+                let topics: SdkVec<Val> = topics;
+                if let Some(first) = topics.get(0) {
+                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
+                        return symbol == Symbol::new(&env, "MaxMoveBpsSetEvent");
+                    }
+                }
+            }
+            false
+        })
+        .collect();
+    assert_eq!(max_move_events.len(), 1);
+}
+
+#[test]
+fn test_set_max_flash_bps_emits_event() {
+    let (env, client, _admin, _user) = setup();
+    let max_flash_bps = 5000_i128;
+    client.set_max_flash_bps(&max_flash_bps);
+
+    let events = env.events().all();
+    let max_flash_events: SdkVec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
+                let topics: SdkVec<Val> = topics;
+                if let Some(first) = topics.get(0) {
+                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
+                        return symbol == Symbol::new(&env, "MaxFlashBpsSetEvent");
+                    }
+                }
+            }
+            false
+        })
+        .collect();
+
+    assert_eq!(
+        max_flash_events.len(),
+        1,
+        "Should emit exactly one MaxFlashBpsSetEvent"
+    );
+}
+
+#[test]
+fn test_set_max_flash_bps_default_emits_event() {
+    let (env, client, _admin, _user) = setup();
+    client.set_max_flash_bps(&10000); // BPS_DENOM
+
+    let events = env.events().all();
+    let max_flash_events: SdkVec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
+                let topics: SdkVec<Val> = topics;
+                if let Some(first) = topics.get(0) {
+                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
+                        return symbol == Symbol::new(&env, "MaxFlashBpsSetEvent");
+                    }
+                }
+            }
+            false
+        })
+        .collect();
+    assert_eq!(max_flash_events.len(), 1);
+}
+
+#[test]
+fn test_set_collateral_asset_emits_event() {
+    let (env, client, _admin, _user) = setup();
+    let asset = Address::generate(&env);
+    client.set_collateral_asset(&asset);
+
+    let events = env.events().all();
+    let collateral_events: SdkVec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
+                let topics: SdkVec<Val> = topics;
+                if let Some(first) = topics.get(0) {
+                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
+                        return symbol == Symbol::new(&env, "CollateralAssetSetEvent");
+                    }
+                }
+            }
+            false
+        })
+        .collect();
+
+    assert_eq!(
+        collateral_events.len(),
+        1,
+        "Should emit exactly one CollateralAssetSetEvent"
+    );
+}
+
+#[test]
+fn test_set_collateral_asset_replaces_event() {
+    let (env, client, _admin, _user) = setup();
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+    client.set_collateral_asset(&asset1);
+    client.set_collateral_asset(&asset2);
+
+    let events = env.events().all();
+    let collateral_events: SdkVec<_> = events
+        .iter()
+        .filter(|e| {
+            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
+                let topics: SdkVec<Val> = topics;
+                if let Some(first) = topics.get(0) {
+                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
+                        return symbol == Symbol::new(&env, "CollateralAssetSetEvent");
+                    }
+                }
+            }
+            false
+        })
+        .collect();
+
+    assert_eq!(
+        collateral_events.len(),
+        2,
+        "Should emit two CollateralAssetSetEvent for two calls"
+    );
+}
+
 #[test]
 fn test_failed_operation_does_not_emit_event() {
     let (_env, client, _admin, user) = setup();

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -561,6 +561,30 @@ pub struct CrossWithdrawEvent {
     pub amount: i128,
 }
 
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MinBorrowSetEvent {
+    pub min_borrow: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaxMoveBpsSetEvent {
+    pub max_move_bps: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaxFlashBpsSetEvent {
+    pub max_flash_bps: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollateralAssetSetEvent {
+    pub asset: Address,
+}
+
 #[contract]
 pub struct LendingContract;
 
@@ -813,6 +837,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::MaxMoveBps, &max_move_bps);
+        MaxMoveBpsSetEvent { max_move_bps }.publish(&env);
         Ok(())
     }
 
@@ -831,6 +856,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::MaxFlashUtilizationBps, &max_flash_bps);
+        MaxFlashBpsSetEvent { max_flash_bps }.publish(&env);
         Ok(())
     }
 
@@ -992,6 +1018,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::BorrowMinAmount, &min_borrow);
+        MinBorrowSetEvent { min_borrow }.publish(&env);
         Ok(())
     }
 
@@ -1172,6 +1199,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::ValuationCollateralAsset, &asset);
+        CollateralAssetSetEvent { asset }.publish(&env);
         Ok(())
     }
 


### PR DESCRIPTION
## Overview

Adds event emission to four admin-gated setters in the lending contract that were silently mutating storage without any indexer-visible signal. New events follow the existing `#[contractevent]` + `.publish(&env)` pattern already used by `set_price_bounds`, `set_emergency_state`, `set_pause`, `AssetParamsSetEvent`, and the cross-asset events.

## Related Issue

Closes #1719

## Changes

### Event structs (lib.rs)

- **[ADD]** `MinBorrowSetEvent { min_borrow: i128 }` � published by `set_min_borrow`
- **[ADD]** `MaxMoveBpsSetEvent { max_move_bps: i128 }` � published by `set_max_move_bps`
- **[ADD]** `MaxFlashBpsSetEvent { max_flash_bps: i128 }` � published by `set_max_flash_bps`
- **[ADD]** `CollateralAssetSetEvent { asset: Address }` � published by `set_collateral_asset`

### Emit calls

- **[MODIFY]** `set_min_borrow` � emits `MinBorrowSetEvent` after storage write
- **[MODIFY]** `set_max_move_bps` � emits `MaxMoveBpsSetEvent` after storage write
- **[MODIFY]** `set_max_flash_bps` � emits `MaxFlashBpsSetEvent` after storage write
- **[MODIFY]** `set_collateral_asset` � emits `CollateralAssetSetEvent` after storage write

### Tests (events_test.rs)

- **[ADD]** `test_set_min_borrow_emits_event` � verifies event emission on success
- **[ADD]** `test_set_min_borrow_event_zero` � verifies event on boundary value (0)
- **[ADD]** `test_set_max_move_bps_emits_event` � verifies event emission on success
- **[ADD]** `test_set_max_move_bps_at_boundary_emits_event` � verifies event at boundary (0)
- **[ADD]** `test_set_max_flash_bps_emits_event` � verifies event emission on success
- **[ADD]** `test_set_max_flash_bps_default_emits_event` � verifies event at BPS_DENOM boundary
- **[ADD]** `test_set_collateral_asset_emits_event` � verifies event emission on success
- **[ADD]** `test_set_collateral_asset_replaces_event` � verifies two calls emit two events

## Verification Results

```
cargo test -p stellarlend-lending events_test
Expected: All new and existing event tests pass
```

Acceptance Criteria | Status
-- | --
`set_min_borrow` emits `MinBorrowSetEvent` | Implemented
`set_max_move_bps` emits `MaxMoveBpsSetEvent` | Implemented
`set_max_flash_bps` emits `MaxFlashBpsSetEvent` | Implemented
`set_collateral_asset` emits `CollateralAssetSetEvent` | Implemented
Events follow existing `#[contractevent]` + `.publish(&env)` pattern | Implemented
Failure paths do not emit events (unchanged from before) | Implemented
