### PR TITLE
feat(validation): updated lib.rs and reviewed bps files.

### DIFF
--- a/stellar-lend/contracts/common/src/bps_inverse_proptest.rs
+++ b/stellar-lend/contracts/common/src/bps_inverse_proptest.rs
@@ -29,16 +29,19 @@ use proptest::prelude::*;
 
 /// Reference oracle for [`scale_bps`] using the same checked primitives.
 ///
-/// Used to prove `scale_bps` returns `None` exactly on overflow and never panics.
+/// Used to prove `scale_bps` returns `None` on out-of-range rates or overflow and never panics.
 fn scale_ref(value: i128, rate_bps: i128) -> Option<i128> {
+    if rate_bps < 0 || rate_bps > BPS_DENOM {
+        return None;
+    }
     value
         .checked_mul(rate_bps)
         .and_then(|product| product.checked_div(BPS_DENOM))
 }
 
-/// Reference oracle for [`unscale_bps`] (zero divisor and overflow → `None`).
+/// Reference oracle for [`unscale_bps`] (zero, negative, >100% rates, and overflow → `None`).
 fn unscale_ref(value: i128, rate_bps: i128) -> Option<i128> {
-    if rate_bps == 0 {
+    if rate_bps <= 0 || rate_bps > BPS_DENOM {
         return None;
     }
     value

--- a/stellar-lend/contracts/common/src/bps_roundtrip_test.rs
+++ b/stellar-lend/contracts/common/src/bps_roundtrip_test.rs
@@ -95,18 +95,20 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_one_fifty_percent() {
-        assert_round_trip_loss_one(1_000_000, BPS_DENOM + 5_000);
+    fn round_trip_fifty_percent() {
+        assert_round_trip_loss_one(1_000_000, BPS_DENOM / 2);
     }
 
     #[test]
-    fn round_trip_two_hundred_percent() {
-        assert_round_trip_loss_one(1_000_000, BPS_DENOM * 2);
+    fn round_trip_above_hundred_percent_rejected() {
+        assert!(scale_bps(1_000_000, BPS_DENOM * 2).is_none());
+        assert!(unscale_bps(1_000_000, BPS_DENOM * 2).is_none());
     }
 
     #[test]
-    fn round_trip_ten_thousand_percent() {
-        assert_round_trip_loss_one(1_000_000, BPS_DENOM * 100);
+    fn round_trip_ten_thousand_percent_rejected() {
+        assert!(scale_bps(1_000_000, BPS_DENOM * 100).is_none());
+        assert!(unscale_bps(1_000_000, BPS_DENOM * 100).is_none());
     }
 
     #[test]
@@ -128,7 +130,7 @@ mod tests {
     fn round_trip_small_value_at_hundred_percent() {
         assert_round_trip_loss_one(1, BPS_DENOM);
         assert_round_trip_loss_one(7, BPS_DENOM);
-        assert_round_trip_loss_one(99, BPS_DENOM + 1);
+        assert_round_trip_loss_one(99, BPS_DENOM - 1);
     }
 
     #[test]
@@ -185,9 +187,12 @@ mod tests {
 
     #[test]
     fn round_trip_negative_rate_with_positive_value() {
-        assert_round_trip_loss_one(100, -BPS_DENOM);
-        assert_round_trip_loss_one(1_000_000, -500);
-        assert_round_trip_loss_one(42, -1);
+        assert!(scale_bps(100, -BPS_DENOM).is_none());
+        assert!(unscale_bps(100, -BPS_DENOM).is_none());
+        assert!(scale_bps(1_000_000, -500).is_none());
+        assert!(unscale_bps(1_000_000, -500).is_none());
+        assert!(scale_bps(42, -1).is_none());
+        assert!(unscale_bps(42, -1).is_none());
     }
 
     // ── Overflow → None (never wrap) ───────────────────────────────
@@ -239,12 +244,12 @@ mod tests {
     }
 
     #[test]
-    fn composition_small_loss_at_full_rate() {
-        // 5 * 10_000 / 10_000 = 5
-        // 5 * 10_000 / 10_001 = 4  (truncation loss of 1)
-        let scaled = scale_bps(5, BPS_DENOM + 1).unwrap();
-        assert_eq!(scaled, 5);
-        let round_trip = unscale_bps(scaled, BPS_DENOM + 1).unwrap();
+    fn composition_small_loss_at_near_full_rate() {
+        // 5 * 9_999 / 10_000 = 4
+        // 4 * 10_000 / 9_999 = 4 (truncation loss of 1 from the original value)
+        let scaled = scale_bps(5, BPS_DENOM - 1).unwrap();
+        assert_eq!(scaled, 4);
+        let round_trip = unscale_bps(scaled, BPS_DENOM - 1).unwrap();
         assert_eq!(round_trip, 4);
         let diff = round_trip.abs_diff(5);
         assert_eq!(diff, 1);
@@ -276,7 +281,7 @@ mod tests {
     fn composition_is_deterministic() {
         for _ in 0..10 {
             assert_round_trip_loss_one(99_999, BPS_DENOM);
-            assert_round_trip_loss_one(99_999, BPS_DENOM + 1);
+            assert_round_trip_loss_one(99_999, BPS_DENOM - 1);
         }
     }
 }

--- a/stellar-lend/contracts/common/src/lib.rs
+++ b/stellar-lend/contracts/common/src/lib.rs
@@ -44,7 +44,8 @@ pub enum LendingError {
 
 /// Multiply `value` by `rate_bps` and divide by [`BPS_DENOM`].
 ///
-/// Returns `None` on overflow.
+/// Only basis-point rates in the valid range `0..=BPS_DENOM` are accepted.
+/// Negative rates and rates above `100%` return `None`, as do overflow cases.
 ///
 /// # Examples
 /// ```
@@ -56,12 +57,16 @@ pub enum LendingError {
 /// ```
 #[inline]
 pub fn scale_bps(value: i128, rate_bps: i128) -> Option<i128> {
+    if rate_bps < 0 || rate_bps > BPS_DENOM {
+        return None;
+    }
     value.checked_mul(rate_bps)?.checked_div(BPS_DENOM)
 }
 
 /// Divide `value` by `rate_bps` and multiply by [`BPS_DENOM`] (inverse of `scale_bps`).
 ///
-/// Returns `None` if `rate_bps` is zero or on overflow.
+/// Only basis-point rates in the valid range `0..=BPS_DENOM` are accepted.
+/// Zero, negative, and rates above `100%` return `None`, as do overflow cases.
 ///
 /// # Examples
 /// ```
@@ -73,7 +78,7 @@ pub fn scale_bps(value: i128, rate_bps: i128) -> Option<i128> {
 /// ```
 #[inline]
 pub fn unscale_bps(value: i128, rate_bps: i128) -> Option<i128> {
-    if rate_bps == 0 {
+    if rate_bps <= 0 || rate_bps > BPS_DENOM {
         return None;
     }
     value.checked_mul(BPS_DENOM)?.checked_div(rate_bps)
@@ -126,6 +131,12 @@ mod tests {
         assert_eq!(scale_bps(10_000, 1), Some(1));
     }
 
+    #[test]
+    fn scale_bps_out_of_range_rate_returns_none() {
+        assert_eq!(scale_bps(1_000_000, -500), None);
+        assert_eq!(scale_bps(1_000_000, BPS_DENOM + 1), None);
+    }
+
     // ── unscale_bps ──────────────────────────────────────────────────────────
 
     #[test]
@@ -157,6 +168,12 @@ mod tests {
     #[test]
     fn unscale_bps_negative_value() {
         assert_eq!(unscale_bps(-50_000, 500), Some(-1_000_000));
+    }
+
+    #[test]
+    fn unscale_bps_out_of_range_rate_returns_none() {
+        assert_eq!(unscale_bps(1_000_000, -500), None);
+        assert_eq!(unscale_bps(1_000_000, BPS_DENOM + 1), None);
     }
 
     // ── LendingError discriminants ────────────────────────────────────────────


### PR DESCRIPTION
closes #1690 
 Shifted the behavior to a stricter contract at the helper boundary
Updated the surrounding regression coverage to reflect that range restriction instead of the old “accept any integer” semantics.
