### PR TITLE
 fix(lending): remove duplicate mod declarations in lib.rs (#1494

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -49,8 +49,6 @@ mod deposit_cap_race_test;
 #[cfg(test)]
 mod effective_supply_rate_test;
 #[cfg(test)]
-mod effective_supply_rate_test;
-#[cfg(test)]
 mod emergency_state_matrix_test;
 #[cfg(test)]
 mod error_codes_test;
@@ -97,15 +95,11 @@ mod liquidation_sequence_invariant_test;
 #[cfg(test)]
 mod max_borrow_proptest;
 #[cfg(test)]
-mod compound_interest_proptest;
-#[cfg(test)]
 mod property_invariants_test;
 #[cfg(test)]
 mod oracle_staleness_test;
 #[cfg(test)]
 mod position_summary_bench_test;
-#[cfg(test)]
-mod property_invariants_test;
 #[cfg(test)]
 mod rate_cache_test;
 #[cfg(test)]
@@ -120,8 +114,6 @@ mod rate_smoothing_state_test;
 mod rate_smoothing_test;
 #[cfg(test)]
 mod rate_updated_event_test;
-#[cfg(test)]
-mod repay_debt_floor_test;
 #[cfg(test)]
 mod repay_debt_floor_test;
 #[cfg(test)]
@@ -4242,7 +4234,3 @@ pub(crate) mod test {
         assert!(env.ledger().sequence() >= 0);
     }
 }
-#[cfg(test)]
-mod max_borrow_proptest;
-#[cfg(test)]
-mod compound_interest_proptest;

--- a/stellar-lend/contracts/vesting/Cargo.toml
+++ b/stellar-lend/contracts/vesting/Cargo.toml
@@ -1,22 +1,16 @@
 [package]
-name = "soroban-token-vesting"
-version = "0.1.0"
 name = "stellarlend-vesting"
 version = "0.0.0"
 edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "lib"]
 crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
 soroban-token-sdk = { workspace = true }
-
-[dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }


### PR DESCRIPTION
  Duplicate mod declarations for effective_supply_rate_test,
  compound_interest_proptest, property_invariants_test,
  repay_debt_floor_test, and max_borrow_proptest caused E0428
  "defined multiple times" errors, preventing the lending crate
  from compiling.
  
  Remove the duplicate mod lines, keeping one declaration per
  module. Also fix duplicate keys in vesting/Cargo.toml that
  blocked workspace resolution.

closes #1494