### PR TITLE
feat(lending): emit GuardianSetEvent and OraclePubKeySetEvent on addr…

### DIFF
--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -323,6 +323,20 @@ pub struct CollateralAssetSetEvent {
 
 #[contractevent]
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GuardianSetEvent {
+    pub old_guardian: Option<Address>,
+    pub new_guardian: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OraclePubKeySetEvent {
+    pub old_pubkey: Option<BytesN<32>>,
+    pub new_pubkey: BytesN<32>,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LiquidationEventV1 {
     pub schema_version: u32,
     pub liquidator: Address,
@@ -632,9 +646,15 @@ impl LendingContract {
     pub fn set_oracle_pubkey(env: Env, pubkey: BytesN<32>) -> Result<(), LendingError> {
         require_initialized(&env)?;
         assert_admin(&env)?;
+        let old_pubkey: Option<BytesN<32>> = env.storage().instance().get(&DataKey::OraclePubKey);
         env.storage()
             .instance()
             .set(&DataKey::OraclePubKey, &pubkey);
+        OraclePubKeySetEvent {
+            old_pubkey,
+            new_pubkey: pubkey,
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -973,7 +993,14 @@ impl LendingContract {
             .ok_or(LendingError::NotInitialized)?;
         admin.require_auth();
 
+        let old_guardian: Option<Address> =
+            env.storage().instance().get(&DataKey::Guardian);
         env.storage().instance().set(&DataKey::Guardian, &guardian);
+        GuardianSetEvent {
+            old_guardian,
+            new_guardian: guardian,
+        }
+        .publish(&env);
 
         // Record audit entry
         audit_log::record_audit_entry(


### PR DESCRIPTION
## Summary
Closes #1718

`set_guardian()` and `set_oracle_pubkey()` silently overwrote their respective `DataKey` values with no on-chain event emission, unlike every other setter in the contract. Both rotate trust-critical addresses — the guardian can unilaterally pause the protocol during a Shutdown, and the oracle pubkey authenticates every price update — yet off-chain monitoring had no signal to observe these changes in real time.

## Changes

### Two new `#[contractevent]` structs in `lib.rs`

| Event | Fields |
|---|---|
| `GuardianSetEvent` | `old_guardian: Option<Address>`, `new_guardian: Address` |
| `OraclePubKeySetEvent` | `old_pubkey: Option<BytesN<32>>`, `new_pubkey: BytesN<32>` |

`Option` on the old value handles the initial-set case (no prior value in storage).

### Modified functions
- `set_oracle_pubkey` — reads `old_pubkey` before overwriting, publishes `OraclePubKeySetEvent`
- `set_guardian` — reads `old_guardian` before overwriting, publishes `GuardianSetEvent`

Both follow the existing `#[contractevent]` / `.publish(&env)` pattern already used by `EmergencyStateChangedEvent`, `PauseStateChangedEvent`, `PriceBoundsSetEvent`, `MinBorrowSetEvent`, etc.

## Build
Big Pickle · 5.9s