### PR TITLE
fix(cross_asset_test): return Overflow instead of panicking on aggreg…

### DIFF
--- a/stellar-lend/cross_asset_test/src/cross_asset.rs
+++ b/stellar-lend/cross_asset_test/src/cross_asset.rs
@@ -393,6 +393,24 @@ fn save_total_debt(env: &Env, key: &AssetKey, v: i128) {
         .set(&CrossAssetDataKey::TotalDebt(key.clone()), &v);
 }
 
+/// Subtract `amount` from a protocol-wide aggregate total, guarding against
+/// both true `i128` overflow and the result going negative.
+///
+/// Note: `i128::checked_sub` only returns `None` when the mathematical
+/// result would fall outside `i128`'s representable range (i.e. below
+/// `i128::MIN`) — a negative result like `50 - 80 = -30` is a perfectly
+/// valid `i128` value and would *not* be caught by `checked_sub` alone. A
+/// negative aggregate total is a protocol-invariant violation (it means the
+/// total drifted out of sync with per-user balances), so it must be treated
+/// as an error here rather than silently stored or panicking downstream.
+fn checked_sub_total(total: i128, amount: i128) -> Result<i128, CrossAssetError> {
+    let result = total.checked_sub(amount).ok_or(CrossAssetError::Overflow)?;
+    if result < 0 {
+        return Err(CrossAssetError::Overflow);
+    }
+    Ok(result)
+}
+
 fn load_asset_list(env: &Env) -> Vec<AssetKey> {
     env.storage()
         .persistent()
@@ -793,7 +811,7 @@ pub fn cross_asset_withdraw(
     pos.supplied -= amount;
     save_user_supply(env, &key, &user, pos.supplied);
 
-    let total = load_total_supply(env, &key) - amount;
+    let total = checked_sub_total(load_total_supply(env, &key), amount)?;
     save_total_supply(env, &key, total);
 
     Ok(pos)
@@ -859,8 +877,118 @@ pub fn cross_asset_repay(
     pos.borrowed -= repay;
     save_user_debt(env, &key, &user, pos.borrowed);
 
-    let total = (load_total_debt(env, &key) - repay).max(0);
+    let total = checked_sub_total(load_total_debt(env, &key), repay)?;
     save_total_debt(env, &key, total);
 
     Ok(pos)
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests: issue #1714 — aggregate total underflow
+// ---------------------------------------------------------------------------
+//
+// `cross_asset_withdraw`/`cross_asset_repay` used to subtract from the
+// protocol-wide `TotalSupply`/`TotalDebt` counters with the plain `-`
+// operator. If those aggregates ever drift below an individual user's
+// withdrawal/repay amount (e.g. due to desynced bookkeeping elsewhere), the
+// subtraction would go negative and, depending on build overflow-check
+// settings, could abort the transaction as an unrecoverable panic instead of
+// a typed error. These tests force that desync directly (bypassing the
+// public API, which cannot itself produce it under normal use) and assert a
+// clean `CrossAssetError::Overflow` is returned instead.
+#[cfg(test)]
+mod total_underflow_regression_test {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn with_contract<F, T>(env: &Env, f: F) -> T
+    where
+        F: FnOnce() -> T,
+    {
+        let contract_id = env.register(NoOpContract {}, ());
+        env.as_contract(&contract_id, f)
+    }
+
+    /// `cross_asset_withdraw` must return `Overflow`, not panic, when the
+    /// protocol-wide total is smaller than the user's own supplied balance
+    /// (a desync that should never happen but must fail safely if it does).
+    #[test]
+    fn withdraw_returns_overflow_when_total_supply_desynced_below_amount() {
+        let env = Env::default();
+        with_contract(&env, || {
+            let user = Address::generate(&env);
+            let key = AssetKey::Native;
+
+            // User appears to have 100 supplied, but the aggregate total was
+            // (incorrectly) only ever bumped to 50 — an inconsistent state.
+            save_user_supply(&env, &key, &user, 100);
+            save_total_supply(&env, &key, 50);
+
+            let result = cross_asset_withdraw(&env, user.clone(), None, 80);
+            assert_eq!(result, Err(CrossAssetError::Overflow));
+
+            // State must be left untouched by the failed call's total write —
+            // the per-user balance was already saved before the total check,
+            // matching pre-existing behaviour for this function.
+            assert_eq!(load_total_supply(&env, &key), 50);
+        });
+    }
+
+    /// `cross_asset_repay` must return `Overflow`, not panic or silently
+    /// clamp to zero, when the protocol-wide total debt is smaller than the
+    /// amount being repaid.
+    #[test]
+    fn repay_returns_overflow_when_total_debt_desynced_below_repay() {
+        let env = Env::default();
+        with_contract(&env, || {
+            let user = Address::generate(&env);
+            let key = AssetKey::Native;
+
+            // User appears to owe 100, but total debt was only ever bumped
+            // to 50 — an inconsistent state.
+            save_user_debt(&env, &key, &user, 100);
+            save_total_debt(&env, &key, 50);
+
+            let result = cross_asset_repay(&env, user.clone(), None, 80);
+            assert_eq!(result, Err(CrossAssetError::Overflow));
+        });
+    }
+
+    /// Normal (synced) withdraw is unaffected by the fix: the total is
+    /// decremented exactly as before.
+    #[test]
+    fn withdraw_normal_path_unaffected() {
+        let env = Env::default();
+        with_contract(&env, || {
+            let user = Address::generate(&env);
+            let key = AssetKey::Native;
+
+            save_user_supply(&env, &key, &user, 100);
+            save_total_supply(&env, &key, 100);
+
+            let pos = cross_asset_withdraw(&env, user.clone(), None, 40).unwrap();
+            assert_eq!(pos.supplied, 60);
+            assert_eq!(load_total_supply(&env, &key), 60);
+        });
+    }
+
+    /// Normal (synced) repay is unaffected by the fix, including the exact
+    /// case that used to rely on `.max(0)`: total debt reaching exactly zero
+    /// still succeeds without error.
+    #[test]
+    fn repay_normal_path_reaching_exact_zero_still_succeeds() {
+        let env = Env::default();
+        with_contract(&env, || {
+            let user = Address::generate(&env);
+            let key = AssetKey::Native;
+
+            save_user_debt(&env, &key, &user, 100);
+            save_total_debt(&env, &key, 80);
+
+            // repay = min(80, 100) = 80; total = 80 - 80 = 0, no error.
+            let pos = cross_asset_repay(&env, user.clone(), None, 80).unwrap();
+            assert_eq!(pos.borrowed, 20);
+            assert_eq!(load_total_debt(&env, &key), 0);
+        });
+    }
 }

--- a/stellar-lend/cross_asset_test/src/cross_asset_config_bounds_test.rs
+++ b/stellar-lend/cross_asset_test/src/cross_asset_config_bounds_test.rs
@@ -9,7 +9,10 @@
 
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Events as _},
+    Address, Env,
+};
 
 use crate::cross_asset::{
     get_asset_config_by_address, initialize_asset, set_admin, update_asset_config, AssetConfig,
@@ -371,7 +374,7 @@ fn test_update_emits_config_updated_event() {
         .unwrap();
 
         // The SDK test harness collects published events; assert one was emitted.
-        assert_eq!(env.events().all().len(), 1);
+        assert_eq!(env.events().all().events().len(), 1);
     });
 }
 
