### PR TITLE
docs(lending): fix README view names that don't exist in lib.rs (#1721)

### DIFF
--- a/stellar-lend/contracts/lending/README.md
+++ b/stellar-lend/contracts/lending/README.md
@@ -239,10 +239,10 @@ The contract treats the current struct-returning getter responses as view schema
 
 Covered getters:
 
-- `get_user_debt() -> DebtPosition`
-- `get_user_collateral() -> BorrowCollateral`
-- `get_user_collateral_deposit() -> DepositCollateral`
-- `get_user_position() -> UserPositionSummary`
+- `get_debt_position(user: Address) -> DebtPosition`
+- `get_position(user: Address) -> PositionSummary` (aliased as `get_user_position(user: Address)`)
+- `get_cross_position_summary(user: Address) -> CrossPositionSummary`
+- `get_debt_asset_position(user: Address, asset: Address) -> DebtPosition`
 
 Wire-format guarantee:
 
@@ -259,7 +259,7 @@ Stable decoding guidance:
 Versioning strategy:
 
 - Existing getter response structs are preserved in place for schema `v1`.
-- Any additive or breaking change to one of the getter structs must ship as a new versioned getter/type, for example `get_user_position_v2()`, instead of mutating the current response shape.
+- Any additive or breaking change to one of the getter structs must ship as a new versioned getter/type, for example `get_position_v2()`, instead of mutating the current response shape. (No such versioned getter exists today — this describes the strategy to follow if/when one is needed.)
 - A runtime `schema` field is intentionally not added to the existing structs because that would itself be a breaking ABI change for the current getter surface.
 
 ## Contract Interface


### PR DESCRIPTION
## Summary

The "View Serialization Stability" section of
`stellar-lend/contracts/lending/README.md` listed `get_user_debt()`,
`get_user_collateral()`, `get_user_collateral_deposit()`, and
`get_user_position_v2()` as the contract's covered read-only views,
with return types `DebtPosition`/`BorrowCollateral`/`DepositCollateral`/
`UserPositionSummary`. None of those function names exist in
`src/lib.rs`, and neither do the `BorrowCollateral`, `DepositCollateral`,
or `UserPositionSummary` types — the `_v2` suffix in particular pointed
at an API-versioning attempt that never shipped.

Cross-checked the section against `lib.rs`'s actual `pub fn`
declarations and struct definitions, and replaced the list with the
real getters and signatures:

- `get_debt_position(user: Address) -> DebtPosition`
- `get_position(user: Address) -> PositionSummary` (aliased as `get_user_position`)
- `get_cross_position_summary(user: Address) -> CrossPositionSummary`
- `get_debt_asset_position(user: Address, asset: Address) -> DebtPosition`

Also reworded the versioning-strategy example to reference the real
`get_position()` getter (as a hypothetical `get_position_v2()`) instead
of a name that was never shipped, and made explicit that no such
versioned getter exists today.

## Test plan

This is a documentation-only change (no source/behavior changes).
Verified by cross-referencing every function name and struct
introduced in the corrected list directly against `pub fn`/`pub struct`
declarations in `stellar-lend/contracts/lending/src/lib.rs` (and
`debt.rs` for `DebtPosition`), confirming exact name, parameter, and
return-type matches.

Closes #1721