### PR TITLE
fix: reject execute_recovery when old_admin no longer matches current admin

### DIFF
--- a/stellar-lend/contracts/hello-world/src/governance.rs
+++ b/stellar-lend/contracts/hello-world/src/governance.rs
@@ -55,6 +55,10 @@ pub enum GovernanceError {
     /// of zero, threshold exceeding the guardian count, or a removal that
     /// would make the current threshold unreachable).
     InvalidGuardianConfig = 12,
+    /// The recovery request's `old_admin` no longer matches the current admin,
+    /// meaning the admin was changed after the recovery was started.  The
+    /// recovery must be restarted against the current admin.
+    RecoveryAdminMismatch = 13,
 }
 
 // ---------------------------------------------------------------------------
@@ -682,6 +686,10 @@ pub fn execute_recovery(env: &Env, executor: Address) -> Result<(), GovernanceEr
         .instance()
         .get(&GovernanceDataKey::Config)
         .ok_or(GovernanceError::NotInitialized)?;
+
+    if config.admin != request.old_admin {
+        return Err(GovernanceError::RecoveryAdminMismatch);
+    }
 
     config.admin = request.new_admin;
     env.storage()


### PR DESCRIPTION
## Summary

Fixes #1696

Adds a check in `execute_recovery()` that verifies `request.old_admin` still equals the current `config.admin` before overwriting it.

## Problem

`execute_recovery` loads a pending `RecoveryRequest`, checks the guardian approval threshold, and then unconditionally sets `config.admin = request.new_admin` — it never verifies that `request.old_admin` still matches the current admin.

If the admin is legitimately changed (e.g. via a separate governance action) after `start_recovery` was called but before `execute_recovery` runs, a stale, already-approved recovery request can silently overwrite whatever the current admin is with the originally-proposed `new_admin`, even though the situation the guardians approved no longer holds.

## Solution

Added a guard in `execute_recovery()` (governance.rs:690):

```rust
if config.admin != request.old_admin {
    return Err(GovernanceError::RecoveryAdminMismatch);
}
```

Also added a new `RecoveryAdminMismatch = 13` variant to `GovernanceError` to give callers a clear, distinct error code.

## Acceptance Criteria

- [x] Reject `execute_recovery` with a clear error when `request.old_admin != config.admin`
- [x] Requires recovery to be restarted against the current admin