### PR TITLE
fix: use checked arithmetic for TWAP extrapolation in amm_twap.rs

### DIFF
--- a/stellar-lend/contracts/hello-world/src/amm_twap.rs
+++ b/stellar-lend/contracts/hello-world/src/amm_twap.rs
@@ -365,9 +365,16 @@ pub fn get_twap(env: &Env, asset: &Address, window_secs: u64) -> u128 {
     let elapsed_since_stored = now.saturating_sub(current_state.last_timestamp);
     let mut cumulative_now = current_state.price0_cumulative;
     if elapsed_since_stored > 0 && current_state.last_reserve0 > 0 {
-        let extrapolation = (current_state.last_reserve1 * PRICE_SCALE
-            / current_state.last_reserve0)
-            * elapsed_since_stored as u128;
+        let scaled_reserve1 = current_state
+            .last_reserve1
+            .checked_mul(PRICE_SCALE)
+            .expect("TWAP extrapolation overflow: last_reserve1 * PRICE_SCALE");
+        let ratio = scaled_reserve1
+            .checked_div(current_state.last_reserve0)
+            .expect("TWAP extrapolation overflow: last_reserve1 * PRICE_SCALE / last_reserve0");
+        let extrapolation = ratio
+            .checked_mul(elapsed_since_stored as u128)
+            .expect("TWAP extrapolation overflow: reserve ratio * elapsed_since_stored");
         cumulative_now = cumulative_now.wrapping_add(extrapolation);
     }
 


### PR DESCRIPTION
## Summary

Fixes #1698

Replaces the unchecked u128 multiplication chain in `get_twap()` (`amm_twap.rs:368`) with `checked_mul`/`checked_div` at each step.

## Problem

The original code computed:
```rust
let extrapolation = (current_state.last_reserve1 * PRICE_SCALE
    / current_state.last_reserve0)
    * elapsed_since_stored as u128;
```

With `PRICE_SCALE` at `1e18` and real reserve values potentially in the billions, `last_reserve1 * PRICE_SCALE` alone can approach `u128::MAX`. Multiplying the result again by an arbitrary `elapsed_since_stored` can overflow and either:
- Panic (with overflow checks on), or
- Silently wrap to a garbage price (with them off)

This price is used by the oracle-fallback path for borrowers and liquidators.

## Solution

Replaced the chain with `checked_mul`/`checked_div` at each operation:

```rust
let scaled_reserve1 = current_state
    .last_reserve1
    .checked_mul(PRICE_SCALE)
    .expect("TWAP extrapolation overflow: last_reserve1 * PRICE_SCALE");
let ratio = scaled_reserve1
    .checked_div(current_state.last_reserve0)
    .expect("TWAP extrapolation overflow: last_reserve1 * PRICE_SCALE / last_reserve0");
let extrapolation = ratio
    .checked_mul(elapsed_since_stored as u128)
    .expect("TWAP extrapolation overflow: reserve ratio * elapsed_since_stored");
```

Each overflow case now panics with a descriptive message identifying the exact operation that failed, rather than silently computing a wrong extrapolated price.

## Acceptance Criteria

- [x] Replace the chain with `checked_mul`/`checked_div`
- [x] Propagate an error/panic message that identifies the overflow
- [x] No silent wrong extrapolated price on overflow