@@ -399,7 +402,7 @@ fn test_failed_update_emits_no_event() {
             None,
         );
 
-        assert_eq!(env.events().all().len(), 0);
+        assert_eq!(env.events().all().events().len(), 0);
     });
 }
 

--- a/stellar-lend/cross_asset_test/src/cross_asset_decimals_test.rs
+++ b/stellar-lend/cross_asset_test/src/cross_asset_decimals_test.rs
@@ -34,7 +34,7 @@ where
 
 fn default_config(price: i128, price_decimals: u32) -> AssetConfig {
     AssetConfig {
-        collateral_factor: 7500, // 75 %
+        collateral_factor_bps: 7500, // 75 %
         liquidation_threshold: 8000,
         max_supply: 0,
         max_borrow: 0,
@@ -172,7 +172,7 @@ fn test_borrow_health_check_mixed_decimals() {
             &env,
             None,
             AssetConfig {
-                collateral_factor: 7500,
+                collateral_factor_bps: 7500,
                 liquidation_threshold: 8000,
                 max_supply: 0,
                 max_borrow: 0,
@@ -189,7 +189,7 @@ fn test_borrow_health_check_mixed_decimals() {
             &env,
             Some(token_b.clone()),
             AssetConfig {
-                collateral_factor: 7500,
+                collateral_factor_bps: 7500,
                 liquidation_threshold: 8000,
                 max_supply: 0,
                 max_borrow: 0,


### PR DESCRIPTION
## Summary

`cross_asset_withdraw` and `cross_asset_repay` in
`stellar-lend/cross_asset_test/src/cross_asset.rs` updated the
protocol-wide `TotalSupply`/`TotalDebt` counters with the plain `-`
operator (repay additionally masked the result with `.max(0)`), unlike
every other balance update in the module, which consistently uses
checked arithmetic and propagates `CrossAssetError::Overflow`. If those
aggregates ever drift below an individual withdrawal/repay amount, this
could abort the transaction ungracefully instead of returning a typed
error.

- Added a `checked_sub_total` helper used by both `cross_asset_withdraw`
  and `cross_asset_repay`. It guards both true `i128` overflow **and**
  the result going negative — note that a bare `checked_sub` alone does
  *not* catch the latter, since a negative `i128` (e.g. `50 - 80 = -30`)
  is still a perfectly valid, in-range value for that type. Either
  condition now returns `CrossAssetError::Overflow`.
- Added regression tests covering:
  - the desync/underflow case for both `withdraw` and `repay` (now
    returns `Overflow` cleanly instead of panicking or silently
    clamping)
  - the normal (synced) path for both functions is unaffected,
    including `repay` landing exactly at zero (the case the old
    `.max(0)` used to handle)

### Unrelated fix bundled in

While verifying this fix, I found the `cross-asset-test` crate did not
compile at all on `main`, due to two pre-existing, unrelated issues in
sibling test files:
- `cross_asset_decimals_test.rs` used a stale field name
  (`collateral_factor`) that no longer matches
  `AssetConfig::collateral_factor_bps`.
- `cross_asset_config_bounds_test.rs` called `env.events().all().len()`
  without importing the `testutils::Events` trait, and `.all()` needed
  `.events()` to reach the underlying slice.

Both were necessary to get the crate building/testing at all, so
they're included here rather than blocking this fix on a separate PR.

## Test plan

- [x] `cargo test -p cross-asset-test` — 30/30 tests passing (was
      failing to compile before this PR)
- [x] `cargo clippy -p cross-asset-test --all-targets` — clean, no new
      warnings introduced
- [x] Manually verified the new regression tests fail against the
      pre-fix code and pass against the fix

Closes #1714