### PR TITLE
docs: fix ORACLE_CONFIGURATION_GUIDE provider weights (135%→100%)

### DIFF
--- a/docs/ORACLE_CONFIGURATION_GUIDE.md
+++ b/docs/ORACLE_CONFIGURATION_GUIDE.md
@@ -20,8 +20,8 @@ This document outlines the procedures for managing oracle configurations in the 
 
 3. **Price Providers**
    - CoinGecko (primary, 60% weight)
-   - Binance (secondary, 40% weight)
-   - CoinMarketCap (optional, 35% weight)
+   - Binance (secondary, 25% weight)
+   - CoinMarketCap (optional, 15% weight)
 
 ## Role-Based Access Control
 


### PR DESCRIPTION
## Summary

The three price-provider weights (60% + 40% + 35% = 135%) did not sum to 100%.

## Change
- CoinGecko (primary): **60%** (unchanged)
- Binance (secondary): 40% → **25%**
- CoinMarketCap (optional): 35% → **15%**

Closes: #1750