### PR TITLE
fix(lending): resolve storage tier test module wiring and fix AssetParams assertion

### DIFF
--- a/stellar-lend/contracts/lending/src/storage_tier_test.rs
+++ b/stellar-lend/contracts/lending/src/storage_tier_test.rs
@@ -231,7 +231,6 @@ fn test_per_address_keys_never_in_instance_storage() {
         DataKey::Debt(addr.clone()),
         DataKey::Balance(addr.clone(), addr.clone()),
         DataKey::Treasury(addr.clone()),
-        DataKey::AssetParams(addr.clone()),
     ];
 
     env.as_contract(&contract_id, || {


### PR DESCRIPTION
## Summary

The `#[cfg(test)] mod storage_tier_test;` declaration is already wired into `lib.rs`, so the module now compiles and runs. Additionally, this PR fixes a logical contradiction in `test_per_address_keys_never_in_instance_storage` where `DataKey::AssetParams` was incorrectly listed as a key that must never be in Instance storage.

`AssetParams` is deliberately stored in instance storage per the project design (confirmed by `test_asset_params_uses_instance_storage` in the same file and `cross_asset::set_asset_params_internal` doc comments).

## Changes

- Removed `DataKey::AssetParams(addr.clone())` from the keys array in `test_per_address_keys_never_in_instance_storage` to align with the project's actual storage tier design

Closes #1526