### PR TITLE
fix: resolve issues #1700, #1704, #1711, #1717

### DIFF
--- a/stellar-lend/contracts/hello-world/src/cross_asset.rs
+++ b/stellar-lend/contracts/hello-world/src/cross_asset.rs
@@ -100,7 +100,14 @@ pub fn get_max_debt_assets_per_user(env: &Env) -> Option<u32> {
 }
 
 /// Require that `caller` is the stored admin; returns `Unauthorized` otherwise.
+///
+/// Calls `caller.require_auth()` so that Soroban enforces a cryptographic
+/// signature check, consistent with `admin::require_admin` and
+/// `bridge::require_guardian`.  A pure address-equality check without
+/// `require_auth` would allow any account to spoof the admin address as a
+/// plain argument with no proof of key ownership.
 fn require_admin(env: &Env, caller: &Address) -> Result<(), CrossAssetError> {
+    caller.require_auth();
     let admin = get_admin(env).ok_or(CrossAssetError::Unauthorized)?;
     if &admin != caller {
         return Err(CrossAssetError::Unauthorized);

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -47,6 +47,8 @@ mod twap_eviction_test;
 mod twap_fallback_event_test;
 #[cfg(test)]
 mod twap_tests;
+#[cfg(test)]
+mod twap_view_test;
 
 #[cfg(test)]
 mod bridge_fee_test;

--- a/stellar-lend/contracts/lending/src/events.rs
+++ b/stellar-lend/contracts/lending/src/events.rs
@@ -189,3 +189,55 @@ pub fn emit_liquidate(
     env.events()
         .publish((Symbol::new(env, "LiquidateEvent"),), event);
 }
+
+/// Emitted when the admin updates the protocol-level debt ceiling.
+///
+/// Indexers and risk dashboards should subscribe to `"DebtCeilingUpdatedEvent"`
+/// to react to ceiling changes in real time.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebtCeilingUpdatedEvent {
+    /// Schema version for safe decoding across upgrades.
+    pub schema_version: u32,
+    /// New debt ceiling value (strictly positive).
+    pub new_ceiling: i128,
+    /// Timestamp of the update (ledger timestamp).
+    pub timestamp: u64,
+}
+
+/// Emitted when the admin updates the flash loan fee in basis points.
+///
+/// Indexers and integrators should subscribe to `"FlashFeeUpdatedEvent"`
+/// to react to fee changes before issuing flash loans.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FlashFeeUpdatedEvent {
+    /// Schema version for safe decoding across upgrades.
+    pub schema_version: u32,
+    /// New flash loan fee in basis points (0–1000).
+    pub new_fee_bps: i128,
+    /// Timestamp of the update (ledger timestamp).
+    pub timestamp: u64,
+}
+
+/// Emit a debt-ceiling updated event.
+pub fn emit_debt_ceiling_updated(env: &Env, new_ceiling: i128) {
+    let event = DebtCeilingUpdatedEvent {
+        schema_version: EVENT_SCHEMA_VERSION,
+        new_ceiling,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events()
+        .publish((Symbol::new(env, "DebtCeilingUpdatedEvent"),), event);
+}
+
+/// Emit a flash-fee updated event.
+pub fn emit_flash_fee_updated(env: &Env, new_fee_bps: i128) {
+    let event = FlashFeeUpdatedEvent {
+        schema_version: EVENT_SCHEMA_VERSION,
+        new_fee_bps,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events()
+        .publish((Symbol::new(env, "FlashFeeUpdatedEvent"),), event);
+}

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -1865,6 +1865,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::DebtCeiling, &ceiling);
+        crate::events::emit_debt_ceiling_updated(&env, ceiling);
         Ok(())
     }
 
@@ -1878,6 +1879,7 @@ impl LendingContract {
         env.storage()
             .instance()
             .set(&DataKey::FlashFeeBps, &fee_bps);
+        crate::events::emit_flash_fee_updated(&env, fee_bps);
         Ok(())
     }
 

--- a/stellar-lend/contracts/vesting/VESTING_REVOKE_SECURITY.md
+++ b/stellar-lend/contracts/vesting/VESTING_REVOKE_SECURITY.md
@@ -12,7 +12,7 @@
 1. Rejects `caller != admin` with `Unauthorized`.
 2. Checks the pause gate (`check_not_paused`) **after** the auth check, so an
    unauthorized caller never learns the pause state.
-3. `sync_grants(grantee, now)` so `released` reflects the vested amount at `now`.
+3. `merge_grants(grantee, now)` so `released` reflects the vested amount at `now`.
 4. For each non-revoked grant: `unvested = grant.locked()`, accumulates
    `transfer`, decrements `total_locked`, sets `grant.total = grant.released`,
    marks `grant.revoked = true`.


### PR DESCRIPTION
## Summary

Four independent bug fixes across the hello-world, lending, and vesting crates.

### #1700 — hello-world cross_asset.rs: add caller.require_auth()

The private require_admin helper compared addresses but never called
caller.require_auth(), meaning any account could bypass admin gating by
passing the real admin address as a plain argument with no cryptographic
proof of key ownership. Added require_auth() before the address check,
consistent with admin::require_admin and bridge::require_guardian.

### #1704 — vesting/VESTING_REVOKE_SECURITY.md: fix phantom sync_grants reference

Step 3 referenced sync_grants(grantee, now), which does not exist anywhere
in the crate. Replaced with merge_grants(grantee, now), the real (currently
broken) function that the step describes.

### #1711 — hello-world lib.rs: wire twap_view_test into the module tree

twap_view_test.rs was never declared in lib.rs, so Rust silently skipped it
and cargo test never ran its assertions. Added #[cfg(test)] mod twap_view_test;
alongside the other TWAP test modules.

### #1717 — lending: emit events from set_debt_ceiling and set_flash_fee

Both setters silently mutated critical risk parameters with no on-chain event.
Added DebtCeilingUpdatedEvent and FlashFeeUpdatedEvent to events.rs (following
the existing schema_version + timestamp convention) and emit them at the end of
each successful setter.

## Files changed

- hello-world/src/cross_asset.rs — caller.require_auth() in require_admin
- hello-world/src/lib.rs — #[cfg(test)] mod twap_view_test
- lending/src/events.rs — DebtCeilingUpdatedEvent, FlashFeeUpdatedEvent, emitters
- lending/src/lib.rs — emit calls in set_debt_ceiling and set_flash_fee
- vesting/VESTING_REVOKE_SECURITY.md — sync_grants → merge_grants

Closes #1700
Closes #1704 
Closes  #1711 
Closes #1717
