### PR TITLE
fix(docs): correct glossary Close Factor range to match set_close_factor_bps (#1751)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,7 +20,7 @@ This glossary defines key protocol terms, numeric scales, and common pitfalls fo
 ### Close Factor
 - **Definition**: The maximum proportion of a distressed borrower's debt that a liquidator can repay in a single transaction.
 - **Scale**: Basis points (`5,000` = `50%`).
-- **Safety Limit**: Usually capped at `7,500` (75%) to prevent total wipeout in a single block.
+- **Safety Limit**: Accepts any value in `(0, 10000]` via `set_close_factor_bps`, allowing an admin to configure up to 100% (complete debt repayment in a single liquidation call).
 
 ### Reserve Factor
 - **Definition**: The percentage of interest paid by borrowers that is redirected to the protocol treasury rather than distributed to lenders.


### PR DESCRIPTION
## Summary
Fixes #1751

## Problem
`docs/glossary.md` "Close Factor" entry states the limit is "Usually capped at `7,500` (75%) to prevent total wipeout in a single block." But `set_close_factor_bps` in `contracts/lending/src/lib.rs` only rejects `close_factor_bps <= 0 || close_factor_bps > BPS_DENOM` — it accepts any value in `(0, 10000]`, with no 7,500 cap anywhere. An admin can configure a 100% close factor, allowing a single `liquidate` call to repay a borrower's entire debt.

## Fix
Updated the "Safety Limit" bullet to accurately describe the actual validation range `(0, 10000]` accepted by `set_close_factor_bps`, noting that admins can configure up to 100% if desired.