### PR TITLE
fix(docs): add set_pause and get_pause_state to interface quick reference (#1553)

### DIFF
--- a/docs/interface_quick_reference.md
+++ b/docs/interface_quick_reference.md
@@ -76,6 +76,8 @@
 | `set_debt_ceiling` | `(ceiling: i128)` | admin | `Result<(), LendingError>` |
 | `set_flash_fee` | `(fee_bps: i128)` | admin | `Result<(), LendingError>` |
 | `set_emergency_state` | `(new_state: EmergencyState)` | admin; guardian may set `Shutdown` | `()` |
+| `set_pause` | `(pause_type: PauseType, paused: bool, ttl_ledgers: u32)` | admin or guardian | `Result<(), LendingError>` |
+| `get_pause_state` | `(pause_type: PauseType)` | — | `bool` |
 | `set_asset_params` | `(admin: Address, asset: Address, ltv_bps: i128, liquidation_threshold_bps: i128, debt_ceiling: i128, borrow_cap: i128, supply_cap: i128)` | admin | `Result<(), LendingError>` |
 | `get_asset_params` | `(asset: Address)` | — | `Option<AssetParams>` |
 | `set_close_factor_bps` | `(close_factor_bps: i128)` | admin | `Result<(), LendingError>` |


### PR DESCRIPTION
## Summary

Fixes #1553 — `docs/interface_quick_reference.md` was missing `set_pause` and `get_pause_state` from the Admin & Risk Controls table, even though both are real public entrypoints on `LendingContract`.

## Changes

- Added `set_pause` and `get_pause_state` rows to the **Admin & Risk Controls** table in Section 2
- Both entries include accurate signatures, authorization requirements, and return types matching the `pub fn` implementations in `stellar-lend/contracts/lending/src/lib.rs`

## Verification

- ✅ `set_oracle_paused` is already absent from `interface_quick_reference.md` (was removed previously)
- ✅ `get_emergency_state` is correctly categorized in Section 7 (Planned — Not Yet Implemented) as a planned future public view
- ✅ `set_pause` signature: `(pause_type: PauseType, paused: bool, ttl_ledgers: u32)` — matches implementation
- ✅ `get_pause_state` signature: `(pause_type: PauseType) → bool` — matches implementation

## Acceptance Criteria (from #1553)

> "either add a public `get_emergency_state` wrapper entrypoint, or correct the doc to list `get_pause_state` instead"

This PR takes the documentation correction path: `get_pause_state` (the actual callable entrypoint) is now listed alongside `set_pause` in the implemented functions table.
