### PR TITLE
fix(scripts): point deploy.sh LENDING_WASM at stellarlend_lending.wasm (#1730)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -157,7 +157,7 @@ fi
 # ---------------------------------------------------------------------------
 # Locate WASM files
 # ---------------------------------------------------------------------------
-LENDING_WASM="$WASM_DIR/hello_world.optimized.wasm"
+LENDING_WASM="$WASM_DIR/stellarlend_lending.optimized.wasm"
 AMM_WASM="$WASM_DIR/stellarlend_amm.optimized.wasm"
 
 if [[ ! -f "$LENDING_WASM" ]]; then


### PR DESCRIPTION
## Summary
Fixes #1730

## Problem
`scripts/deploy.sh` sets `LENDING_WASM="$WASM_DIR/hello_world.optimized.wasm"`, but the lending crate's build artifact is actually named `stellarlend_lending.wasm` (per `contracts/lending/Cargo.toml` `[lib] name = "stellarlend_lending"`). Using `hello_world.wasm` would either fail to find the file or deploy the wrong contract.

## Fix
Changed `LENDING_WASM` from `hello_world.optimized.wasm` to `stellarlend_lending.optimized.wasm` to match the actual build output of the lending contract crate.