### PR TITLE
Fix unused liquidate event

### DIFF
--- a/stellar-lend/contracts/lending/src/events.rs
+++ b/stellar-lend/contracts/lending/src/events.rs
@@ -82,27 +82,6 @@ pub struct RepayEvent {
     pub timestamp: u64,
 }
 
-/// Emitted when a liquidator liquidates an undercollateralized position.
-#[contracttype]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiquidateEvent {
-    /// Schema version for safe decoding across upgrades.
-    pub schema_version: u32,
-    /// Address of the liquidator executing the liquidation.
-    pub liquidator: Address,
-    /// Address of the borrower being liquidated.
-    pub borrower: Address,
-    /// Amount of debt repaid by the liquidator.
-    pub repaid_debt: i128,
-    /// Amount of collateral seized by the liquidator.
-    pub seized_collateral: i128,
-    /// Borrower's remaining debt after liquidation.
-    pub borrower_remaining_debt: i128,
-    /// Borrower's remaining collateral after liquidation.
-    pub borrower_remaining_collateral: i128,
-    /// Timestamp of the liquidation (ledger timestamp).
-    pub timestamp: u64,
-}
 
 /// Emit the schema version event during contract initialization.
 pub fn emit_schema_version(env: &Env) {
@@ -166,26 +145,3 @@ pub fn emit_repay(env: &Env, user: &Address, amount: i128, new_debt: i128) {
         .publish((Symbol::new(env, "RepayEvent"),), event);
 }
 
-/// Emit a liquidate event.
-pub fn emit_liquidate(
-    env: &Env,
-    liquidator: &Address,
-    borrower: &Address,
-    repaid_debt: i128,
-    seized_collateral: i128,
-    borrower_remaining_debt: i128,
-    borrower_remaining_collateral: i128,
-) {
-    let event = LiquidateEvent {
-        schema_version: EVENT_SCHEMA_VERSION,
-        liquidator: liquidator.clone(),
-        borrower: borrower.clone(),
-        repaid_debt,
-        seized_collateral,
-        borrower_remaining_debt,
-        borrower_remaining_collateral,
-        timestamp: env.ledger().timestamp(),
-    };
-    env.events()
-        .publish((Symbol::new(env, "LiquidateEvent"),), event);
-}

--- a/stellar-lend/contracts/lending/src/events_test.rs
+++ b/stellar-lend/contracts/lending/src/events_test.rs
@@ -333,35 +333,6 @@ fn test_full_repay_emits_event_with_zero_debt() {
     );
 }
 
-#[test]
-fn test_liquidate_event_emitted() {
-    let (env, client, _admin, user) = setup();
-    let liquidator = Address::generate(&env);
-
-    // Set up an undercollateralized position (simplified for this test)
-    // Note: The actual liquidate function may need specific setup
-    // This test focuses on event emission structure
-
-    // Verify liquidate events are filterable
-    let events = env.events().all();
-    let _liquidate_events: SdkVec<_> = events
-        .iter()
-        .filter(|e| {
-            if let Ok(topics) = e.topics.clone().try_into_val(&env) {
-                let topics: SdkVec<Val> = topics;
-                if let Some(first) = topics.get(0) {
-                    if let Ok(symbol) = Symbol::try_from_val(&env, &first) {
-                        return symbol == Symbol::new(&env, "LiquidateEvent");
-                    }
-                }
-            }
-            false
-        })
-        .collect();
-
-    // Liquidation requires specific collateral/debt ratios
-    // This test verifies the event structure can be filtered
-}
 
 #[test]
 fn test_events_have_consistent_schema_version() {

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -1265,8 +1265,6 @@ impl LendingContract {
         let position = load_debt(&env, &user);
         let prev_principal = position.principal;
         let now = env.ledger().timestamp();
-        let position = load_debt(&env, &user);
-        let prev_principal = position.principal;
         let rate = current_borrow_rate(&env);
         let settled_position = settle_and_accrue_insurance(&env, &position, now, rate)?;
         let updated = borrow_amount(settled_position, now, amount, rate).map_err(|e| match e {
@@ -1820,11 +1818,7 @@ impl LendingContract {
         let position = load_debt(&env, &user);
         let prev_principal = position.principal;
         let now = env.ledger().timestamp();
-        let position = load_debt(&env, &user);
-        let prev_principal = position.principal;
         let rate = current_borrow_rate(&env);
-        let position = load_debt(&env, &user);
-        let prev_principal = position.principal;
         let settled_position = settle_and_accrue_insurance(&env, &position, now, rate)?;
         let updated = repay_amount(settled_position, now, amount, rate).map_err(|e| match e {
             debt::DebtError::InvalidAmount => LendingError::InvalidAmount,
@@ -1850,7 +1844,7 @@ impl LendingContract {
         // Emit repay event
         emit_repay(&env, &user, amount, updated.principal);
 
-        updated.principal
+        Ok(updated.principal)
     }
 
     pub fn get_debt_position(env: Env, user: Address) -> DebtPosition {

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -142,7 +142,7 @@ use debt::{
     repay_amount, save_debt, touch_borrow_index, DebtPosition, DEFAULT_APR_BPS,
 };
 use events::{
-    emit_borrow, emit_deposit, emit_liquidate, emit_repay, emit_schema_version, emit_withdraw,
+    emit_borrow, emit_deposit, emit_repay, emit_schema_version, emit_withdraw,
 };
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::xdr::ToXdr;


### PR DESCRIPTION
Closes #1509 

This PR removes the unused `LiquidateEvent` struct and `emit_liquidate` helper function from `events.rs`.

**Reason for changes:**
The `LendingContract::liquidate` function actually publishes a completely different, separately-defined `LiquidationEventV1` struct when liquidations occur. The `LiquidateEvent` schema in `events.rs` was entirely unreachable dead code, creating a discrepancy where two independent event schemas existed for the same economic action. Removing it prevents indexers and developers from relying on an event schema that the contract never actually emits.

**Changes:**
- Removed `LiquidateEvent` struct from `stellar-lend/contracts/lending/src/events.rs`.
- Removed `emit_liquidate` function from `stellar-lend/contracts/lending/src/events.rs`.
- Removed the `emit_liquidate` import from `stellar-lend/contracts/lending/src/lib.rs`.
- Removed the unused test `test_liquidate_event_emitted` from `stellar-lend/contracts/lending/src/events_test.rs` which was testing the removed schema.