### PR TITLE
fix(hello-world/cross_asset): gate initialize_asset behind require_au…

### DIFF
--- a/stellar-lend/contracts/hello-world/src/asset_price_age_test.rs
+++ b/stellar-lend/contracts/hello-world/src/asset_price_age_test.rs
@@ -7,11 +7,11 @@
 #![cfg(test)]
 
 use crate::cross_asset::{
-    get_asset_price_age, initialize_asset, update_asset_price, AssetConfig, CrossAssetError,
-    NoOpContract,
+    get_asset_price_age, initialize_asset, set_admin, update_asset_price, AssetConfig,
+    CrossAssetError, NoOpContract,
 };
 use crate::{HelloContract, HelloContractClient};
-use soroban_sdk::{Env, Address};
+use soroban_sdk::{Address, Env};
 
 /// Helper to set up a test Soroban environment and register the test contract execution context.
 fn make_env() -> Env {
@@ -49,11 +49,14 @@ fn default_config(price: i128, price_decimals: u32) -> AssetConfig {
 fn test_get_asset_price_age_equals_now_minus_ts() {
     let env = make_env();
     with_contract(&env, || {
+        let admin = Address::generate(&env);
+        set_admin(&env, &admin);
+
         // Set initial ledger timestamp
         env.ledger().set_timestamp(1_000);
 
         // Register asset (initial timestamp set to 1000)
-        initialize_asset(&env, None, default_config(1_000_000, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(1_000_000, 6)).unwrap();
 
         // Initial age at timestamp 1000 should be 0
         let age_init = get_asset_price_age(&env, None).unwrap();
@@ -61,7 +64,7 @@ fn test_get_asset_price_age_equals_now_minus_ts() {
 
         // Update asset price at timestamp 2_000
         env.ledger().set_timestamp(2_000);
-        update_asset_price(&env, None, 1_050_000).unwrap();
+        update_asset_price(&env, &admin, None, 1_050_000).unwrap();
 
         // Advance ledger timestamp to 2_500
         env.ledger().set_timestamp(2_500);
@@ -77,8 +80,11 @@ fn test_get_asset_price_age_equals_now_minus_ts() {
 fn test_fresh_update_resets_age() {
     let env = make_env();
     with_contract(&env, || {
+        let admin = Address::generate(&env);
+        set_admin(&env, &admin);
+
         env.ledger().set_timestamp(10_000);
-        initialize_asset(&env, None, default_config(1_000_000, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(1_000_000, 6)).unwrap();
 
         // Advance timestamp by 3,600 seconds (1 hour)
         env.ledger().set_timestamp(13_600);
@@ -86,7 +92,7 @@ fn test_fresh_update_resets_age() {
         assert_eq!(age_before, 3_600);
 
         // A fresh price update at timestamp 13_600 resets age to 0
-        update_asset_price(&env, None, 1_100_000).unwrap();
+        update_asset_price(&env, &admin, None, 1_100_000).unwrap();
         let age_after = get_asset_price_age(&env, None).unwrap();
         assert_eq!(age_after, 0);
     });
@@ -108,8 +114,11 @@ fn test_unknown_asset_returns_error_without_panic() {
 fn test_monotonic_age_growth() {
     let env = make_env();
     with_contract(&env, || {
+        let admin = Address::generate(&env);
+        set_admin(&env, &admin);
+
         env.ledger().set_timestamp(5_000);
-        initialize_asset(&env, None, default_config(2_000_000, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(2_000_000, 6)).unwrap();
 
         let mut prev_age = get_asset_price_age(&env, None).unwrap();
         assert_eq!(prev_age, 0);
@@ -133,12 +142,16 @@ fn test_contract_client_get_asset_price_age() {
     let contract_id = env.register(HelloContract, ());
     let client = HelloContractClient::new(&env, &contract_id);
 
+    // Initialize the contract so an admin is stored, then register an asset.
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
     env.ledger().set_timestamp(50_000);
-    client.initialize_asset(&None, &default_config(1_000_000, 6));
+    client.initialize_asset(&admin, &None, &default_config(1_000_000, 6));
 
     // Update price at t=60,000
     env.ledger().set_timestamp(60_000);
-    client.update_asset_price(&None, &1_200_000);
+    client.update_asset_price(&admin, &None, &1_200_000);
 
     // Check age at t=60_300
     env.ledger().set_timestamp(60_300);

--- a/stellar-lend/contracts/hello-world/src/cross_asset.rs
+++ b/stellar-lend/contracts/hello-world/src/cross_asset.rs
@@ -434,15 +434,23 @@ pub fn initialize(env: &Env, admin: Address) -> Result<(), CrossAssetError> {
 
 /// Register a new asset with its initial configuration.
 ///
+/// # Access control
+/// `caller` must equal the stored admin address, else
+/// [`CrossAssetError::Unauthorized`] is returned before any state is touched.
+///
 /// # Errors
+/// - [`CrossAssetError::Unauthorized`] — caller is not the protocol admin.
 /// - [`CrossAssetError::AssetAlreadyExists`] — asset key already registered.
 /// - [`CrossAssetError::InvalidDecimals`] — `config.price_decimals > 38`.
 /// - [`CrossAssetError::InvalidCollateralFactor`] — factor outside `[0, 10_000]`.
 pub fn initialize_asset(
     env: &Env,
+    caller: &Address,
     asset: Option<Address>,
     config: AssetConfig,
 ) -> Result<(), CrossAssetError> {
+    require_admin(env, caller)?;
+
     if config.price_decimals > 38 {
         return Err(CrossAssetError::InvalidDecimals);
     }

--- a/stellar-lend/contracts/hello-world/src/cross_asset_config_bounds_test.rs
+++ b/stellar-lend/contracts/hello-world/src/cross_asset_config_bounds_test.rs
@@ -55,12 +55,13 @@ fn default_config() -> AssetConfig {
 #[test]
 fn test_update_rejects_non_admin() {
     let env = make_env();
+    env.mock_all_auths();
     with_contract(&env, || {
         let admin = Address::generate(&env);
         let non_admin = Address::generate(&env);
 
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         let r = update_asset_config(
             &env, &non_admin, None, None, None, None, None, None, None, None,
@@ -77,12 +78,10 @@ fn test_update_rejects_non_admin() {
 #[test]
 fn test_update_rejects_when_no_admin_set() {
     let env = make_env();
+    env.mock_all_auths();
     with_contract(&env, || {
-        initialize_asset(&env, None, default_config()).unwrap();
         let caller = Address::generate(&env);
-        let r = update_asset_config(
-            &env, &caller, None, None, None, None, None, None, None, None,
-        );
+        let r = initialize_asset(&env, &caller, None, default_config());
         assert_eq!(r, Err(CrossAssetError::Unauthorized));
     });
 }
@@ -100,7 +99,7 @@ fn test_update_rejects_ltv_above_threshold() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         // Factor 8001 > threshold 8000 → reject.
         let r = update_asset_config(
@@ -132,7 +131,7 @@ fn test_update_rejects_threshold_below_current_factor() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         // Drop threshold to 7000 without changing factor (7500 > 7000) → reject.
         let r = update_asset_config(
@@ -160,7 +159,7 @@ fn test_update_accepts_ltv_equal_to_threshold() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         // Set factor == threshold (8000 == 8000) → accept.
         let r = update_asset_config(
@@ -196,14 +195,10 @@ fn test_update_rejects_ltv_above_100_pct() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(
-            &env,
-            None,
-            AssetConfig {
-                liquidation_threshold: 10_000,
-                ..default_config()
-            },
-        )
+        initialize_asset(&env, &admin, None, AssetConfig {
+            liquidation_threshold: 10_000,
+            ..default_config()
+        })
         .unwrap();
 
         let r = update_asset_config(
@@ -230,7 +225,7 @@ fn test_update_rejects_negative_factor() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         let r = update_asset_config(
             &env,
@@ -260,7 +255,7 @@ fn test_update_rejects_zero_decimals() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         let r = update_asset_config(
             &env,
@@ -286,7 +281,7 @@ fn test_update_rejects_decimals_above_38() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         let r = update_asset_config(
             &env,
@@ -316,7 +311,7 @@ fn test_update_valid_persists_changes() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         let r = update_asset_config(
             &env,
@@ -351,7 +346,7 @@ fn test_update_all_none_is_noop() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         update_asset_config(&env, &admin, None, None, None, None, None, None, None, None).unwrap();
 
@@ -374,7 +369,7 @@ fn test_update_emits_config_updated_event() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         update_asset_config(
             &env,
@@ -402,7 +397,7 @@ fn test_failed_update_emits_no_event() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         set_admin(&env, &admin);
-        initialize_asset(&env, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
 
         let _ = update_asset_config(
             &env,
@@ -431,8 +426,8 @@ fn test_update_preserves_other_assets() {
         set_admin(&env, &admin);
 
         let other_asset = Address::generate(&env);
-        initialize_asset(&env, None, default_config()).unwrap();
-        initialize_asset(&env, Some(other_asset.clone()), default_config()).unwrap();
+        initialize_asset(&env, &admin, None, default_config()).unwrap();
+        initialize_asset(&env, &admin, Some(other_asset.clone()), default_config()).unwrap();
 
         update_asset_config(
             &env,

--- a/stellar-lend/contracts/hello-world/src/cross_asset_decimals_test.rs
+++ b/stellar-lend/contracts/hello-world/src/cross_asset_decimals_test.rs
@@ -128,9 +128,13 @@ fn test_position_summary_equal_usd_different_decimals() {
     let token_b = Address::generate(&env);
 
     with_contract(&env, || {
+        let admin = Address::generate(&env);
+        crate::cross_asset::set_admin(&env, &admin);
+
         // Asset A: 6-decimal feed, $1.00 → price = 1_000_000
         initialize_asset(
             &env,
+            &admin,
             None, // Native slot for asset A
             default_config(1_000_000, 6),
         )
@@ -139,6 +143,7 @@ fn test_position_summary_equal_usd_different_decimals() {
         // Asset B: 18-decimal feed, $1.00 → price = 1_000_000_000_000_000_000
         initialize_asset(
             &env,
+            &admin,
             Some(token_b.clone()),
             default_config(1_000_000_000_000_000_000, 18),
         )
@@ -168,9 +173,13 @@ fn test_borrow_health_check_mixed_decimals() {
     let token_b = Address::generate(&env);
 
     with_contract(&env, || {
+        let admin = Address::generate(&env);
+        crate::cross_asset::set_admin(&env, &admin);
+
         // Collateral asset: 6-dp, $2.00 per unit, collateral_factor_bps = 7500 (75 %)
         initialize_asset(
             &env,
+            &admin,
             None,
             AssetConfig {
                 collateral_factor_bps: 7500,
@@ -189,6 +198,7 @@ fn test_borrow_health_check_mixed_decimals() {
         // Borrow asset: 18-dp, $1.00 per unit
         initialize_asset(
             &env,
+            &admin,
             Some(token_b.clone()),
             AssetConfig {
                 collateral_factor_bps: 7500,
@@ -234,10 +244,14 @@ fn test_no_regression_same_decimals() {
     let token_b = Address::generate(&env);
 
     with_contract(&env, || {
+        let admin = Address::generate(&env);
+        crate::cross_asset::set_admin(&env, &admin);
+
         // Both assets use 18-decimal feeds, $1.00 price.
         for tok in [token_a.clone(), token_b.clone()] {
             initialize_asset(
                 &env,
+                &admin,
                 Some(tok),
                 default_config(1_000_000_000_000_000_000, 18),
             )
@@ -253,19 +267,24 @@ fn test_no_regression_same_decimals() {
     });
 }
 
-/// Edge case: initialize_asset rejects price_decimals > 38.
+/// Edge case: initialize_asset rejects price_decimals > 38 (after auth).
 #[test]
 fn test_invalid_decimals_rejected() {
     let env = make_env();
-    let result = initialize_asset(
-        &env,
-        None,
-        AssetConfig {
-            price_decimals: 39,
-            ..default_config(1, 18)
-        },
-    );
-    assert_eq!(result, Err(CrossAssetError::InvalidDecimals));
+    with_contract(&env, || {
+        let admin = Address::generate(&env);
+        crate::cross_asset::set_admin(&env, &admin);
+        let result = initialize_asset(
+            &env,
+            &admin,
+            None,
+            AssetConfig {
+                price_decimals: 39,
+                ..default_config(1, 18)
+            },
+        );
+        assert_eq!(result, Err(CrossAssetError::InvalidDecimals));
+    });
 }
 
 /// Price update works and the new price is reflected in position summary.
@@ -278,7 +297,7 @@ fn test_price_update_reflected_in_summary() {
 
     with_contract(&env, || {
         initialize(&env, admin.clone()).unwrap();
-        initialize_asset(&env, None, default_config(1_000_000, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(1_000_000, 6)).unwrap();
         cross_asset_deposit(&env, user.clone(), None, 10).unwrap();
 
         // Initially $1.00 each → collateral = 10.

--- a/stellar-lend/contracts/hello-world/src/cross_asset_ltv_test.rs
+++ b/stellar-lend/contracts/hello-world/src/cross_asset_ltv_test.rs
@@ -90,20 +90,22 @@ fn collateral_only_asset_config(price: i128, price_decimals: u32, factor_bps: i1
 #[test]
 fn test_init_rejects_negative_factor() {
     let env = make_env();
-    let result = initialize_asset(&env, None, asset_config(1_000_000, 6, -1));
-    assert_eq!(result, Err(CrossAssetError::InvalidCollateralFactor));
+    with_contract(&env, || {
+        let admin = setup_admin(&env);
+        let result = initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, -1));
+        assert_eq!(result, Err(CrossAssetError::InvalidCollateralFactor));
+    });
 }
 
 /// `collateral_factor_bps` above 10_000 must be rejected at the init call.
 #[test]
 fn test_init_rejects_factor_above_max() {
     let env = make_env();
-    let result = initialize_asset(
-        &env,
-        None,
-        asset_config(1_000_000, 6, MAX_COLLATERAL_FACTOR_BPS + 1),
-    );
-    assert_eq!(result, Err(CrossAssetError::InvalidCollateralFactor));
+    with_contract(&env, || {
+        let admin = setup_admin(&env);
+        let result = initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, MAX_COLLATERAL_FACTOR_BPS + 1));
+        assert_eq!(result, Err(CrossAssetError::InvalidCollateralFactor));
+    });
 }
 
 /// Boundary: factor = 0 is accepted (zero-capacity tier).
@@ -111,7 +113,8 @@ fn test_init_rejects_factor_above_max() {
 fn test_init_accepts_zero_factor_boundary() {
     let env = make_env();
     with_contract(&env, || {
-        let result = initialize_asset(&env, None, asset_config(1_000_000, 6, 0));
+        let admin = setup_admin(&env);
+        let result = initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, 0));
         assert_eq!(result, Ok(()));
     });
 }
@@ -121,7 +124,8 @@ fn test_init_accepts_zero_factor_boundary() {
 fn test_init_accepts_max_factor_boundary() {
     let env = make_env();
     with_contract(&env, || {
-        let result = initialize_asset(&env, None, asset_config(1_000_000, 6, 10_000));
+        let admin = setup_admin(&env);
+        let result = initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, 10_000));
         assert_eq!(result, Ok(()));
     });
 }
@@ -132,7 +136,7 @@ fn test_update_rejects_out_of_range_factor() {
     let env = make_env();
     with_contract(&env, || {
         let admin = setup_admin(&env);
-        initialize_asset(&env, None, asset_config(1_000_000, 6, 7500)).unwrap();
+        initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, 7500)).unwrap();
 
         // 10_001 → reject
         let r = update_asset_config(
@@ -182,12 +186,8 @@ fn test_update_factor_takes_effect_immediately() {
     with_contract(&env, || {
         let admin = setup_admin(&env);
         // Collateral at 50 % LTV, $1 per unit. Borrow asset also $1 per unit.
-        initialize_asset(&env, None, asset_config(1_000_000, 6, 5_000)).unwrap();
-        initialize_asset(
-            &env,
-            Some(borrow_asset.clone()),
-            borrow_only_asset_config(1_000_000, 6, 5_000),
-        )
+        initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, 5_000)).unwrap();
+        initialize_asset(&env, &admin, Some(borrow_asset.clone()), borrow_only_asset_config(1_000_000, 6, 5_000))
         .unwrap();
 
         cross_asset_deposit(&env, user.clone(), None, 100).unwrap();
@@ -255,11 +255,7 @@ fn test_full_factor_no_regression() {
             asset_config(1_000_000, 6, 10_000), // 100 %
         )
         .unwrap();
-        initialize_asset(
-            &env,
-            Some(borrow_asset.clone()),
-            borrow_only_asset_config(1_000_000, 6, 10_000),
-        )
+        initialize_asset(&env, &admin, Some(borrow_asset.clone()), borrow_only_asset_config(1_000_000, 6, 10_000))
         .unwrap();
 
         cross_asset_deposit(&env, user.clone(), None, 100).unwrap();
@@ -295,11 +291,7 @@ fn test_zero_factor_asset_no_capacity() {
             collateral_only_asset_config(1_000_000, 6, 0), // 0 %
         )
         .unwrap();
-        initialize_asset(
-            &env,
-            Some(borrow_asset.clone()),
-            borrow_only_asset_config(1_000_000, 6, 10_000),
-        )
+        initialize_asset(&env, &admin, Some(borrow_asset.clone()), borrow_only_asset_config(1_000_000, 6, 10_000))
         .unwrap();
 
         cross_asset_deposit(&env, user.clone(), None, 1000).unwrap();
@@ -327,20 +319,12 @@ fn test_mixed_factor_portfolio() {
 
     with_contract(&env, || {
         // Blue-chip: $1 / unit, 90 %
-        initialize_asset(&env, None, asset_config(1_000_000, 6, 9_000)).unwrap();
+        initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, 9_000)).unwrap();
         // Long-tail: $1 / unit, 40 %
-        initialize_asset(
-            &env,
-            Some(blue_chip.clone()),
-            asset_config(1_000_000, 6, 4_000),
-        )
+        initialize_asset(&env, &admin, Some(blue_chip.clone()), asset_config(1_000_000, 6, 4_000))
         .unwrap();
         // Borrow asset (configured to allow borrow)
-        initialize_asset(
-            &env,
-            Some(borrow_asset.clone()),
-            borrow_only_asset_config(1_000_000, 6, 0),
-        )
+        initialize_asset(&env, &admin, Some(borrow_asset.clone()), borrow_only_asset_config(1_000_000, 6, 0))
         .unwrap();
 
         // Note: we deposit using the `None` (Native) slot for the first
@@ -400,11 +384,7 @@ fn test_factor_weighting_arithmetic_reference() {
         )
         .unwrap();
         // Borrow side.
-        initialize_asset(
-            &env,
-            Some(borrow_asset.clone()),
-            borrow_only_asset_config(1_000_000, 6, 0),
-        )
+        initialize_asset(&env, &admin, Some(borrow_asset.clone()), borrow_only_asset_config(1_000_000, 6, 0))
         .unwrap();
 
         // Deposit 100 units each → values: 100×$1=100, 50×$2=100, 20×$5=100.
@@ -444,7 +424,7 @@ fn test_factor_does_not_change_total_collateral_value() {
     with_contract(&env, || {
         let admin = setup_admin(&env);
         // Same collateral at 100 % vs 0 %.
-        initialize_asset(&env, None, asset_config(1_000_000, 6, 10_000)).unwrap();
+        initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, 10_000)).unwrap();
         cross_asset_deposit(&env, user.clone(), None, 7).unwrap();
 
         let s_full = get_user_position_summary(&env, &user).unwrap();
@@ -480,7 +460,7 @@ fn test_factor_50bps_small_collateral() {
     let user = Address::generate(&env);
 
     with_contract(&env, || {
-        initialize_asset(&env, None, asset_config(1_000_000, 6, 50)).unwrap();
+        initialize_asset(&env, &admin, None, asset_config(1_000_000, 6, 50)).unwrap();
         cross_asset_deposit(&env, user.clone(), None, 100).unwrap();
         let s = get_user_position_summary(&env, &user).unwrap();
         // 100 × 50 / 10_000 = 0  (integer division)

--- a/stellar-lend/contracts/hello-world/src/cross_asset_price_authorization_test.rs
+++ b/stellar-lend/contracts/hello-world/src/cross_asset_price_authorization_test.rs
@@ -41,6 +41,7 @@ fn default_config(price: i128, price_decimals: u32) -> AssetConfig {
         can_borrow: true,
         price,
         price_decimals,
+        last_update_ts: 0,
     }
 }
 
@@ -58,7 +59,7 @@ fn test_price_update_rejects_non_admin() {
         let non_admin = Address::generate(&env);
 
         initialize(&env, admin.clone()).unwrap();
-        initialize_asset(&env, None, default_config(1_000_000, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(1_000_000, 6)).unwrap();
 
         // Non-admin cannot update price
         let r = update_asset_price(&env, &non_admin, None, 2_000_000);
@@ -76,16 +77,10 @@ fn test_price_update_rejects_when_no_admin_set() {
     let env = make_env();
     env.mock_all_auths();
     with_contract(&env, || {
-        initialize_asset(&env, None, default_config(1_000_000, 6)).unwrap();
+        // No admin set — any update_asset_price call must fail.
         let caller = Address::generate(&env);
-
-        // Any caller should be rejected when no admin is set
         let r = update_asset_price(&env, &caller, None, 2_000_000);
         assert_eq!(r, Err(CrossAssetError::Unauthorized));
-
-        // Price on disk is unchanged
-        let cfg = get_asset_config_by_address(&env, None).unwrap();
-        assert_eq!(cfg.price, 1_000_000);
     });
 }
 
@@ -104,7 +99,7 @@ fn test_price_update_succeeds_with_admin() {
         let new_price = 2_000_000;
 
         initialize(&env, admin.clone()).unwrap();
-        initialize_asset(&env, None, default_config(initial_price, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(initial_price, 6)).unwrap();
 
         // Admin updates price
         let r = update_asset_price(&env, &admin, None, new_price);
@@ -127,8 +122,8 @@ fn test_price_update_multiple_assets() {
         let token_b = Address::generate(&env);
 
         initialize(&env, admin.clone()).unwrap();
-        initialize_asset(&env, Some(token_a.clone()), default_config(100, 6)).unwrap();
-        initialize_asset(&env, Some(token_b.clone()), default_config(50, 6)).unwrap();
+        initialize_asset(&env, &admin, Some(token_a.clone()), default_config(100, 6)).unwrap();
+        initialize_asset(&env, &admin, Some(token_b.clone()), default_config(50, 6)).unwrap();
 
         // Update token A price
         update_asset_price(&env, &admin, Some(token_a.clone()), 200).unwrap();
@@ -153,7 +148,7 @@ fn test_price_update_rejects_zero() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         initialize(&env, admin.clone()).unwrap();
-        initialize_asset(&env, None, default_config(1_000_000, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(1_000_000, 6)).unwrap();
 
         let r = update_asset_price(&env, &admin, None, 0);
         assert_eq!(r, Err(CrossAssetError::InvalidAmount));
@@ -172,7 +167,7 @@ fn test_price_update_rejects_negative() {
     with_contract(&env, || {
         let admin = Address::generate(&env);
         initialize(&env, admin.clone()).unwrap();
-        initialize_asset(&env, None, default_config(1_000_000, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(1_000_000, 6)).unwrap();
 
         let r = update_asset_price(&env, &admin, None, -1_000_000);
         assert_eq!(r, Err(CrossAssetError::InvalidAmount));
@@ -194,7 +189,7 @@ fn test_unauthorized_rejected_before_validation() {
         let non_admin = Address::generate(&env);
 
         initialize(&env, admin).unwrap();
-        initialize_asset(&env, None, default_config(1_000_000, 6)).unwrap();
+        initialize_asset(&env, &admin, None, default_config(1_000_000, 6)).unwrap();
 
         // Non-admin tries to set invalid price (zero)
         // Should get Unauthorized, not InvalidAmount

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -815,12 +815,15 @@ impl HelloContract {
     }
 
     /// Initialize/register a new asset with configuration.
+    ///
+    /// `caller` must be the stored protocol admin.
     pub fn initialize_asset(
         env: Env,
+        caller: Address,
         asset: Option<Address>,
         config: AssetConfig,
     ) -> Result<(), CrossAssetError> {
-        initialize_asset(&env, asset, config)
+        initialize_asset(&env, &caller, asset, config)
     }
 
     /// Update asset configuration (admin only).


### PR DESCRIPTION
…th()

initialize_asset() had no access control: any address could register an arbitrary asset with attacker-chosen risk parameters, completely bypassing the admin-only invariant upheld by update_asset_config() and update_asset_price().

Changes
-------
cross_asset.rs
- initialize_asset() now accepts a caller: &Address parameter and calls require_admin(env, caller)? before performing any validation or storage writes. The auth check is first so callers learn nothing about existing state before proving identity.
- Updated doc comment to document the new Unauthorized error path.

lib.rs
- initialize_asset entrypoint gains the matching caller: Address parameter and forwards it to the module function.
- Inline doc updated to note the admin-only requirement.

Test updates (all 5 test files that exercise initialize_asset)
- cross_asset_config_bounds_test.rs: all initialize_asset() calls now pass &admin. test_update_rejects_when_no_admin_set is repurposed to verify that initialize_asset itself rejects an unauthenticated caller when no admin has been stored. Added mock_all_auths() where missing.
- cross_asset_ltv_test.rs: all initialize_asset() calls now pass &admin. The two raw validation tests (negative factor, above-max factor) are wrapped in with_contract + setup_admin so the auth check passes first, then the validation check fires.
- cross_asset_decimals_test.rs: all initialize_asset() calls now pass &admin; each test closure sets up an admin inline. The test_invalid_decimals_rejected test is moved inside with_contract so it has storage context and a valid admin.
- cross_asset_price_authorization_test.rs: all initialize_asset() calls now pass &admin. Added last_update_ts: 0 field to default_config() (the struct gained the field in a prior commit). Rewrote test_price_update_rejects_when_no_admin_set to not call initialize_asset (which would also fail auth), instead directly testing update_asset_price when no admin is stored.
- asset_price_age_test.rs: every test closure now creates an admin via set_admin() and passes it to initialize_asset() and update_asset_price(). The HelloContractClient integration test now calls client.initialize() first and passes the admin address to client.initialize_asset() and client.update_asset_price().

Closes #1689

## Summary

<!-- 1-3 bullet points describing what this PR changes and why -->

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage / upgrade change

---

## Contracts Release Checklist

> Full checklist: [docs/release_checklist.md](../docs/release_checklist.md)
> Skip sections that do not apply and note why.

### Functional tests
- [ ] New public functions have success-path and failure-path tests
- [ ] All new error codes are reachable through a test
- [ ] Zero/negative/boundary values tested for numeric inputs
- [ ] `cargo test` passes — no new failures beyond the [known baseline](../docs/release_checklist.md#quick-reference-known-pre-existing-test-failures)

### Invariants
- [ ] Cross-asset view guarantees G-1..G-10 hold (if `cross_asset` touched)
- [ ] Repay semantics preserved: borrow system errors on overpay; cross-asset clamps
- [ ] Interest ceiling division unchanged (`interest ≥ 1` for any `principal > 0 && elapsed > 0`)

### Upgrade safety _(skip if no storage / signature changes)_
- [ ] No storage key renamed or removed without a migration path
- [ ] New persistent entries documented in `docs/storage.md`
- [ ] `initialize` still idempotent (second call → `AlreadyInitialized`)

### Monitoring / events _(skip if no event changes)_
- [ ] New operations emit an event with topic + data
- [ ] No existing topic string renamed silently

### Security notes

**Auth / access control**
- [ ] `require_auth()` called for every entry point that modifies user state
- [ ] No new function bypasses the pause guard without justification

**Arithmetic**
- [ ] No unchecked arithmetic on untrusted values
- [ ] No new division site can produce divide-by-zero

**Reentrancy** _(skip if no cross-contract calls)_
- [ ] State updated before external call (Checks-Effects-Interactions)

**Rounding**
- [ ] Floor for collateral capacity; ceiling for interest owed

### Docs
- [ ] Public functions have a doc comment (error codes, params, return)
- [ ] Relevant docs sections updated (`CROSS_ASSET_RULES.md`, `REPAY_SEMANTICS.md`, `storage.md`)

### CI
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] No secrets or key material committed
