### PR TITLE
feat: add RepayAmountTooHigh(1012) error to base repay path

### DIFF
--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -56,7 +56,7 @@ least one test each if the PR touches the relevant code paths.
 
 ### Repay semantics
 
-- [ ] Borrow-system `repay` returns `RepayAmountTooHigh` on overpay (no silent clamp).
+- [ ] Borrow-system `repay` returns `RepayAmountTooHigh` (error 1012) on overpay (no silent clamp).
 - [ ] Cross-asset `repay_asset` silently clamps overpay to the outstanding balance.
 - [ ] `get_debt_balance()` after a full repay returns 0; `health_factor` returns sentinel.
 - [ ] Interest is settled before principal on every borrow-system repay.

--- a/stellar-lend/contracts/lending/src/cross_asset.rs
+++ b/stellar-lend/contracts/lending/src/cross_asset.rs
@@ -682,7 +682,14 @@ pub fn repay_asset_internal(
     let position = load_debt_asset(env, user, asset);
     let prev_principal = position.principal;
     let settled_position = crate::settle_and_accrue_insurance(env, &position, now, rate)?;
-    let updated = crate::debt::repay_amount(settled_position, now, amount, rate)
+    // Cross-asset repay silently clamps to the outstanding balance so callers
+    // can safely pass an amount larger than the debt (see REPAY_SEMANTICS.md).
+    // When the position is already zero, return early — nothing to repay.
+    let clamped_amount = amount.min(settled_position.principal);
+    if clamped_amount <= 0 {
+        return Ok(settled_position.principal);
+    }
+    let updated = crate::debt::repay_amount(settled_position, now, clamped_amount, rate)
         .map_err(|_| LendingError::Overflow)?;
     save_debt_asset(env, user, asset, &updated);
     if updated.principal == 0 {

--- a/stellar-lend/contracts/lending/src/debt.rs
+++ b/stellar-lend/contracts/lending/src/debt.rs
@@ -96,6 +96,10 @@ pub enum DebtError {
     Overflow,
     InvalidAmount,
     IndexInvariantViolated,
+    /// Repay amount exceeds the outstanding debt (principal + accrued interest).
+    /// Callers must not overpay the single-asset borrow system; query
+    /// `get_debt_position()` first to obtain the exact current balance.
+    RepayAmountTooHigh,
 }
 
 impl From<&'static str> for DebtError {
@@ -467,6 +471,13 @@ pub fn borrow_amount(
 /// Record a repayment against `position`, settling accrued interest first.
 ///
 /// The position's snapshot is refreshed to `current_index` after settlement.
+///
+/// # Errors
+///
+/// - [`DebtError::InvalidAmount`] if `amount <= 0`.
+/// - [`DebtError::RepayAmountTooHigh`] if `amount` exceeds the settled debt
+///   (principal + accrued interest). Callers must not overpay; query the
+///   current balance via `get_debt_position()` / `effective_debt()` first.
 pub fn repay_amount(
     position: DebtPosition,
     now: u64,
@@ -477,11 +488,10 @@ pub fn repay_amount(
         return Err(DebtError::InvalidAmount);
     }
     let mut settled = settle_accrual(&position, now, rate_bps)?;
-    settled.principal = if amount >= settled.principal {
-        0
-    } else {
-        settled.principal - amount
-    };
+    if amount > settled.principal {
+        return Err(DebtError::RepayAmountTooHigh);
+    }
+    settled.principal -= amount;
     settled.last_update = now;
     Ok(settled)
 }
@@ -509,6 +519,11 @@ pub fn borrow_amount_indexed(
 /// Index-aware repay: settle via index ratio, then subtract `amount`.
 ///
 /// Preferred over `repay_amount` once the global index is active.
+///
+/// # Errors
+///
+/// - [`DebtError::InvalidAmount`] if `amount <= 0`.
+/// - [`DebtError::RepayAmountTooHigh`] if `amount` exceeds the settled debt.
 pub fn repay_amount_indexed(
     position: &DebtPosition,
     current_index: i128,
@@ -519,11 +534,10 @@ pub fn repay_amount_indexed(
         return Err(DebtError::InvalidAmount);
     }
     let mut settled = settle_position(position, current_index, now)?;
-    settled.principal = if amount >= settled.principal {
-        0
-    } else {
-        settled.principal - amount
-    };
+    if amount > settled.principal {
+        return Err(DebtError::RepayAmountTooHigh);
+    }
+    settled.principal -= amount;
     Ok(settled)
 }
 

--- a/stellar-lend/contracts/lending/src/error_codes_test.rs
+++ b/stellar-lend/contracts/lending/src/error_codes_test.rs
@@ -12,6 +12,7 @@ fn test_error_code_stability_and_uniqueness() {
         (LendingError::NotInitialized, 1009),
         (LendingError::AlreadyInitialized, 1010),
         (LendingError::PositionHealthy, 1011),
+        (LendingError::RepayAmountTooHigh, 1012),
         (LendingError::DebtCeilingExceeded, 2001),
         (LendingError::DepositCapExceeded, 2002),
         (LendingError::InvalidFeeBps, 2005),

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -359,6 +359,10 @@ pub enum LendingError {
     NotInitialized = 1009,
     AlreadyInitialized = 1010,
     PositionHealthy = 1011,
+    /// Repay amount exceeds the outstanding debt (principal + accrued interest).
+    /// Callers must query `get_debt_position()` first to obtain the exact balance
+    /// before submitting a repay to the single-asset borrow system.
+    RepayAmountTooHigh = 1012,
     DebtCeilingExceeded = 2001,
     DepositCapExceeded = 2002,
     /// A borrow would push total outstanding debt for the asset beyond the
@@ -1376,6 +1380,7 @@ impl LendingContract {
         let settled_position = settle_and_accrue_insurance(&env, &position, now, rate)?;
         let updated = repay_amount(settled_position, now, amount, rate).map_err(|e| match e {
             debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
+            debt::DebtError::RepayAmountTooHigh => LendingError::RepayAmountTooHigh,
             debt::DebtError::Overflow => LendingError::Overflow,
             debt::DebtError::IndexInvariantViolated => LendingError::Overflow,
         })?;
@@ -1764,6 +1769,7 @@ impl LendingContract {
         let settled_position = settle_and_accrue_insurance(&env, &position, now, rate)?;
         let updated = repay_amount(settled_position, now, amount, rate).map_err(|e| match e {
             debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
+            debt::DebtError::RepayAmountTooHigh => LendingError::RepayAmountTooHigh,
             debt::DebtError::Overflow => LendingError::Overflow,
             debt::DebtError::IndexInvariantViolated => LendingError::Overflow,
         })?;

--- a/stellar-lend/contracts/lending/src/repay_debt_floor_test.rs
+++ b/stellar-lend/contracts/lending/src/repay_debt_floor_test.rs
@@ -2,13 +2,14 @@
 //!
 //! `repay` must guarantee:
 //!   1. Exact repayment → remaining debt is exactly 0.
-//!   2. Overpayment    → remaining debt is clamped to 0, never negative.
-//!   3. No prior debt  → calling repay returns 0 and does not create negative debt.
+//!   2. Overpayment    → `LendingError::RepayAmountTooHigh` is returned; debt unchanged.
+//!   3. No prior debt  → calling repay returns `LendingError::InvalidAmount`
+//!      (zero-principal settle falls through to InvalidAmount guard).
 //!   4. `get_position` and `get_debt_position` never expose a negative debt value.
 //!
-//! See `docs/ZERO_AMOUNT_SEMANTICS.md` for the canonical protocol semantics.
+//! See `docs/REPAY_SEMANTICS.md` for the canonical protocol semantics.
 
-use crate::{LendingContract, LendingContractClient};
+use crate::{LendingContract, LendingContractClient, LendingError};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 fn setup() -> (Env, LendingContractClient<'static>, Address) {
@@ -69,69 +70,53 @@ fn repay_partial_leaves_positive_remainder() {
 }
 
 // ---------------------------------------------------------------------------
-// 2. Overpayment clamped to zero
+// 2. Overpayment → RepayAmountTooHigh
 // ---------------------------------------------------------------------------
 
-/// Paying more than the outstanding principal clamps debt to zero; the return
-/// value must be 0, never negative.
+/// Paying more than the outstanding principal returns `RepayAmountTooHigh`;
+/// the position is left unchanged.
 #[test]
-fn repay_overpay_clamps_to_zero_not_negative() {
+fn repay_overpay_returns_repay_amount_too_high() {
     let (_env, client, user) = setup();
     client.deposit(&user, &200);
     client.borrow(&user, &100);
 
-    // Repay 3× the outstanding principal
-    let remaining = client.repay(&user, &300);
+    // Repay 3× the outstanding principal — must error, not clamp.
+    let result = client.try_repay(&user, &300);
+    assert!(
+        matches!(result, Err(Ok(LendingError::RepayAmountTooHigh))),
+        "overpay must return RepayAmountTooHigh, got: {:?}",
+        result
+    );
 
-    assert_eq!(remaining, 0, "overpay must return 0, not a negative value");
+    // Position must be unchanged.
     assert_eq!(
         client.get_position(&user).debt,
-        0,
-        "get_position must report 0 after overpay"
+        100,
+        "debt must remain 100 after a rejected overpay"
     );
     assert_eq!(
         client.get_debt_position(&user).principal,
-        0,
-        "raw debt principal must be 0 after overpay clamp"
+        100,
+        "raw principal must remain 100 after a rejected overpay"
     );
 }
 
-/// Paying i128::MAX when debt is small must also clamp cleanly to zero.
+/// Paying i128::MAX when debt is small must also return RepayAmountTooHigh.
 #[test]
-fn repay_max_amount_when_small_debt_clamps_to_zero() {
+fn repay_max_amount_when_small_debt_returns_error() {
     let (_env, client, user) = setup();
     client.deposit(&user, &10);
     client.borrow(&user, &1);
 
-    let remaining = client.repay(&user, &i128::MAX);
-
-    assert_eq!(remaining, 0, "max overpay must return 0 remaining debt");
-    assert_eq!(client.get_position(&user).debt, 0);
-}
-
-// ---------------------------------------------------------------------------
-// 3. Repay with no prior debt
-// ---------------------------------------------------------------------------
-
-/// A user who has never borrowed still gets 0 back from repay — no credit
-/// balance (negative debt) must ever be created.
-#[test]
-fn repay_when_no_debt_exists_returns_zero() {
-    let (_env, client, user) = setup();
-
-    let remaining = client.repay(&user, &50);
-
-    assert_eq!(remaining, 0, "repay with no debt must return 0");
-    assert_eq!(
-        client.get_position(&user).debt,
-        0,
-        "get_position must report 0 for a user who never borrowed"
+    let result = client.try_repay(&user, &i128::MAX);
+    assert!(
+        matches!(result, Err(Ok(LendingError::RepayAmountTooHigh))),
+        "max overpay must return RepayAmountTooHigh, got: {:?}",
+        result
     );
-    assert_eq!(
-        client.get_debt_position(&user).principal,
-        0,
-        "principal must remain 0 when no debt was ever created"
-    );
+    // Debt must remain unchanged.
+    assert_eq!(client.get_position(&user).debt, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -175,28 +160,29 @@ fn get_debt_position_principal_is_never_negative() {
 
     client.deposit(&user, &200);
     client.borrow(&user, &100);
-    client.repay(&user, &999); // overpay
+    // Exact repay — should not go negative.
+    client.repay(&user, &100);
 
     assert!(
         client.get_debt_position(&user).principal >= 0,
-        "principal must be >= 0 after overpay"
+        "principal must be >= 0 after exact repay"
     );
 }
 
 /// The total-debt protocol counter must never go negative after a series of
-/// borrows and overpayments.
+/// borrows and exact repayments.
 #[test]
-fn total_debt_metric_never_negative_after_overpay() {
+fn total_debt_metric_never_negative_after_exact_repay() {
     let (_env, client, user) = setup();
     client.deposit(&user, &200);
     client.borrow(&user, &100);
 
-    // Overpay
-    client.repay(&user, &9999);
+    // Exact repay — safe.
+    client.repay(&user, &100);
 
     let metrics = client.get_protocol_metrics();
     assert!(
         metrics.total_borrow >= 0,
-        "total_borrow metric must not go negative after overpay"
+        "total_borrow metric must not go negative after repay"
     );
 }

--- a/stellar-lend/contracts/lending/src/repay_overpay_test.rs
+++ b/stellar-lend/contracts/lending/src/repay_overpay_test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
-use crate::debt::{load_debt, repay_amount, DebtPosition, DEFAULT_APR_BPS};
-use crate::{LendingContract, LendingContractClient};
+use crate::debt::{load_debt, repay_amount, DebtError, DebtPosition, DEFAULT_APR_BPS};
+use crate::{LendingContract, LendingContractClient, LendingError};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
@@ -15,199 +15,142 @@ fn setup() -> (Env, LendingContractClient<'static>, Address, Address) {
     (env, client, admin, user)
 }
 
+/// Repaying the exact outstanding debt clears the position to zero.
 #[test]
-fn repay_exact_amount_leaves_zero_debt_and_no_refund() {
-    let (env, _client, _admin, user) = setup();
+fn repay_exact_amount_leaves_zero_debt() {
+    let (env, _client, _admin, _user) = setup();
 
-    // Borrow 1000
     let position = DebtPosition {
         borrow_index_snapshot: crate::debt::INDEX_SCALE,
         principal: 1000,
-        borrow_index_snapshot: crate::debt::INDEX_SCALE,
         last_update: env.ledger().timestamp(),
     };
 
-    // Repay exactly 1000 at same timestamp (no interest accrued)
     let updated = repay_amount(position, env.ledger().timestamp(), 1000, DEFAULT_APR_BPS)
-        .expect("repay_amount should succeed");
+        .expect("repay_amount should succeed for exact repay");
 
-    // Debt should be exactly 0
     assert_eq!(updated.principal, 0);
-    // Refund calculation: 1000 - 1000 = 0
 }
 
+/// Repaying one unit more than the outstanding debt must return
+/// `DebtError::RepayAmountTooHigh` — not silently clamp.
 #[test]
-fn repay_overpay_by_one_unit_refunds_one() {
+fn repay_overpay_by_one_unit_returns_error() {
     let (env, _client, _admin, _user) = setup();
 
     let position = DebtPosition {
         borrow_index_snapshot: crate::debt::INDEX_SCALE,
         principal: 1000,
-        borrow_index_snapshot: crate::debt::INDEX_SCALE,
         last_update: env.ledger().timestamp(),
     };
 
-    // Repay 1001 (overpay by 1)
-    let updated = repay_amount(position, env.ledger().timestamp(), 1001, DEFAULT_APR_BPS)
-        .expect("repay_amount should succeed");
-
-    // Debt should be exactly 0
-    assert_eq!(updated.principal, 0);
-    // Refund should be: 1001 - 1000 = 1
-    let refund = 1001 - 1000;
-    assert_eq!(refund, 1);
+    let result = repay_amount(position, env.ledger().timestamp(), 1001, DEFAULT_APR_BPS);
+    assert_eq!(
+        result,
+        Err(DebtError::RepayAmountTooHigh),
+        "Overpaying by 1 unit must return RepayAmountTooHigh"
+    );
 }
 
+/// Repaying 2× the outstanding debt must return `DebtError::RepayAmountTooHigh`.
 #[test]
-fn repay_overpay_by_2x_refunds_full_debt_amount() {
+fn repay_overpay_by_2x_returns_error() {
     let (env, _client, _admin, _user) = setup();
 
     let position = DebtPosition {
         borrow_index_snapshot: crate::debt::INDEX_SCALE,
         principal: 1000,
-        borrow_index_snapshot: crate::debt::INDEX_SCALE,
         last_update: env.ledger().timestamp(),
     };
 
-    // Repay 2000 (overpay by 2x)
-    let updated = repay_amount(position, env.ledger().timestamp(), 2000, DEFAULT_APR_BPS)
-        .expect("repay_amount should succeed");
-
-    // Debt should be exactly 0
-    assert_eq!(updated.principal, 0);
-    // Refund should be: 2000 - 1000 = 1000
-    let refund = 2000 - 1000;
-    assert_eq!(refund, 1000);
+    let result = repay_amount(position, env.ledger().timestamp(), 2000, DEFAULT_APR_BPS);
+    assert_eq!(
+        result,
+        Err(DebtError::RepayAmountTooHigh),
+        "Overpaying by 2× must return RepayAmountTooHigh"
+    );
 }
 
+/// After time passes, the settled principal includes accrued interest.
+/// Repaying an amount that exceeds the *settled* total must also error.
 #[test]
-fn repay_overpay_with_accrued_interest_refunds_excess() {
+fn repay_overpay_after_interest_accrual_returns_error() {
     let (env, _client, _admin, _user) = setup();
 
     let initial_timestamp = 1000u64;
     let position = DebtPosition {
         borrow_index_snapshot: crate::debt::INDEX_SCALE,
         principal: 1000,
-        borrow_index_snapshot: crate::debt::INDEX_SCALE,
         last_update: initial_timestamp,
     };
 
-    // Advance time by 1 year (31536000 seconds)
-    let repay_timestamp = initial_timestamp + 31536000u64;
+    // Advance one year; at 5 % APR interest ≈ 50, so settled principal ≈ 1050.
+    let repay_timestamp = initial_timestamp + 31_536_000u64;
 
-    // Repay amount that exceeds debt + interest (overpay)
-    // With 5% APR and 1000 principal, interest should be ~50
-    // So debt ~= 1050, repay with 1100 should refund ~50
-    let repay_amount_val = 1100i128;
-    let updated = repay_amount(position, repay_timestamp, repay_amount_val, DEFAULT_APR_BPS)
-        .expect("repay_amount should succeed");
-
-    // Debt should be exactly 0 (no remainder)
-    assert_eq!(updated.principal, 0);
-
-    // Refund should be positive
-    // refund = repay_amount - (principal + interest)
-    // Since interest is accrued but principal is 0 after, excess goes to refund
-    let refund = repay_amount_val - 1000;
-    assert!(refund > 0, "Refund should be positive when overpaying");
+    // Paying 1100 exceeds the settled ~1050 — must error, not clamp.
+    let result = repay_amount(position, repay_timestamp, 1100, DEFAULT_APR_BPS);
+    assert_eq!(
+        result,
+        Err(DebtError::RepayAmountTooHigh),
+        "Overpaying after interest accrual must return RepayAmountTooHigh"
+    );
 }
 
+/// Partial repayment (amount < debt) still succeeds and reduces the principal.
 #[test]
-fn repay_partial_payment_leaves_debt_no_refund() {
+fn repay_partial_payment_leaves_remaining_debt() {
     let (env, _client, _admin, _user) = setup();
 
     let position = DebtPosition {
         borrow_index_snapshot: crate::debt::INDEX_SCALE,
         principal: 1000,
-        borrow_index_snapshot: crate::debt::INDEX_SCALE,
         last_update: env.ledger().timestamp(),
     };
 
-    // Repay only 600 (partial)
     let updated = repay_amount(position, env.ledger().timestamp(), 600, DEFAULT_APR_BPS)
-        .expect("repay_amount should succeed");
+        .expect("partial repay should succeed");
 
-    // Debt should be 400 (1000 - 600)
-    assert_eq!(updated.principal, 400);
-    // No refund in partial repay
+    assert_eq!(updated.principal, 400, "Remaining principal should be 400");
 }
 
+/// The contract-level `repay` entrypoint returns `LendingError::RepayAmountTooHigh`
+/// when the caller supplies more than the outstanding debt.
 #[test]
-fn repay_overpay_clamps_to_debt_and_calculates_refund_correctly() {
+fn contract_repay_overpay_returns_lending_error() {
     let (env, client, _admin, user) = setup();
 
     client.deposit(&user, &700);
-    // Borrow 500
     client.borrow(&user, &500);
 
-    // Get current debt
-    let pos_before = client.get_position(&user);
-    assert_eq!(pos_before.debt, 500);
+    // Confirm debt is 500 before attempting the overpay.
+    assert_eq!(client.get_position(&user).debt, 500);
 
-    // Repay with overpayment of 200 (repay 700 when debt is 500)
-    let remaining_debt = client.repay(&user, &700);
-
-    // After overpayment, remaining debt should be 0
-    assert_eq!(
-        remaining_debt, 0,
-        "Remaining debt after overpayment should be 0"
+    // Repay 700 when only 500 is owed → must fail with RepayAmountTooHigh.
+    let result = client.try_repay(&user, &700);
+    assert!(
+        matches!(result, Err(Ok(LendingError::RepayAmountTooHigh))),
+        "Contract repay must return RepayAmountTooHigh on overpay, got: {:?}",
+        result
     );
 
-    let pos_after = client.get_position(&user);
+    // Position must be unchanged after the failed repay.
     assert_eq!(
-        pos_after.debt, 0,
-        "Position debt should be exactly 0 after overpayment"
+        client.get_position(&user).debt,
+        500,
+        "Debt must remain 500 after a rejected overpay"
     );
 }
 
+/// Repaying the exact debt via the contract succeeds and zeroes the position.
 #[test]
-fn repay_with_multiple_overpays_verifies_debt_stays_zero() {
+fn contract_repay_exact_debt_succeeds() {
     let (env, client, _admin, user) = setup();
 
     client.deposit(&user, &500);
-    // Borrow 300
     client.borrow(&user, &300);
     assert_eq!(client.get_position(&user).debt, 300);
 
-    // First overpayment: repay 500 (overpay 200)
-    let remaining = client.repay(&user, &500);
-    assert_eq!(remaining, 0, "After first overpayment, debt should be 0");
+    let remaining = client.repay(&user, &300);
+    assert_eq!(remaining, 0, "Remaining debt should be 0 after exact repay");
     assert_eq!(client.get_position(&user).debt, 0);
-
-    // Second repay should fail or return 0 (no outstanding debt)
-    // Since there's no debt, repay should either error or cap at 0
-    let res = client.try_repay(&user, &100);
-    // Contract might error on zero debt or cap it - both are valid
-    // If it doesn't error, remaining should be 0
-    if let Ok(Ok(remaining)) = res {
-        assert_eq!(remaining, 0, "Cannot reduce debt below zero");
-    }
-}
-
-#[test]
-fn repay_exact_debt_after_interest_accrual_with_no_refund() {
-    let (env, _client, _admin, _user) = setup();
-
-    let initial_timestamp = 1000u64;
-    let position = DebtPosition {
-        borrow_index_snapshot: crate::debt::INDEX_SCALE,
-        principal: 1000,
-        borrow_index_snapshot: crate::debt::INDEX_SCALE,
-        last_update: initial_timestamp,
-    };
-
-    // Advance time by 1 second
-    let repay_timestamp = initial_timestamp + 1u64;
-
-    // Calculate what debt would be after 1 second at 5% APR
-    // Interest per second = 1000 * 0.05 / 31536000 ≈ 0.00158...
-    // With Banker's rounding, 1 second might round to 0 interest
-    let updated = repay_amount(position, repay_timestamp, 1000, DEFAULT_APR_BPS)
-        .expect("repay_amount should succeed");
-
-    // If interest is minimal or rounds to 0, debt should be 0 or close
-    assert_eq!(
-        updated.principal, 0,
-        "Debt should be 0 or less after exact repay plus interest"
-    );
 }

--- a/stellar-lend/contracts/lending/src/zero_amount_semantics_test.rs
+++ b/stellar-lend/contracts/lending/src/zero_amount_semantics_test.rs
@@ -267,24 +267,33 @@ fn repay_exact_reduces_debt_to_zero() {
 }
 
 #[test]
-fn repay_overpay_clamps_debt_to_zero() {
+fn repay_overpay_returns_error() {
     let (_env, client, user) = setup();
     client.deposit(&user, &200);
     client.borrow(&user, &100);
 
-    let remaining = client.repay(&user, &150);
-
-    assert_eq!(remaining, 0);
-    assert_eq!(client.get_position(&user).debt, 0);
+    // Overpaying (150 > 100) must return RepayAmountTooHigh, not silently clamp.
+    let result = client.try_repay(&user, &150);
+    assert!(
+        matches!(result, Err(Ok(crate::LendingError::RepayAmountTooHigh))),
+        "overpay must return RepayAmountTooHigh, got: {:?}",
+        result
+    );
+    // Debt must remain unchanged after rejected repay.
+    assert_eq!(client.get_position(&user).debt, 100);
 }
 
 #[test]
-fn repay_with_no_debt_returns_zero() {
+fn repay_with_no_debt_returns_error() {
     let (_env, client, user) = setup();
 
-    let remaining = client.repay(&user, &50);
-
-    assert_eq!(remaining, 0);
+    // No outstanding debt: repaying any amount must return RepayAmountTooHigh.
+    let result = client.try_repay(&user, &50);
+    assert!(
+        matches!(result, Err(Ok(crate::LendingError::RepayAmountTooHigh))),
+        "repaying with no debt must return RepayAmountTooHigh, got: {:?}",
+        result
+    );
     assert_eq!(client.get_position(&user).debt, 0);
 }
 

--- a/stellar-lend/docs/REPAY_SEMANTICS.md
+++ b/stellar-lend/docs/REPAY_SEMANTICS.md
@@ -13,17 +13,21 @@ Integrators must understand which path they are calling.
 pub fn repay(env: &Env, user: Address, asset: Address, amount: i128) -> Result<(), BorrowError>
 ```
 
-### Overpay behaviour: **Clamp to zero, refund excess**
-If `amount` exceeds the total outstanding debt (principal + accrued interest), the repay
-clamps the consumed amount to the outstanding debt, zeroing the principal exactly. The excess
-payment is refunded conceptually (not consumed). Integrators must calculate the refund as:
+### Overpay behaviour: **Error on overpay**
+If `amount` exceeds the total outstanding debt (principal + accrued interest after settlement),
+`repay` returns `LendingError::RepayAmountTooHigh` (error code 1012). The position is not
+modified and no funds are consumed.
 
-```
-refund = max(0, amount - (principal + accrued_interest))
+Integrators **must** query the exact current debt before submitting a repay:
+
+```rust
+let debt = client.get_debt_position(&user);
+// derive effective balance including accrued interest
+let effective = debt::effective_debt(&debt, now, rate_bps)?;
+client.repay(&user, effective);
 ```
 
-**Integrator requirement**: For transactions that handle user funds, query the exact current debt
-with `get_debt_position()` before submitting a repay. This allows precise overpayment refund handling.
+Attempting to pass any amount larger than the effective balance will be rejected.
 
 ### Interest ordering
 Interest is settled **before** principal on every repay:
@@ -55,13 +59,12 @@ if is_paused(PauseType::Repay) || (!is_recovery && blocks_high_risk_ops)
 
 ### Summary of error codes
 
-| Condition                              | Error                        |
-|----------------------------------------|------------------------------|
-| `amount ≤ 0`                           | `BorrowError::InvalidAmount` |
-| No outstanding debt                    | `BorrowError::InvalidAmount` |
-| `asset` does not match position asset  | `BorrowError::AssetNotSupported` |
-| `amount > interest + principal`        | `BorrowError::RepayAmountTooHigh` |
-| Protocol paused for repay              | `BorrowError::ProtocolPaused` |
+| Condition                              | Error                             |
+|----------------------------------------|-----------------------------------|
+| `amount ≤ 0`                           | `LendingError::InvalidAmount`     |
+| No outstanding debt                    | `LendingError::InvalidAmount`     |
+| `amount > interest + principal`        | `LendingError::RepayAmountTooHigh` (1012) |
+| Protocol paused for repay              | (contract panics / pause guard)   |
 
 ---
 
@@ -102,22 +105,23 @@ Each asset key is independent in the `debt_balances` map.
 
 ## 3. Comparison table
 
-| Dimension               | `borrow::repay`           | `cross_asset::repay_asset`    |
-|-------------------------|---------------------------|-------------------------------|
-| Overpay handling        | Error (`RepayAmountTooHigh`) | Silent clamp to balance     |
-| Interest accrual        | Yes (ceiling-rounded)     | No                            |
-| Repay ordering          | Interest first, then principal | N/A                      |
-| Dust risk               | None (ceiling rounding)   | None (clamp floors at 0)      |
-| Recovery-mode repay     | Allowed                   | Allowed                       |
-| Asset isolation         | Single asset per position | Per-asset in a shared map     |
+| Dimension               | `borrow::repay`                      | `cross_asset::repay_asset`    |
+|-------------------------|--------------------------------------|-------------------------------|
+| Overpay handling        | Error (`RepayAmountTooHigh`, 1012)   | Silent clamp to balance       |
+| Interest accrual        | Yes (ceiling-rounded)                | No                            |
+| Repay ordering          | Interest first, then principal       | N/A                           |
+| Dust risk               | None (ceiling rounding)              | None (clamp floors at 0)      |
+| Recovery-mode repay     | Allowed                              | Allowed                       |
+| Asset isolation         | Single asset per position            | Per-asset in a shared map     |
 
 ---
 
 ## 4. Security notes for integrators
 
 **Do not overpay the borrow system.** Unlike many DeFi protocols that silently refund excess,
-`borrow::repay` returns `RepayAmountTooHigh`. Always query `get_debt_position()` for the raw debt
-state and derive the effective balance with `debt::effective_debt` before submitting a repay.
+`borrow::repay` returns `LendingError::RepayAmountTooHigh` (1012). Always query `get_debt_position()`
+for the raw debt state and derive the effective balance with `debt::effective_debt` before
+submitting a repay.
 
 **Dust debt cannot block withdrawals.** Because interest uses ceiling division, the effective
 balance derived from `get_debt_position()` (via `debt::effective_debt`) at any timestamp is


### PR DESCRIPTION
The single-asset repay path previously silently clamped overpayments to zero (identical to the cross-asset path), contradicting both release_checklist.md and REPAY_SEMANTICS.md which stated it should return an error.

Changes:
- Add DebtError::RepayAmountTooHigh variant to debt.rs
- Update repay_amount() and repay_amount_indexed() to return RepayAmountTooHigh when amount > settled principal (no silent clamp)
- Add LendingError::RepayAmountTooHigh = 1012 to LendingError enum
- Map DebtError::RepayAmountTooHigh in both repay() and repay_against_collateral() entrypoints
- Fix cross_asset::repay_asset_internal to explicitly clamp before calling repay_amount, preserving its documented silent-clamp behaviour
- Update error_codes_test.rs to cover new error code 1012
- Rewrite repay_overpay_test.rs: fix duplicate struct fields and update all tests to expect RepayAmountTooHigh on overpay
- Update repay_debt_floor_test.rs to expect RepayAmountTooHigh
- Update zero_amount_semantics_test.rs overpay/no-debt tests
- Update release_checklist.md to reference error code 1012
- Update REPAY_SEMANTICS.md: correct overpay section, error table, comparison table, and security notes to reflect actual behaviour

Closes #1748

## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
