### PR TITLE
test: wire borrow_isolation_tier_test into lib.rs (#1706)

### DIFF
--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -1278,6 +1278,9 @@ mod test;
 #[cfg(test)]
 mod amm_pause_integration_test;
 #[cfg(test)]
+mod borrow_isolation_tier_test;
+
+#[cfg(test)]
 mod claim_reserves_test;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`borrow_isolation_tier_test.rs` exists in `hello-world/src/` but was never
declared as a `#[cfg(test)]` module in `lib.rs`, causing `cargo test` to
silently skip it.

## Change

- Add `#[cfg(test)] mod borrow_isolation_tier_test;` to `lib.rs`

Closes #1706