### PR TITLE
Fix hello-world governance error typing

### DIFF
--- a/stellar-lend/contracts/hello-world/src/errors.rs
+++ b/stellar-lend/contracts/hello-world/src/errors.rs
@@ -1,1 +1,1 @@
-// Stub module
+pub use crate::governance::GovernanceError;

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -323,7 +323,7 @@ impl HelloContract {
         caller: Address,
         guardians: soroban_sdk::Vec<Address>,
         threshold: u32,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         recovery::set_guardians(&env, caller, guardians, threshold)
     }
 
@@ -332,15 +332,15 @@ impl HelloContract {
         initiator: Address,
         old_admin: Address,
         new_admin: Address,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         recovery::start_recovery(&env, initiator, old_admin, new_admin)
     }
 
-    pub fn approve_recovery(env: Env, approver: Address) -> Result<(), errors::GovernanceError> {
+    pub fn approve_recovery(env: Env, approver: Address) -> Result<(), crate::governance::GovernanceError> {
         recovery::approve_recovery(&env, approver)
     }
 
-    pub fn execute_recovery(env: Env, executor: Address) -> Result<(), errors::GovernanceError> {
+    pub fn execute_recovery(env: Env, executor: Address) -> Result<(), crate::governance::GovernanceError> {
         recovery::execute_recovery(&env, executor)
     }
 
@@ -349,7 +349,7 @@ impl HelloContract {
         caller: Address,
         admins: soroban_sdk::Vec<Address>,
         threshold: u32,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         multisig::ms_set_admins(&env, caller, admins, threshold)
     }
 
@@ -357,7 +357,7 @@ impl HelloContract {
         env: Env,
         proposer: Address,
         new_ratio: i128,
-    ) -> Result<u64, errors::GovernanceError> {
+    ) -> Result<u64, crate::governance::GovernanceError> {
         multisig::ms_propose_set_min_cr(&env, proposer, new_ratio)
     }
 
@@ -365,7 +365,7 @@ impl HelloContract {
         env: Env,
         approver: Address,
         proposal_id: u64,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         multisig::ms_approve(&env, approver, proposal_id)
     }
 
@@ -373,7 +373,7 @@ impl HelloContract {
         env: Env,
         executor: Address,
         proposal_id: u64,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         multisig::ms_execute(&env, executor, proposal_id)
     }
 
@@ -1006,7 +1006,7 @@ impl HelloContract {
         proposal_threshold: Option<i128>,
         timelock_duration: Option<u64>,
         default_voting_threshold: Option<i128>,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::initialize(
             &env,
             admin,
@@ -1027,7 +1027,7 @@ impl HelloContract {
         proposal_type: ProposalType,
         description: soroban_sdk::String,
         voting_threshold: Option<i128>,
-    ) -> Result<u64, errors::GovernanceError> {
+    ) -> Result<u64, crate::governance::GovernanceError> {
         let soroban_desc = soroban_sdk::String::from_str(&env, &description.to_string());
         governance::create_proposal(
             &env,
@@ -1044,7 +1044,7 @@ impl HelloContract {
         voter: Address,
         proposal_id: u64,
         vote_type: VoteType,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::vote(&env, voter, proposal_id, vote_type)
     }
 
@@ -1053,7 +1053,7 @@ impl HelloContract {
         env: Env,
         caller: Address,
         proposal_id: u64,
-    ) -> Result<ProposalOutcome, errors::GovernanceError> {
+    ) -> Result<ProposalOutcome, crate::governance::GovernanceError> {
         governance::queue_proposal(&env, caller, proposal_id)
     }
 
@@ -1062,7 +1062,7 @@ impl HelloContract {
         env: Env,
         executor: Address,
         proposal_id: u64,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::execute_proposal(&env, executor, proposal_id)
     }
 
@@ -1071,7 +1071,7 @@ impl HelloContract {
         env: Env,
         caller: Address,
         proposal_id: u64,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::cancel_proposal(&env, caller, proposal_id)
     }
 
@@ -1080,7 +1080,7 @@ impl HelloContract {
         env: Env,
         approver: Address,
         proposal_id: u64,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::approve_proposal(&env, approver, proposal_id)
     }
 
@@ -1090,7 +1090,7 @@ impl HelloContract {
         caller: Address,
         admins: Vec<Address>,
         threshold: u32,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::set_multisig_config(&env, caller, admins, threshold)
     }
 
@@ -1099,7 +1099,7 @@ impl HelloContract {
         env: Env,
         caller: Address,
         guardian: Address,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::add_guardian(&env, caller, guardian)
     }
 
@@ -1108,7 +1108,7 @@ impl HelloContract {
         env: Env,
         caller: Address,
         guardian: Address,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::remove_guardian(&env, caller, guardian)
     }
 
@@ -1117,7 +1117,7 @@ impl HelloContract {
         env: Env,
         caller: Address,
         threshold: u32,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::set_guardian_threshold(&env, caller, threshold)
     }
 
@@ -1127,7 +1127,7 @@ impl HelloContract {
         initiator: Address,
         old_admin: Address,
         new_admin: Address,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::start_recovery(&env, initiator, old_admin, new_admin)
     }
 
@@ -1135,7 +1135,7 @@ impl HelloContract {
     pub fn gov_approve_recovery(
         env: Env,
         approver: Address,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::approve_recovery(&env, approver)
     }
 
@@ -1143,7 +1143,7 @@ impl HelloContract {
     pub fn gov_execute_recovery(
         env: Env,
         executor: Address,
-    ) -> Result<(), errors::GovernanceError> {
+    ) -> Result<(), crate::governance::GovernanceError> {
         governance::execute_recovery(&env, executor)
     }
 


### PR DESCRIPTION
## Summary
- replace incorrect errors::GovernanceError references in hello-world contract entrypoints with the real governance error type
- re-export GovernanceError from errors.rs so the module remains a compatibility shim

## Testing
- verified no remaining errors::GovernanceError references remain in the hello-world source tree
- checked workspace diagnostics for the affected Rust files