### PR TITLE
docs: remove stale multisig entrypoint references from hello-world st…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,6 @@ Key admin entrypoints (see contract for full list):
 - `register_bridge(caller, network_id, bridge, fee_bps)`
 - `set_bridge_fee(caller, network_id, fee_bps)`
 - `upgrade_propose/approve/execute`
-- `ms_set_admins`, `ms_propose_set_min_cr`, `ms_approve`, `ms_execute`
 
 ## Monitoring & Analytics
 
@@ -96,6 +95,11 @@ Key admin entrypoints (see contract for full list):
 
 - Set guardians per-user and execute timelocked recoveries
 - Multisig supports proposing and executing admin changes with threshold
+
+> **Authoritative multisig:** The canonical multisig implementation is the standalone
+> `stellarlend-multisig` crate at `stellar-lend/contracts/multisig/`. The lending contract
+> also has its own timelocked upgrade governance in `upgrade.rs`, which is independent.
+> The now-deleted `hello-world` contract previously contained a stub; it is not authoritative.
 
 ## Documentation
 

--- a/docs/multisig.md
+++ b/docs/multisig.md
@@ -7,10 +7,9 @@ proposal–approve–execute governance pattern for critical StellarLend protoco
 It is a standalone Soroban smart contract (`MultisigContract`) that enforces an
 m-of-n signature threshold before any governed action takes effect.
 
-> **Scope note:** This document describes the real `stellarlend-multisig` crate found at
-> `stellar-lend/contracts/multisig/src/lib.rs`. The `hello-world` contract contains a
-> one-line placeholder stub (`// Stub module`) in `src/multisig.rs` and does **not**
-> expose any multisig entrypoints.
+> **Scope note:** This document describes the authoritative `stellarlend-multisig` crate found at
+> `stellar-lend/contracts/multisig/src/lib.rs`. The now-deleted `hello-world` contract previously
+> contained a one-line placeholder stub; the canonical multisig implementation is this crate.
 
 ---
 


### PR DESCRIPTION
## Summary

The hello-world contract has been deleted from the workspace (removed in prior commits). Its `multisig.rs` stub and the nonexistent `ms_set_admins` / `ms_propose_set_min_cr` / `ms_approve` / `ms_execute` entrypoints are no longer referenced anywhere in the codebase.

## Changes
- **`docs/README.md`**: Removed stale `ms_*` admin entrypoints from the Admin Operations list. Added authoritative multisig note clarifying that `stellarlend-multisig` (`stellar-lend/contracts/multisig/`) is the canonical implementation, the lending contract's `upgrade.rs` is independent, and the deleted hello-world stub was not authoritative.
- **`docs/multisig.md`**: Updated scope note to reflect hello-world deletion and that this crate is the canonical implementation.

Closes #1467