### PR TITLE
feat(lending): emit events for set_min_borrow, set_max_move_bps, set_max_flash_bps, set_collateral_asset

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -282,6 +282,30 @@ pub struct PriceBoundsSetEvent {
 
 #[contractevent]
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MinBorrowSetEvent {
+    pub min_borrow: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaxMoveBpsSetEvent {
+    pub max_move_bps: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaxFlashBpsSetEvent {
+    pub max_flash_bps: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollateralAssetSetEvent {
+    pub asset: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LiquidationEventV1 {
     pub schema_version: u32,
     pub liquidator: Address,
@@ -813,6 +837,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::MaxMoveBps, &max_move_bps);
+        MaxMoveBpsSetEvent { max_move_bps }.publish(&env);
         Ok(())
     }
 
@@ -831,6 +856,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::MaxFlashUtilizationBps, &max_flash_bps);
+        MaxFlashBpsSetEvent { max_flash_bps }.publish(&env);
         Ok(())
     }
 
@@ -992,6 +1018,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::BorrowMinAmount, &min_borrow);
+        MinBorrowSetEvent { min_borrow }.publish(&env);
         Ok(())
     }
 
@@ -1172,6 +1199,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::ValuationCollateralAsset, &asset);
+        CollateralAssetSetEvent { asset }.publish(&env);
         Ok(())
     }
 


### PR DESCRIPTION
## What

Four admin-gated setters in the lending contract wrote storage keys with no corresponding event, the same gap already identified for other setters. This adds event structs and `.publish()` calls for all four, following the `set_price_bounds` / `PriceBoundsSetEvent` pattern.

## Events added

| Event struct | Setter | Fields |
|---|---|---|
| `MinBorrowSetEvent` | `set_min_borrow` | `min_borrow: i128` |
| `MaxMoveBpsSetEvent` | `set_max_move_bps` | `max_move_bps: i128` |
| `MaxFlashBpsSetEvent` | `set_max_flash_bps` | `max_flash_bps: i128` |
| `CollateralAssetSetEvent` | `set_collateral_asset` | `asset: Address` |

Each event is published after the storage write, giving indexers full visibility into governed parameter changes.

Fixes #1719