### PR TITLE
fix(ci): remove set -e from local-ci.sh so full suite runs (#1727)

### DIFF
--- a/local-ci.sh
+++ b/local-ci.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # local-ci.sh - Reproduce CI checks locally
 
-set -e
-
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -25,6 +23,9 @@ fi
 
 cd "$PROJECT_DIR"
 
+# Track overall status to report at end
+OVERALL_PASSED=true
+
 # Function to run a command and report status
 run_check() {
     local name=$1
@@ -35,6 +36,7 @@ run_check() {
         echo -e "${GREEN}✅ $name passed${NC}"
     else
         echo -e "${RED}❌ $name failed${NC}"
+        OVERALL_PASSED=false
         return 1
     fi
 }
@@ -91,7 +93,7 @@ if [ -d "target/wasm32-unknown-unknown/release" ]; then
     for wasm in target/wasm32-unknown-unknown/release/*.wasm; do
         if [ -f "$wasm" ]; then
             run_check "Contract Optimization" "stellar contract optimize --wasm $wasm"
-            
+
             # Inspect optimized contract
             optimized_wasm="${wasm%.wasm}-optimized.wasm"
             if [ -f "$optimized_wasm" ]; then
@@ -131,6 +133,11 @@ echo -e "\n${GREEN}🎉 All CI checks completed!${NC}"
 echo "=============================="
 echo -e "${GREEN}If all checks passed, your code should pass CI pipeline.${NC}"
 echo -e "${YELLOW}Note: Some checks might behave slightly differently in CI environment.${NC}"
+
+if [ "$OVERALL_PASSED" = false ]; then
+    echo -e "\n${RED}❌ Some checks failed. See output above for details.${NC}"
+    exit 1
+fi
 
 # Summary of what to fix if any checks failed
 echo -e "\n${BLUE}💡 Quick fixes for common issues:${NC}"


### PR DESCRIPTION
## Summary
Fixes #1727

## Problem
`local-ci.sh` has `set -e` at line 4, which causes the script to abort at the first failing check instead of running the full suite it advertises. The `run_check` helper already handles failures gracefully (prints a red "❌ failed" line and returns 1), but `set -e` overrides this and terminates the entire script on the first non-zero return, preventing Clippy, contract build, unit tests, and the security audit from running.

## Fix
- Removed `set -e` so `run_check`'s own return-code handling controls flow
- Added `OVERALL_PASSED` variable to track whether any check failed
- Script now runs ALL checks and reports overall pass/fail at the end
- Exits with code 1 if any check failed (maintaining CI-compatible behavior)