### PR TITLE
fix(hello-world/admin): implement real two-step propose/accept admin …

### DIFF
--- a/stellar-lend/contracts/hello-world/src/admin.rs
+++ b/stellar-lend/contracts/hello-world/src/admin.rs
@@ -1,18 +1,38 @@
 //! Admin module — two-step admin handover with safety guards.
 //!
-//! Provides functions to read, set, and transfer the protocol admin authority.
-//! The [`set_admin`] function validates that the new admin is a sane address
-//! before writing, preventing accidental lockout of admin-gated operations.
+//! Provides functions to read, propose, accept, and initialise the protocol
+//! admin authority.
+//!
+//! ## Two-step handover
+//!
+//! Admin transfer is intentionally two-phased to ensure the incoming admin
+//! consents before control is transferred:
+//!
+//! 1. The current admin calls [`propose_admin`], which records `new_admin` as
+//!    the pending admin. This does **not** change the active admin.
+//! 2. The proposed admin calls [`accept_admin`], which requires their
+//!    signature (`new_admin.require_auth()`), promotes them to active admin,
+//!    and clears the pending slot.
+//!
+//! This prevents accidental lockout: if the proposed address is wrong or
+//! unreachable, no handover occurs — the current admin retains control and
+//! can propose a different address.
+//!
+//! The validation guards (`CannotTransferToSelf`, `AlreadyAdmin`) on
+//! [`propose_admin`] further prevent fat-finger proposals.
 
 use soroban_sdk::{contracterror, contractevent, contracttype, Address, Env};
 
 // ---------------------------------------------------------------------------
-// Storage key
+// Storage keys
 // ---------------------------------------------------------------------------
 
 #[contracttype]
 pub enum AdminDataKey {
+    /// The active protocol admin.
     Admin,
+    /// A pending admin proposed by the current admin; cleared on acceptance.
+    PendingAdmin,
 }
 
 // ---------------------------------------------------------------------------
@@ -32,13 +52,27 @@ pub enum AdminError {
     Unauthorized = 3,
     /// Admin has not been initialized yet.
     NotInitialized = 4,
+    /// `accept_admin` was called but no admin has been proposed.
+    PendingAdminNotSet = 5,
 }
 
 // ---------------------------------------------------------------------------
-// Event
+// Events
 // ---------------------------------------------------------------------------
 
-/// Emitted when the protocol admin is transferred to a new address.
+/// Emitted when a new admin is proposed by the current admin.
+///
+/// Topics: `("admin", "proposed")`
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AdminProposedEvent {
+    /// Address of the current admin who submitted the proposal.
+    pub current_admin: Address,
+    /// Address of the proposed new admin.
+    pub proposed_admin: Address,
+}
+
+/// Emitted when the proposed admin accepts and becomes the active admin.
 ///
 /// Topics: `("admin", "transferred")`
 #[contractevent]
@@ -64,6 +98,11 @@ pub fn get_admin(env: &Env) -> Option<Address> {
     env.storage().instance().get(&AdminDataKey::Admin)
 }
 
+/// Return the pending admin address, or `None` if no proposal is active.
+pub fn get_pending_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&AdminDataKey::PendingAdmin)
+}
+
 /// Require `caller` to be the stored protocol admin.
 ///
 /// This is the shared authorization check for admin-gated modules. Keeping
@@ -80,90 +119,138 @@ pub fn require_admin(env: &Env, caller: &Address) -> Result<(), AdminError> {
 }
 
 // ---------------------------------------------------------------------------
-// Mutator
+// Initialisation
 // ---------------------------------------------------------------------------
 
-/// Set (or transfer) the protocol admin.
+/// Store the initial admin during contract initialisation (no auth required).
 ///
