### PR TITLE
test: wire position_summary_test into lib.rs (#1710)

### DIFF
--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -1282,6 +1282,8 @@ mod claim_reserves_test;
 
 #[cfg(test)]
 mod gov_can_vote_test;
+#[cfg(test)]
+mod position_summary_test;
 // mod governance_test;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`position_summary_test.rs` exists in `hello-world/src/` but was never
declared as a `#[cfg(test)]` module in `lib.rs`, causing `cargo test` to
silently skip it.

## Change

- Add `#[cfg(test)] mod position_summary_test;` to `lib.rs`

Closes #1710