### PR TITLE
docs: add stub notice to config.md (#1735)

### DIFF
--- a/stellar-lend/contracts/hello-world/config.md
+++ b/stellar-lend/contracts/hello-world/config.md
@@ -1,3 +1,5 @@
+> **⚠ STUB NOTICE**: The `config_set`, `config_get`, `config_backup`, and `config_restore` functions documented below are **not yet implemented** — `config.rs` is currently a stub. This documentation describes the intended design only.
+
 # Protocol Configuration Module (`config.rs`)
 
 The `config` module provides a flexible, key-value storage system for the StellarLend protocol's configuration parameters. It allows the protocol admin to efficiently add, retrieve, back up, and restore configuration settings without needing to upgrade the entire contract.


### PR DESCRIPTION
## Summary

`config.md` documents `config_set`, `config_get`, `config_backup`, and
`config_restore` as fully implemented admin key-value storage, but
`config.rs` is an empty stub file. This discrepancy misleads readers.

## Change

- Add a prominent stub notice at the top of `config.md` clarifying that
  the documented functions are not yet implemented

Closes #1735