-/// # Arguments
-///
-/// * `env` — Soroban environment.
-/// * `new_admin` — The address to set as admin.
-/// * `caller` — When `Some(caller)`, authorises as the current admin and
-///   performs safety validation. When `None` (used during contract
-///   initialisation), skips auth and validation.
-///
-/// # Errors
-///
-/// * [`AdminError::CannotTransferToSelf`] — `new_admin` is the contract's own
-///   address. Transferring admin to the contract would permanently brick
-///   every admin-gated control because the contract itself cannot sign
-///   transactions.
-/// * [`AdminError::AlreadyAdmin`] — `new_admin` equals the current admin.
-///   Rejecting this prevents unnecessary events and storage writes from
-///   no-op churn.
-/// * [`AdminError::Unauthorized`] — `caller` is `Some` but is not the current
-///   admin.
-/// * [`AdminError::NotInitialized`] — No admin exists yet (contract has not
-///   been initialised with [`initialize`]).
-///
-/// # Events
-///
-/// Emits [`AdminTransferredEvent`] on success when `caller` is `Some`
-/// (i.e. during a handover, not during initialisation).
-///
-/// # Safety model
-///
-/// The two-step flow is preserved: the current admin proposes by calling
-/// `transfer_admin`, and the target address must sign to accept.  The
-/// validation checks added here (`CannotTransferToSelf`, `AlreadyAdmin`)
-/// prevent fat-finger lockout scenarios that have historically caused
-/// irrecoverable protocol halts.
+/// This is the only path that bypasses authentication. It must only be called
+/// once, during `initialize`, before any admin is stored.
 pub fn set_admin(env: &Env, new_admin: Address, caller: Option<Address>) -> Result<(), AdminError> {
-    // When caller is provided, validate authorisation and check for unsafe
-    // target addresses.
     if let Some(caller) = caller {
-        caller.require_auth();
-
-        let current_admin = env
-            .storage()
-            .instance()
-            .get::<AdminDataKey, Address>(&AdminDataKey::Admin)
-            .ok_or(AdminError::NotInitialized)?;
-
-        if caller != current_admin {
-            return Err(AdminError::Unauthorized);
-        }
-
-        // Guard: reject transfer to the contract's own address.
-        // The contract address can never sign a transaction, so handing
-        // admin to it would permanently lock all admin-gated functions.
-        if new_admin == env.current_contract_address() {
-            return Err(AdminError::CannotTransferToSelf);
-        }
-
-        // Guard: reject transfer to the same admin (no-op churn).
-        if new_admin == current_admin {
-            return Err(AdminError::AlreadyAdmin);
-        }
-
-        // Persist the new admin.
-        env.storage()
-            .instance()
-            .set(&AdminDataKey::Admin, &new_admin);
-
-        // Emit event after successful state mutation.
-        AdminTransferredEvent {
-            old_admin: current_admin,
-            new_admin,
-        }
-        .publish(env);
+        // Delegate to the two-step propose path for post-init transfers.
+        // Callers that previously used set_admin(env, new_admin, Some(caller))
+        // should migrate to propose_admin + accept_admin.
+        propose_admin(env, new_admin, caller)
     } else {
         // Initialisation path: no validation needed, just store.
         env.storage()
             .instance()
             .set(&AdminDataKey::Admin, &new_admin);
+        Ok(())
     }
+}
+
+// ---------------------------------------------------------------------------
+// Two-step handover
+// ---------------------------------------------------------------------------
+
+/// Propose a new admin (current admin only) — step 1 of 2.
+///
+/// Records `new_admin` as the pending admin candidate. The active admin is
+/// **not** changed until `new_admin` calls [`accept_admin`].
+///
+/// Calling this a second time with a different address replaces the earlier
+/// pending proposal (useful for correcting a mis-typed address).
+///
+/// # Arguments
+///
+/// * `env` — Soroban environment.
+/// * `new_admin` — The address being nominated as the next admin.
+/// * `caller` — Must be the current active admin.
+///
+/// # Errors
+///
+/// * [`AdminError::NotInitialized`] — No admin exists yet.
+/// * [`AdminError::Unauthorized`] — `caller` is not the current admin.
+/// * [`AdminError::CannotTransferToSelf`] — `new_admin` is the contract's own
+///   address; the contract can never sign, so this would permanently lock
+///   every admin-gated function.
+/// * [`AdminError::AlreadyAdmin`] — `new_admin` is already the active admin.
+///
+/// # Events
+///
+/// Emits [`AdminProposedEvent`] on success.
+pub fn propose_admin(env: &Env, new_admin: Address, caller: Address) -> Result<(), AdminError> {
+    caller.require_auth();
+
+    let current_admin = get_admin(env).ok_or(AdminError::NotInitialized)?;
+
+    if caller != current_admin {
+        return Err(AdminError::Unauthorized);
+    }
+
+    // Guard: reject proposal to the contract's own address.
+    if new_admin == env.current_contract_address() {
+        return Err(AdminError::CannotTransferToSelf);
+    }
+
+    // Guard: reject proposal to the same admin (no-op churn).
+    if new_admin == current_admin {
+        return Err(AdminError::AlreadyAdmin);
+    }
+
+    env.storage()
+        .instance()
+        .set(&AdminDataKey::PendingAdmin, &new_admin);
+
+    AdminProposedEvent {
+        current_admin: caller,
+        proposed_admin: new_admin,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Accept the pending admin proposal (proposed admin only) — step 2 of 2.
+///
+/// The caller must be the address that was nominated via [`propose_admin`].
+/// On success, the caller becomes the active admin and the pending slot is
+/// cleared.
+///
+/// # Arguments
+///
+/// * `env` — Soroban environment.
+/// * `caller` — Must match the stored pending admin address.
+///
+/// # Errors
+///
+/// * [`AdminError::NotInitialized`] — No admin exists yet.
+/// * [`AdminError::PendingAdminNotSet`] — No proposal is currently active.
+/// * [`AdminError::Unauthorized`] — `caller` does not match the pending admin.
+///
+/// # Events
+///
+/// Emits [`AdminTransferredEvent`] on success.
+pub fn accept_admin(env: &Env, caller: Address) -> Result<(), AdminError> {
+    caller.require_auth();
+
+    if !has_admin(env) {
+        return Err(AdminError::NotInitialized);
+    }
+
+    let pending_admin = get_pending_admin(env).ok_or(AdminError::PendingAdminNotSet)?;
+
+    if caller != pending_admin {
+        return Err(AdminError::Unauthorized);
+    }
+
+    let old_admin = get_admin(env).expect("admin must exist if pending admin is set");
+
+    // Promote pending admin to active admin and clear the pending slot.
+    env.storage()
+        .instance()
+        .set(&AdminDataKey::Admin, &pending_admin);
+    env.storage()
+        .instance()
+        .remove(&AdminDataKey::PendingAdmin);
+
+    AdminTransferredEvent {
+        old_admin,
+        new_admin: pending_admin,
+    }
+    .publish(env);
 
     Ok(())
 }
@@ -181,18 +268,31 @@ mod tests {
 
     #[contractimpl]
     impl TestHost {
-        /// Expose `set_admin` so we can test it through the contract client,
-        /// which gives us a real `env.current_contract_address()`.
-        pub fn set_admin(env: Env, new_admin: Address, caller: Address) -> Result<(), AdminError> {
-            crate::admin::set_admin(&env, new_admin, Some(caller))
-        }
-
+        /// Initialise the contract with the given admin (no auth required).
         pub fn initialize(env: Env, admin: Address) {
             crate::admin::set_admin(&env, admin, None).unwrap();
         }
 
+        /// Step 1: propose a new admin (current admin only).
+        pub fn propose_admin(
+            env: Env,
+            new_admin: Address,
+            caller: Address,
+        ) -> Result<(), AdminError> {
+            crate::admin::propose_admin(&env, new_admin, caller)
+        }
+
+        /// Step 2: accept the pending admin proposal (proposed admin only).
+        pub fn accept_admin(env: Env, caller: Address) -> Result<(), AdminError> {
+            crate::admin::accept_admin(&env, caller)
+        }
+
         pub fn get_admin(env: Env) -> Option<Address> {
             crate::admin::get_admin(&env)
+        }
+
+        pub fn get_pending_admin(env: Env) -> Option<Address> {
+            crate::admin::get_pending_admin(&env)
         }
 
         pub fn has_admin(env: Env) -> bool {
@@ -212,118 +312,105 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Happy path
+    // Happy path: full two-step flow
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_transfer_to_valid_new_admin_succeeds() {
+    fn test_full_two_step_flow_succeeds() {
         let (env, client, admin, new_admin) = setup();
-        let prev_admin = client.get_admin();
-        assert_eq!(prev_admin, Some(admin.clone()));
+        assert_eq!(client.get_admin(), Some(admin.clone()));
+        assert_eq!(client.get_pending_admin(), None);
 
-        // Transfer to a different address.
-        let result = client.try_set_admin(&new_admin, &admin);
-        assert!(result.is_ok(), "transfer to valid new admin should succeed");
+        // Step 1: current admin proposes.
+        let r = client.try_propose_admin(&new_admin, &admin);
+        assert!(r.is_ok(), "propose_admin should succeed");
+        assert_eq!(client.get_admin(), Some(admin.clone()), "active admin must not change after propose");
+        assert_eq!(client.get_pending_admin(), Some(new_admin.clone()), "pending admin should be set");
 
-        let current = client.get_admin();
-        assert_eq!(current, Some(new_admin));
+        // Step 2: proposed admin accepts.
+        let r = client.try_accept_admin(&new_admin);
+        assert!(r.is_ok(), "accept_admin should succeed");
+        assert_eq!(client.get_admin(), Some(new_admin.clone()), "active admin should be the new admin");
+        assert_eq!(client.get_pending_admin(), None, "pending admin should be cleared after acceptance");
     }
 
     #[test]
-    fn test_admin_transferred_event_emitted_on_transfer() {
+    fn test_admin_transferred_event_emitted_on_accept() {
         let (env, client, admin, new_admin) = setup();
 
+        client.propose_admin(&new_admin, &admin);
+
         let event_count_before = env.events().all().len();
-        let _ = client.try_set_admin(&new_admin, &admin);
+        let _ = client.try_accept_admin(&new_admin);
         let event_count_after = env.events().all().len();
 
         assert!(
             event_count_after > event_count_before,
-            "AdminTransferredEvent should have been emitted"
+            "AdminTransferredEvent should have been emitted on accept"
+        );
+    }
+
+    #[test]
+    fn test_admin_proposed_event_emitted_on_propose() {
+        let (env, client, admin, new_admin) = setup();
+
+        let event_count_before = env.events().all().len();
+        let _ = client.try_propose_admin(&new_admin, &admin);
+        let event_count_after = env.events().all().len();
+
+        assert!(
+            event_count_after > event_count_before,
+            "AdminProposedEvent should have been emitted on propose"
         );
     }
 
     // -----------------------------------------------------------------------
-    // Guard: transfer to the contract's own address
+    // Propose guards
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_transfer_to_self_contract_rejected() {
+    fn test_propose_to_self_contract_rejected() {
         let (env, client, admin, _new_admin) = setup();
         let contract_addr = env.current_contract_address();
 
-        let result = client.try_set_admin(&contract_addr, &admin);
+        let result = client.try_propose_admin(&contract_addr, &admin);
         assert!(
             matches!(result, Err(Ok(AdminError::CannotTransferToSelf))),
-            "transfer to self-contract should be rejected with CannotTransferToSelf, got {:?}",
+            "propose to self-contract should be rejected, got {:?}",
             result
         );
-
-        // Admin should remain unchanged.
-        assert_eq!(client.get_admin(), Some(admin));
+        assert_eq!(client.get_pending_admin(), None, "pending admin should remain unset");
     }
 
-    // -----------------------------------------------------------------------
-    // Guard: transfer to the same admin (no-op churn)
-    // -----------------------------------------------------------------------
-
     #[test]
-    fn test_transfer_to_current_admin_rejected() {
-        let (env, client, admin, _new_admin) = setup();
+    fn test_propose_to_current_admin_rejected() {
+        let (_env, client, admin, _new_admin) = setup();
 
-        let result = client.try_set_admin(&admin, &admin);
+        let result = client.try_propose_admin(&admin, &admin);
         assert!(
             matches!(result, Err(Ok(AdminError::AlreadyAdmin))),
-            "transfer to current admin should be rejected with AlreadyAdmin, got {:?}",
+            "propose to current admin should be rejected, got {:?}",
             result
         );
-
-        // Admin should remain unchanged.
-        assert_eq!(client.get_admin(), Some(admin));
+        assert_eq!(client.get_pending_admin(), None);
     }
 
-    // -----------------------------------------------------------------------
-    // Guard: unauthorised caller
-    // -----------------------------------------------------------------------
-
     #[test]
-    fn test_transfer_by_non_admin_rejected() {
-        let (env, _client, _admin, _new_admin) = setup();
+    fn test_propose_by_non_admin_rejected() {
+        let (env, client, _admin, new_admin) = setup();
         let attacker = Address::generate(&env);
 
-        // Disable mock auth so the attacker actually fails auth.
-        let env_no_mock = Env::default();
-        let contract_id = env_no_mock.register(TestHost, ());
-        let client_no_mock = TestHostClient::new(&env_no_mock, &contract_id);
-        let admin = Address::generate(&env_no_mock);
-        // Setup with auth on initialize
-        env_no_mock.mock_auths(&[soroban_sdk::testutils::MockAuth {
-            address: &admin,
-            invoke: &soroban_sdk::testutils::MockAuthInvoke {
-                contract: &contract_id,
-                fn_name: "initialize",
-                args: (admin.clone(),).into_val(&env_no_mock),
-                sub_invokes: &[],
-            },
-        }]);
-        client_no_mock.initialize(&admin);
-
-        // Attacker tries to transfer without auth — should panic on require_auth.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            client_no_mock.set_admin(&Address::generate(&env_no_mock), &attacker);
-        }));
+        let result = client.try_propose_admin(&new_admin, &attacker);
         assert!(
-            result.is_err(),
-            "non-admin caller should panic on require_auth"
+            matches!(result, Err(Ok(AdminError::Unauthorized))),
+            "non-admin caller should be rejected with Unauthorized, got {:?}",
+            result
         );
+        assert_eq!(client.get_pending_admin(), None);
     }
 
-    // -----------------------------------------------------------------------
-    // Guard: transferring before initialisation
-    // -----------------------------------------------------------------------
-
     #[test]
-    fn test_transfer_before_initialization_rejected() {
+    fn test_propose_before_initialization_rejected() {
         let env = Env::default();
         env.mock_all_auths();
         let contract_id = env.register(TestHost, ());
@@ -331,16 +418,120 @@ mod tests {
         let caller = Address::generate(&env);
         let new_admin = Address::generate(&env);
 
-        let result = client.try_set_admin(&new_admin, &caller);
+        let result = client.try_propose_admin(&new_admin, &caller);
         assert!(
             matches!(result, Err(Ok(AdminError::NotInitialized))),
-            "transfer before init should be rejected with NotInitialized, got {:?}",
+            "propose before init should be rejected, got {:?}",
             result
         );
     }
 
     // -----------------------------------------------------------------------
-    // has_admin / get_admin behaviour
+    // Accept guards
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_accept_without_pending_proposal_rejected() {
+        let (_env, client, _admin, new_admin) = setup();
+
+        // No propose has been called — accept should fail.
+        let result = client.try_accept_admin(&new_admin);
+        assert!(
+            matches!(result, Err(Ok(AdminError::PendingAdminNotSet))),
+            "accept with no pending proposal should be rejected, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_accept_by_wrong_address_rejected() {
+        let (env, client, admin, new_admin) = setup();
+        let attacker = Address::generate(&env);
+
+        client.propose_admin(&new_admin, &admin);
+
+        // Attacker tries to accept the pending proposal.
+        let result = client.try_accept_admin(&attacker);
+        assert!(
+            matches!(result, Err(Ok(AdminError::Unauthorized))),
+            "wrong address should be rejected on accept, got {:?}",
+            result
+        );
+        // Active admin must remain unchanged.
+        assert_eq!(client.get_admin(), Some(admin));
+        // Pending admin must still be set.
+        assert_eq!(client.get_pending_admin(), Some(new_admin));
+    }
+
+    #[test]
+    fn test_accept_before_initialization_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TestHost, ());
+        let client = TestHostClient::new(&env, &contract_id);
+        let caller = Address::generate(&env);
+
+        let result = client.try_accept_admin(&caller);
+        assert!(
+            matches!(result, Err(Ok(AdminError::NotInitialized))),
+            "accept before init should be rejected, got {:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Proposal can be overwritten before acceptance
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_propose_can_overwrite_previous_proposal() {
+        let (env, client, admin, first_candidate) = setup();
+        let second_candidate = Address::generate(&env);
+
+        client.propose_admin(&first_candidate, &admin);
+        assert_eq!(client.get_pending_admin(), Some(first_candidate.clone()));
+
+        // Overwrite with second candidate.
+        let r = client.try_propose_admin(&second_candidate, &admin);
+        assert!(r.is_ok(), "overwriting pending proposal should succeed");
+        assert_eq!(client.get_pending_admin(), Some(second_candidate.clone()));
+
+        // First candidate can no longer accept.
+        let result = client.try_accept_admin(&first_candidate);
+        assert!(
+            matches!(result, Err(Ok(AdminError::Unauthorized))),
+            "superseded candidate should not be able to accept, got {:?}",
+            result
+        );
+
+        // Second candidate succeeds.
+        let r2 = client.try_accept_admin(&second_candidate);
+        assert!(r2.is_ok(), "second candidate should accept successfully");
+        assert_eq!(client.get_admin(), Some(second_candidate));
+    }
+
+    // -----------------------------------------------------------------------
+    // Sequential transfers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_sequential_transfers_allowed() {
+        let (env, client, admin, new_admin) = setup();
+        let third_admin = Address::generate(&env);
+
+        // First handover: admin → new_admin
+        client.propose_admin(&new_admin, &admin);
+        client.accept_admin(&new_admin);
+        assert_eq!(client.get_admin(), Some(new_admin.clone()));
+
+        // Second handover: new_admin → third_admin
+        client.propose_admin(&third_admin, &new_admin);
+        client.accept_admin(&third_admin);
+        assert_eq!(client.get_admin(), Some(third_admin));
+    }
+
+    // -----------------------------------------------------------------------
+    // has_admin / get_admin helpers
     // -----------------------------------------------------------------------
 
     #[test]
@@ -372,26 +563,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Multiple transfers work correctly
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_sequential_transfers_allowed() {
-        let (env, client, admin, new_admin) = setup();
-        let third_admin = Address::generate(&env);
-
-        // First transfer: admin → new_admin
-        let r1 = client.try_set_admin(&new_admin, &admin);
-        assert!(r1.is_ok(), "first transfer should succeed");
-        assert_eq!(client.get_admin(), Some(new_admin.clone()));
-
-        // Second transfer: new_admin → third_admin
-        let r2 = client.try_set_admin(&third_admin, &new_admin);
-        assert!(r2.is_ok(), "second transfer should succeed");
-        assert_eq!(client.get_admin(), Some(third_admin));
-    }
-
-    // -----------------------------------------------------------------------
     // Error code stability
     // -----------------------------------------------------------------------
 
@@ -401,5 +572,6 @@ mod tests {
         assert_eq!(AdminError::AlreadyAdmin as u32, 2);
         assert_eq!(AdminError::Unauthorized as u32, 3);
         assert_eq!(AdminError::NotInitialized as u32, 4);
+        assert_eq!(AdminError::PendingAdminNotSet as u32, 5);
     }
 }

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -183,13 +183,29 @@ impl HelloContract {
         Ok(())
     }
 
-    /// Transfer super admin rights.
-    pub fn transfer_admin(
+    /// Propose a new admin — step 1 of the two-step admin handover.
+    ///
+    /// The current admin nominates `new_admin` as a pending candidate. The
+    /// active admin does **not** change until `new_admin` calls
+    /// [`accept_admin`].
+    pub fn propose_admin(
         env: Env,
         caller: Address,
         new_admin: Address,
     ) -> Result<(), crate::admin::AdminError> {
-        crate::admin::set_admin(&env, new_admin, Some(caller))
+        crate::admin::propose_admin(&env, new_admin, caller)
+    }
+
+    /// Accept the pending admin proposal — step 2 of the two-step admin handover.
+    ///
+    /// `caller` must be the address previously nominated via [`propose_admin`].
+    /// On success the caller becomes the active admin and the pending slot is
+    /// cleared.
+    pub fn accept_admin(
+        env: Env,
+        caller: Address,
+    ) -> Result<(), crate::admin::AdminError> {
+        crate::admin::accept_admin(&env, caller)
     }
 
     /// Increment the user's deposit balance.

--- a/stellar-lend/contracts/hello-world/src/rate_clamp_test.rs
+++ b/stellar-lend/contracts/hello-world/src/rate_clamp_test.rs
@@ -178,8 +178,9 @@ fn interest_rate_admin_follows_protocol_admin_transfer() {
         );
         assert!(r.is_ok(), "current admin should be able to update config");
 
-        // Transfer protocol admin: admin_a -> admin_b.
-        crate::admin::set_admin(&env, admin_b.clone(), Some(admin_a.clone())).unwrap();
+        // Transfer protocol admin: admin_a -> admin_b (two-step flow).
+        crate::admin::propose_admin(&env, admin_b.clone(), admin_a.clone()).unwrap();
+        crate::admin::accept_admin(&env, admin_b.clone()).unwrap();
 
         // The OLD admin (admin_a) must now be rejected for interest-rate
         // operations -- this is the exact bug #1479 describes: without this


### PR DESCRIPTION
…handover

The module doc claimed a two-step flow ('the target address must sign to accept') but the only mutator, set_admin(), performed a single-step transfer that only required the current admin's signature.  A reader relying on the stated safety property (new admin must consent) would have been wrong.

Changes
-------
* Added PendingAdmin storage key alongside the existing Admin key.
* Replaced the misleading doc text on set_admin with accurate description; set_admin(_, _, Some(caller)) now delegates to propose_admin so any internal callers that previously used that path still compile correctly.
* Added propose_admin(): current-admin-only step that records the pending candidate without changing the active admin.  Emits AdminProposedEvent.
* Added accept_admin(): proposed-admin-only step that requires the candidate's signature, promotes them, clears the pending slot, and emits AdminTransferredEvent.
* Added AdminProposedEvent and PendingAdminNotSet (error code 5).
* Updated module doc with accurate two-step description and rationale.
* Replaced transfer_admin() entrypoint in lib.rs with propose_admin() + accept_admin() that route through the new functions.
* Updated rate_clamp_test.rs regression test (#1479) to use the two-step flow instead of the old single-call set_admin helper.
* Rewrote admin.rs unit tests to cover the full two-step happy path, proposal overwrite, wrong-address accept, and all new error codes.

Closes #1692

## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
