### PR TITLE
test(governance): cover cancel authorization and post-cancel rejection

### DIFF
--- a/docs/timelock-governance.md
+++ b/docs/timelock-governance.md
@@ -250,6 +250,65 @@ pub fn get_pending_threshold_change(env: Env) -> Option<ThresholdChange>
 pub fn get_min_threshold_delay_ledgers(env: Env) -> u32
 ```
 
+## Multisig Proposal Cancel State Machine
+
+The multisig contract's `cancel_proposal` entrypoint transitions proposals from `Active` to `Cancelled`. A cancelled proposal is permanently dead — it cannot be approved, executed, or batch-executed.
+
+### Cancel State Machine
+
+```
+                    ┌─────────────────────────────────────┐
+                    │                                     │
+                    │   create_proposal                   │
+                    │         │                           │
+                    │         v                           │
+                    │   ┌──────────┐    cancel_proposal   │
+                    │   │  Active  │ ──────────────────►  │
+                    │   └──────────┘    ┌───────────┐    │
+                    │         │         │ Cancelled │    │
+                    │         │         └───────────┘    │
+                    │         │              │           │
+                    │         v              │           │
+                    │   ┌──────────┐         │           │
+                    │   │  Passed  │         │           │
+                    │   └──────────┘         │           │
+                    │         │              │           │
+                    │         v              │           │
+                    │   ┌──────────┐         │           │
+                    │   │ Executed │         │           │
+                    │   └──────────┘         │           │
+                    │         │              │           │
+                    │         v              │           │
+                    │   ┌──────────┐         │           │
+                    │   │ Expired  │         │           │
+                    │   └──────────┘         │           │
+                    │                                     │
+                    └─────────────────────────────────────┘
+```
+
+### Cancel Guards
+
+| Gate | Reverts with | Triggered when |
+|---|---|---|
+| Non-signer | `Unauthorized` | Caller is not a registered signer |
+| Already executed | `AlreadyExecuted` | `proposal.status == Executed` |
+| Already cancelled | `AlreadyCancelled` | `proposal.status == Cancelled` |
+| Expired | `ProposalExpired` | `ledger.sequence() > proposal.expires_at` |
+
+### Cancel Effects
+
+- The `Proposal.status` field is set to `Cancelled` in persistent storage.
+- `approve_proposal`, `execute_proposal`, and `batch_execute` all check `proposal.status == Cancelled` **before** any other processing and return `AlreadyCancelled`.
+- A cancelled proposal can never be revived or re-executed — the status is permanent.
+
+### Cancel Authorization
+
+- **Any registered signer** may call `cancel_proposal`, not only the proposer.
+- `caller.require_auth()` is enforced so the caller must authorize the cancel invocation.
+- `Self::require_signer` verifies the caller is in the registered signer set.
+
+---
+
 ## Timelock Test Coverage
 
 ### Upgrade governance (`contracts/lending/src/upgrade.rs`)
@@ -274,6 +333,20 @@ pub fn get_min_threshold_delay_ledgers(env: Env) -> u32
 | `test_apply_at_exact_min_delay_boundary` | queue + MIN − 1 then queue + MIN | first `DelayNotElapsed`; second succeeds |
 | `test_apply_threshold_change_after_delay` | queue + MIN | threshold updated, pending cleared |
 | `test_same_ledger_protection` | same ledger as queue | `DelayNotElapsed` |
+
+### Multisig cancel lifecycle (`contracts/multisig/src/cancel_proposal_test.rs`)
+
+| Test | Scenario | Expected outcome |
+|---|---|---|
+| `test_cancel_proposal_status_is_cancelled` | Cancel an Active proposal | Status becomes `Cancelled` |
+| `test_cancel_proposal_by_non_proposer_signer` | Non-proposer signer cancels | Status becomes `Cancelled` |
+| `test_cancel_already_cancelled_returns_error` | Double-cancel | `AlreadyCancelled` |
+| `test_cancel_executed_proposal_returns_error` | Cancel an executed proposal | `AlreadyExecuted` |
+| `test_cancel_expired_proposal_returns_error` | Cancel an expired proposal | `ProposalExpired` |
+| `test_cancel_proposal_non_signer_rejected` | Non-signer calls cancel | `Unauthorized` |
+| `test_execute_cancelled_proposal_returns_error` | Execute after cancel | `AlreadyCancelled` |
+| `test_batch_execute_cancelled_proposal_rejected` | Batch-execute after cancel | `AlreadyCancelled` |
+| `test_approve_cancelled_proposal_returns_error` | Approve (vote) after cancel | `AlreadyCancelled` |
 
 ## Integration Checklist
 

--- a/stellar-lend/contracts/lending/src/lib.rs
+++ b/stellar-lend/contracts/lending/src/lib.rs
@@ -3243,7 +3243,12 @@ fn assert_admin_or_guardian(env: &Env, state: &EmergencyState) -> Result<(), Len
                 .instance()
                 .get(&DataKey::Guardian)
                 .ok_or(LendingError::NotInitialized)
-                .or_else(|_| env.storage().instance().get(&DataKey::Admin).ok_or(LendingError::NotInitialized))?;
+                .or_else(|_| {
+                    env.storage()
+                        .instance()
+                        .get(&DataKey::Admin)
+                        .ok_or(LendingError::NotInitialized)
+                })?;
             caller.require_auth();
             Ok(())
         }

--- a/stellar-lend/contracts/multisig/src/cancel_proposal_test.rs
+++ b/stellar-lend/contracts/multisig/src/cancel_proposal_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger;
 use soroban_sdk::{Address, Bytes, Env, Vec};
 
 // ---------------------------------------------------------------------------
@@ -213,5 +214,102 @@ fn test_batch_execute_cancelled_proposal_rejected() {
     assert_eq!(
         client.try_batch_execute(&signers.get(0).unwrap(), &ids, &hashes),
         Err(Ok(MultisigError::AlreadyCancelled))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cancel after execute
+// ---------------------------------------------------------------------------
+
+/// Attempting to cancel an already-executed proposal must return
+/// `MultisigError::AlreadyExecuted`.
+#[test]
+fn test_cancel_executed_proposal_returns_error() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    let hash = make_bytes(&env, b"hash_exec");
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &500u64,
+    );
+
+    // Approve twice to reach threshold (2-of-3) so proposal becomes Passed.
+    client.approve_proposal(&signers.get(0).unwrap(), &id);
+    client.approve_proposal(&signers.get(1).unwrap(), &id);
+
+    // Execute the passed proposal.
+    client.execute_proposal(&signers.get(0).unwrap(), &id, &hash);
+    let p = client.get_proposal(&id);
+    assert_eq!(p.status, ProposalStatus::Executed);
+
+    // Cancel must now fail with AlreadyExecuted.
+    assert_eq!(
+        client.try_cancel_proposal(&signers.get(0).unwrap(), &id),
+        Err(Ok(MultisigError::AlreadyExecuted))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Approve (vote) after cancel
+// ---------------------------------------------------------------------------
+
+/// A cancelled proposal must be rejected by `approve_proposal`.
+#[test]
+fn test_approve_cancelled_proposal_returns_error() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    let hash = make_bytes(&env, b"hash_approve_cancel");
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &500u64,
+    );
+
+    // Cancel while still Active.
+    client.cancel_proposal(&signers.get(0).unwrap(), &id);
+
+    // Approve must now fail with AlreadyCancelled.
+    assert_eq!(
+        client.try_approve_proposal(&signers.get(1).unwrap(), &id),
+        Err(Ok(MultisigError::AlreadyCancelled))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cancel after expiry
+// ---------------------------------------------------------------------------
+
+/// Attempting to cancel an expired proposal must return
+/// `MultisigError::ProposalExpired`.
+#[test]
+fn test_cancel_expired_proposal_returns_error() {
+    let env = make_env();
+    let (contract_id, signers) = setup_multisig(&env);
+    let client = MultisigContractClient::new(&env, &contract_id);
+
+    // Use a 1-ledger TTL so the proposal expires quickly.
+    let hash = make_bytes(&env, b"hash_exp");
+    let id = client.create_proposal(
+        &signers.get(0).unwrap(),
+        &ProposalAction::SetThreshold(3),
+        &hash,
+        &1u64,
+    );
+
+    // Jump past expiry.
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + 2);
+
+    // Cancel must now fail with ProposalExpired.
+    assert_eq!(
+        client.try_cancel_proposal(&signers.get(0).unwrap(), &id),
+        Err(Ok(MultisigError::ProposalExpired))
     );
 }

--- a/stellar-lend/contracts/multisig/src/lib.rs
+++ b/stellar-lend/contracts/multisig/src/lib.rs
@@ -468,7 +468,7 @@ impl MultisigContract {
                 // large as the current threshold, otherwise quorum could never
                 // be reached again and the multisig would be permanently bricked.
                 let threshold = Self::fetch_threshold(env);
-                if (new_signers.len() as u32) < threshold {
+                if new_signers.len() < threshold {
                     return Err(MultisigError::InvalidAction);
                 }
                 env.storage()
@@ -496,6 +496,16 @@ impl MultisigContract {
         Self::require_signer(&env, &caller)?;
 
         let mut proposal = Self::fetch_proposal(&env, id)?;
+
+        // Ledger-based expiry guard (consistent with execute_proposal
+        // and approve_proposal): if the current ledger has passed
+        // expires_at the proposal is expired regardless of the stored
+        // status field.
+        if env.ledger().sequence() as u64 > proposal.expires_at {
+            proposal.status = ProposalStatus::Expired;
+            Self::save_proposal(&env, &proposal);
+            return Err(MultisigError::ProposalExpired);
+        }
         if proposal.status == ProposalStatus::Expired {
             return Err(MultisigError::ProposalExpired);
         }

--- a/stellar-lend/contracts/vesting/src/lib.rs
+++ b/stellar-lend/contracts/vesting/src/lib.rs
@@ -889,6 +889,10 @@ mod cliff_bound_test;
 #[cfg(test)]
 mod grant_transfer_test;
 #[cfg(test)]
+mod grant_transfer_test;
+#[cfg(test)]
+mod initialize_test;
+#[cfg(test)]
 mod lifecycle_e2e_test;
 #[cfg(test)]
 mod milestone_schedule_test;
@@ -896,10 +900,6 @@ mod milestone_schedule_test;
 mod multi_grant_test;
 #[cfg(test)]
 mod partial_claim_test;
-#[cfg(test)]
-mod grant_transfer_test;
-#[cfg(test)]
-mod initialize_test;
 #[cfg(test)]
 mod pause_offset_test;
 #[cfg(test)]


### PR DESCRIPTION
## Description

Adds focused tests around the cancel lifecycle for `cancel_proposal` in the multisig contract (`stellar-lend/contracts/multisig/src/cancel_proposal_test.rs`).

### Tests added
- **test_cancel_executed_proposal_returns_error**: `cancel_proposal` on an executed proposal returns `AlreadyExecuted`
- **test_approve_cancelled_proposal_returns_error**: `approve_proposal` on a cancelled proposal returns `AlreadyCancelled` (a cancelled proposal cannot be voted)
- **test_cancel_expired_proposal_returns_error**: `cancel_proposal` on an expired proposal returns `ProposalExpired`

### Bug fix
Added a ledger-based expiry guard to `cancel_proposal` (matching the pattern in `execute_proposal` and `approve_proposal`) so that an expired-but-still-`Active` proposal is correctly rejected instead of passing through the stored-status-only check.

### Documentation
Extended `docs/timelock-governance.md` with the cancel state machine diagram, guard table, authorization notes, and test coverage table.

Closes #1134