### PR TITLE
docs: KEYS_AUDIT.md add drift disclaimer for stale data key layout

### DIFF
--- a/stellar-lend/contracts/hello-world/KEYS_AUDIT.md
+++ b/stellar-lend/contracts/hello-world/KEYS_AUDIT.md
@@ -1,5 +1,13 @@
 # Storage Key Audit - hello-world
 
+> **⚠️ Document Drift Alert:** The data key layout and enum renames described in
+> this audit (e.g. `LegacyDepositDataKey`, 4-variant `DepositDataKey`) were
+> drafted for a proposed refactoring of storage key types. The current
+> `hello-world` contract does **not** use these structures; its storage keys
+> are defined in `src/deposit.rs` and `src/storage.rs` with different layouts.
+> Use this document as a design reference, not as a specification of the
+> current on-chain key encoding.
+
 ## Summary
 
 - Found duplicate enum name `DepositDataKey` in `src/storage.rs` and `src/deposit.rs`.


### PR DESCRIPTION
## Summary

Fixes #1731

The KEYS_AUDIT.md describes a `DepositDataKey` layout with variants (`CollateralBalance(Address)`, `PauseSwitches`, `ProtocolAnalytics`, `ProtocolReserve(Option<Address>)`) and a `LegacyDepositDataKey` rename that do not match the current contract's storage key structures in `src/deposit.rs` and `src/storage.rs`.

## Changes

1. Added a document drift disclaimer at the top noting that the described layout was drafted for a proposed refactoring and does not represent the current on-chain key encoding
2. Clarified that this document should be used as a design reference rather than a specification

## Type
- [x] Documentation
