### PR TITLE
fix: remove duplicate GuardianConfig definition from types.rs

### DIFF
--- a/stellar-lend/contracts/hello-world/src/types.rs
+++ b/stellar-lend/contracts/hello-world/src/types.rs
@@ -156,17 +156,3 @@ pub struct RecoveryRequest {
     /// Current number of approvals collected.
     pub approval_count: u32,
 }
-
-// ---------------------------------------------------------------------------
-// Guardian configuration
-// ---------------------------------------------------------------------------
-
-/// Guardian configuration for social-recovery authorisation.
-#[contracttype]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct GuardianConfig {
-    /// Set of addresses authorised as recovery guardians.
-    pub guardians: Vec<Address>,
-    /// Number of guardian approvals required to execute a recovery.
-    pub threshold: u32,
-}


### PR DESCRIPTION
Closes #1473 


Removes the duplicate and unused `GuardianConfig` struct definition from `stellar-lend/contracts/hello-world/src/types.rs`. 

The `GuardianConfig` struct was defined identically in both `storage.rs` and `types.rs`. The version in `storage.rs` is the one actively used by the governance module. Maintaining two copies of the same type poses a risk of divergence if a maintainer updates one but not the other, potentially leading to incompatible storage keys in Soroban.

## Changes Made
- Removed the `GuardianConfig` definition from `types.rs` to ensure the crate has only a single source of truth for this type (`crate::storage::GuardianConfig`).