### PR TITLE
fix: add admin authorization gate to set_protocol_totals()

### DIFF
--- a/stellar-lend/contracts/hello-world/src/dual_kink_test.rs
+++ b/stellar-lend/contracts/hello-world/src/dual_kink_test.rs
@@ -19,17 +19,17 @@ where
     env.as_contract(&contract_id, || f(Address::generate(&env)))
 }
 
-fn init(env: &Env, total_deposits: i128, total_borrows: i128) {
+fn init(env: &Env, admin: Address, total_deposits: i128, total_borrows: i128) {
     initialize_interest_rate_config(env).unwrap();
-    set_protocol_totals(env, total_deposits, total_borrows).unwrap();
+    set_protocol_totals(env, admin, total_deposits, total_borrows).unwrap();
 }
 
 #[test]
 fn zero_utilization_uses_base_rate() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |_| {
-        init(&env, 1_000, 0);
+    with_contract(&env, |admin| {
+        init(&env, admin, 1_000, 0);
         let config = InterestRateConfig::default();
         assert_eq!(
             compute_borrow_rate(0, 0, &config).unwrap(),
@@ -42,8 +42,8 @@ fn zero_utilization_uses_base_rate() {
 fn at_first_kink_uses_first_segment_endpoint() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |_| {
-        init(&env, 1_000, 800); // utilization = 8_000 bps (kink1)
+    with_contract(&env, |admin| {
+        init(&env, admin, 1_000, 800); // utilization = 8_000 bps (kink1)
         let config = InterestRateConfig::default();
         let expected = config
             .base_rate_bps
@@ -67,8 +67,8 @@ fn at_first_kink_uses_first_segment_endpoint() {
 fn mid_between_kinks_uses_second_segment() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |_| {
-        init(&env, 1_000, 850); // utilization = 8_500 bps
+    with_contract(&env, |admin| {
+        init(&env, admin, 1_000, 850); // utilization = 8_500 bps
         let config = InterestRateConfig::default();
         let utilization = 8_500;
         let denominator = config.kink2_bps - config.kink_utilization_bps;
@@ -97,8 +97,8 @@ fn mid_between_kinks_uses_second_segment() {
 fn at_second_kink_uses_second_segment_endpoint() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |_| {
-        init(&env, 1_000, 900); // utilization = 9_000 bps (kink2)
+    with_contract(&env, |admin| {
+        init(&env, admin, 1_000, 900); // utilization = 9_000 bps (kink2)
         let config = InterestRateConfig::default();
         let denominator = config.kink2_bps - config.kink_utilization_bps;
         let expected = config
@@ -127,8 +127,8 @@ fn at_second_kink_uses_second_segment_endpoint() {
 fn high_utilization_uses_third_segment() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |_| {
-        init(&env, 1_000, 980); // utilization = 9_800 bps
+    with_contract(&env, |admin| {
+        init(&env, admin, 1_000, 980); // utilization = 9_800 bps
         let config = InterestRateConfig::default();
         let utilization = 9_800;
         let denominator = 10_000 - config.kink2_bps;
@@ -159,8 +159,8 @@ fn high_utilization_uses_third_segment() {
 fn monotonic_rate_non_decreasing() {
     let env = Env::default();
     env.mock_all_auths();
-    with_contract(&env, |_| {
-        init(&env, 1_000, 0);
+    with_contract(&env, |admin| {
+        init(&env, admin, 1_000, 0);
         let config = InterestRateConfig::default();
         let mut prev = compute_borrow_rate(0, 0, &config).unwrap();
         for u in (0..=10_000).step_by(250) {

--- a/stellar-lend/contracts/hello-world/src/interest_rate.rs
+++ b/stellar-lend/contracts/hello-world/src/interest_rate.rs
@@ -189,9 +189,11 @@ pub fn update_interest_rate_config(
 /// accounting in a module separate from the rate model.
 pub fn set_protocol_totals(
     env: &Env,
+    admin: Address,
     total_deposits: i128,
     total_borrows: i128,
 ) -> Result<(), InterestRateError> {
+    require_rate_admin(env, &admin)?;
     if total_deposits < 0 || total_borrows < 0 {
         return Err(InterestRateError::InvalidParameter);
     }

--- a/stellar-lend/contracts/hello-world/src/rate_clamp_test.rs
+++ b/stellar-lend/contracts/hello-world/src/rate_clamp_test.rs
@@ -16,9 +16,9 @@ where
     env.as_contract(&contract_id, || f(Address::generate(&env)))
 }
 
-fn init(env: &Env, total_deposits: i128, total_borrows: i128) {
+fn init(env: &Env, admin: Address, total_deposits: i128, total_borrows: i128) {
     initialize_interest_rate_config(env).unwrap();
-    set_protocol_totals(env, total_deposits, total_borrows).unwrap();
+    set_protocol_totals(env, admin, total_deposits, total_borrows).unwrap();
 }
 
 #[test]
@@ -27,7 +27,7 @@ fn utilization_zero_defaults_to_current_curve_behavior() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, 1_000, 0);
+        init(&env, admin.clone(), 1_000, 0);
 
         assert_eq!(calculate_utilization(&env).unwrap(), 0);
         // Defaults preserve old behavior: floor is 0, so the base rate is not raised.
@@ -41,7 +41,7 @@ fn utilization_at_100_percent_uses_curve_when_ceiling_is_open_by_default() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, 1_000, 1_000);
+        init(&env, admin.clone(), 1_000, 1_000);
 
         assert_eq!(calculate_utilization(&env).unwrap(), 10_000);
         // base + multiplier + post-kink jump = 100 + 2_000 + 10_000 = 12_100
@@ -55,10 +55,10 @@ fn borrow_rate_is_clamped_to_configured_floor_as_final_step() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, 1_000, 0);
+        init(&env, admin.clone(), 1_000, 0);
         update_interest_rate_config(
             &env,
-            admin,
+            admin.clone(),
             Some(0),
             None,
             Some(0),
@@ -80,7 +80,7 @@ fn borrow_rate_is_clamped_to_configured_ceiling_as_final_step() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, 1_000, 1_000);
+        init(&env, admin.clone(), 1_000, 1_000);
         update_interest_rate_config(
             &env,
             admin,
@@ -105,10 +105,10 @@ fn supply_rate_uses_the_clamped_borrow_rate() {
     env.mock_all_auths();
 
     with_rate_contract(&env, |admin| {
-        init(&env, 1_000, 1_000);
+        init(&env, admin.clone(), 1_000, 1_000);
         update_interest_rate_config(
             &env,
-            admin,
+            admin.clone(),
             None,
             None,
             None,

--- a/stellar-lend/contracts/hello-world/src/utilization_clamp_test.rs
+++ b/stellar-lend/contracts/hello-world/src/utilization_clamp_test.rs
@@ -14,9 +14,9 @@ where
     env.as_contract(&contract_id, || f(Address::generate(&env)))
 }
 
-fn init(env: &Env, total_deposits: i128, total_borrows: i128) {
+fn init(env: &Env, admin: Address, total_deposits: i128, total_borrows: i128) {
     initialize_interest_rate_config(env).unwrap();
-    set_protocol_totals(env, total_deposits, total_borrows).unwrap();
+    set_protocol_totals(env, admin, total_deposits, total_borrows).unwrap();
 }
 
 fn assert_within_bounds(utilization: i128) {
@@ -32,8 +32,8 @@ fn calculate_utilization_returns_zero_without_divide_by_zero_when_deposits_are_z
     let env = Env::default();
     env.mock_all_auths();
 
-    with_rate_contract(&env, |_| {
-        init(&env, 0, 1_000);
+    with_rate_contract(&env, |admin| {
+        init(&env, admin, 0, 1_000);
 
         let utilization = calculate_utilization(&env).unwrap();
         assert_eq!(utilization, 0);
@@ -46,14 +46,14 @@ fn calculate_utilization_clamps_to_full_utilization_when_borrows_cover_deposits(
     let env = Env::default();
     env.mock_all_auths();
 
-    with_rate_contract(&env, |_| {
-        init(&env, 1_000, 1_000);
+    with_rate_contract(&env, |admin| {
+        init(&env, admin.clone(), 1_000, 1_000);
 
         let equal_case = calculate_utilization(&env).unwrap();
         assert_eq!(equal_case, BASIS_POINTS_SCALE);
         assert_within_bounds(equal_case);
 
-        set_protocol_totals(&env, 1_000, 1_500).unwrap();
+        set_protocol_totals(&env, admin.clone(), 1_000, 1_500).unwrap();
 
         let over_borrow_case = calculate_utilization(&env).unwrap();
         assert_eq!(over_borrow_case, BASIS_POINTS_SCALE);
@@ -66,8 +66,8 @@ fn calculate_utilization_matches_exact_bps_for_common_ratios() {
     let env = Env::default();
     env.mock_all_auths();
 
-    with_rate_contract(&env, |_| {
-        init(&env, 1_000, 0);
+    with_rate_contract(&env, |admin| {
+        init(&env, admin.clone(), 1_000, 0);
 
         let cases = [
             (1_000, 250, 2_500),
@@ -76,7 +76,7 @@ fn calculate_utilization_matches_exact_bps_for_common_ratios() {
         ];
 
         for (deposits, borrows, expected) in cases {
-            set_protocol_totals(&env, deposits, borrows).unwrap();
+            set_protocol_totals(&env, admin.clone(), deposits, borrows).unwrap();
 
             let utilization = calculate_utilization(&env).unwrap();
             assert_eq!(utilization, expected);


### PR DESCRIPTION
# fix: add admin authorization gate to `set_protocol_totals()`

Closes #1693

## Summary

`set_protocol_totals()` in `stellar-lend/contracts/hello-world/src/interest_rate.rs` wrote the `TotalDeposits` and `TotalBorrows` storage keys — the two values that `calculate_utilization()` (and therefore every borrow rate and supply rate calculation) is derived from — with **no authorization check whatsoever**. Any address could call it to set arbitrary protocol-wide totals, directly manipulating the utilization curve and every derived interest rate for the entire protocol.

This PR adds an `admin: Address` parameter and gates the function with a `require_rate_admin(env, &admin)?` call, matching the exact authorization pattern used by `set_emergency_rate_adjustment()` and `update_interest_rate_config()` in the same file.

## Vulnerability details (pre-fix)

| Component | Status | Impact |
|-----------|--------|--------|
| `set_protocol_totals()` | **No auth check** | Any caller could set arbitrary `TotalDeposits` / `TotalBorrows` |
| `set_emergency_rate_adjustment()` | ✅ Gated by `require_rate_admin` | Reference pattern — correct |
| `update_interest_rate_config()` | ✅ Gated by `require_rate_admin` | Reference pattern — correct |

### Attack vector

1. Attacker calls `set_protocol_totals(env, 1, 1_000_000)` — 1 unit deposited, 1M units borrowed.
2. `calculate_utilization()` returns clamped 10,000 bps (100% utilization).
3. `calculate_borrow_rate()` spikes to the jump-rate ceiling (12,100 bps in default config).
4. `calculate_supply_rate()` follows suit.
5. **Result**: all downstream protocol math — interest accrual, health factors, liquidation thresholds — is derived from attacker-controlled inputs. The attacker can manipulate rates at will without holding any privileged role.

## Changes

### Production code

**`stellar-lend/contracts/hello-world/src/interest_rate.rs`** (+2 lines)

```diff
 pub fn set_protocol_totals(
     env: &Env,
+    admin: Address,
     total_deposits: i128,
     total_borrows: i128,
 ) -> Result<(), InterestRateError> {
+    require_rate_admin(env, &admin)?;
     if total_deposits < 0 || total_borrows < 0 {
```

The authorization check is placed **before** the parameter validation, consistent with `set_emergency_rate_adjustment()` (which validates `adjustment_bps` after `require_rate_admin`). This follows the principle of failing fast on unauthorized access before spending cycles on input validation.

### Test updates (3 files, 33 lines changed)

All three test files that call `set_protocol_totals()` were updated to pass an `admin: Address`:

- **`rate_clamp_test.rs`** — Updated `init()` helper signature; all 6 test closures pass `admin` / `admin.clone()`.
- **`utilization_clamp_test.rs`** — Updated `init()` helper; changed closures from `|_|` to `|admin|`; 4 call sites updated (1 in `init`, 3 direct calls).
- **`dual_kink_test.rs`** — Updated `init()` helper; changed closures from `|_|` to `|admin|`; 6 test functions updated.

All tests use `env.mock_all_auths()`, so the admin auth gate passes transparently.

### Files changed

```
.../hello-world/src/interest_rate.rs           |  2 ++
.../hello-world/src/dual_kink_test.rs           | 14 +++----
.../hello-world/src/rate_clamp_test.rs          |  9 +++---
.../hello-world/src/utilization_clamp_test.rs   | 10 +++---
4 files changed, 35 insertions(+), 33 deletions(-)
```

## Authorization flow (post-fix)

```
set_protocol_totals(env, admin, deposits, borrows)
  │
  ├─ require_rate_admin(env, &admin)
  │   └─ admin::require_admin(env, caller)
  │       ├─ reads AdminDataKey::Admin from persistent storage
  │       ├─ compares caller == stored_admin
  │       ├─ returns Ok(()) if match
  │       └─ returns Err(Unauthorized) if mismatch or NotInitialized if no admin set
  │
  ├─ validate: deposits ≥ 0, borrows ≥ 0
  │
  └─ write TotalDeposits & TotalBorrows to persistent storage
```

This is the same gate used by:
- `update_interest_rate_config()` — line 152
- `set_emergency_rate_adjustment()` — line 216

The `require_rate_admin` helper delegates to `admin::require_admin`, which reads from the **shared protocol admin** key (`AdminDataKey::Admin`). This means the interest-rate admin is the same address as the protocol admin — there is no separate, independently-managed interest-rate admin key (this was fixed separately in #1479).

## Security & correctness

- ✅ `set_protocol_totals` now requires valid admin authorization before any storage write
- ✅ Authorization check uses the **same shared admin key** as every other protected mutator
- ✅ Fails with `InterestRateError::Unauthorized` when caller is not the protocol admin
- ✅ Fails with `InterestRateError::NotInitialized` when no admin has been set
- ✅ Parameter validation (non-negative totals) preserved after auth check
- ✅ All existing tests pass (admin is mocked via `mock_all_auths()`)
- ✅ No new dependencies or storage schema changes
- ✅ Backward compatible at the storage layer (same keys, same values)

## How to test

```bash
# Build the hello-world contract
cargo build -p hello-world

# Run clippy with warnings-as-errors
cargo clippy -p hello-world -- -D warnings

# Run all hello-world tests (includes rate_clamp, utilization_clamp, dual_kink)
cargo test -p hello-world

# Run specific test modules
cargo test -p hello-world rate_clamp
cargo test -p hello-world utilization_clamp
cargo test -p hello-world dual_kink

# Run the admin-transfer regression test
cargo test -p hello-world interest_rate_admin_follows_protocol_admin_transfer
```

## Related issues

- #1479 — Interest-rate admin must follow the shared protocol admin (same `require_rate_admin` gate)
- The `interest_rate_admin_follows_protocol_admin_transfer` test in `rate_clamp_test.rs` verifies that the admin transfer flows correctly through the shared `require_rate_admin` path

Signed-off-by: Victor Ogazie <104174578+Vicistar-V@users.noreply.github.com>