### PR TITLE
docs(vesting): clarify internal Grant::claimable_at vs public claimable_total in VESTING_CLAIM_COST.md (#1683)

### DIFF
--- a/stellar-lend/contracts/vesting/VESTING_CLAIM_COST.md
+++ b/stellar-lend/contracts/vesting/VESTING_CLAIM_COST.md
@@ -11,7 +11,7 @@
 `Vesting` stores a `Vec<Grant>` per grantee and iterates the whole vector on
 every state-touching call:
 
-- `claim` calls `sync_grants` (full pass) then sums `grant.claimable()` over all
+- `claim` calls `sync_grants` (full pass) then sums `Grant::claimable_at` over all
   grants, then `claim_partial_internal` does another full pass.
 - `claim_partial`, `total_locked`, `balance_of`, and `claimable_total` each scan
   the grantee's grants.
@@ -28,7 +28,7 @@ Let `n` = number of grants held by a grantee. Per `claim`:
 | Phase                     | Passes | Work per grant                          |
 |---------------------------|:------:|-----------------------------------------|
 | `sync_grants`             |   1    | vested-at recompute, `released` update  |
-| claimable summation       |   1    | `claimable()` + `saturating_add`        |
+| claimable summation       |   1    | `Grant::claimable_at` + `saturating_add` (exposed via `claimable_total`) |
 | `claim_partial_internal`  |   1    | `min`, `checked_add`, `saturating_sub`  |
 
 Total per-grant work is a small constant `c` (no nested loops, no allocation per
@@ -74,7 +74,7 @@ via `#[cfg(test)] mod claim_cost_bench_test;` in `lib.rs`.
 
 Each benchmark helper carries NatSpec-style `///` doc comments.
 
-1. **Harness** — `fn measure_claim(n: usize) -> u64`: build a `Vesting`, fund the
+1. **Harness** — `fn measure_claim(n: usize) -> u64` (proposed benchmark helper; not an existing function): build a `Vesting`, fund the
    contract, create `n` grants for one grantee with partially-elapsed schedules,
    advance `now`, call `claim`, and return a deterministic cost proxy (iteration
    count or, on-chain, the metered CPU instructions / budget).

--- a/stellar-lend/contracts/vesting/VESTING_CLAIM_COST.md
+++ b/stellar-lend/contracts/vesting/VESTING_CLAIM_COST.md
@@ -8,28 +8,36 @@
 
 ## Problem
 
-`Vesting` stores a `Vec<Grant>` per grantee and iterates the whole vector on
-every state-touching call:
+`VestingContract` stores a `Vec<Grant>` per grantee under
+`VestingKey::Grants(grantee)` and iterates the whole vector on every
+state-touching call:
 
-- `claim` calls `sync_grants` (full pass) then sums `Grant::claimable_at` over all
-  grants, then `claim_partial_internal` does another full pass.
-- `claim_partial`, `total_locked`, `balance_of`, and `claimable_total` each scan
-  the grantee's grants.
+- `claim` (`src/lib.rs:276`) makes **one** pass: per grant it recomputes
+  `Grant::vested_at`, settles `claimed_amount` and writes the grant back. It
+  inlines the very expression that `Grant::claimable_at` (`src/lib.rs:128`,
+  `vested_at(now) - claimed_amount`) encapsulates, rather than calling it.
+- `claim_partial` (`src/lib.rs:321`) makes **two** passes: one to total the
+  claimable amount, one to draw `amount` down across grants.
+- `claimable_total` (`src/lib.rs:558`) is the public view and is the **only**
+  caller of `Grant::claimable_at` (`src/lib.rs:567`); one pass.
+- `total_locked` (`src/lib.rs:591`) is **not** O(n): it is a single
+  `VestingKey::TotalLocked` storage read that the writers above keep in sync.
 
-So a single `claim` is **O(n)** in the grantee's grant count `n`, with roughly
-three passes over the vector. As one grantee accumulates many grants, claim cost
-grows linearly and is unbounded — there is no cap on grants-per-grantee and no
-documented ceiling beyond which `claim` becomes uneconomic.
+So a single `claim` is **O(n)** in the grantee's grant count `n`, with one pass
+over the vector (`claim_partial` costs two). As one grantee accumulates many
+grants, claim cost grows linearly and is unbounded — there is no cap on
+grants-per-grantee and no documented ceiling beyond which `claim` becomes
+uneconomic.
 
 ## Cost Model
 
 Let `n` = number of grants held by a grantee. Per `claim`:
 
-| Phase                     | Passes | Work per grant                          |
-|---------------------------|:------:|-----------------------------------------|
-| `sync_grants`             |   1    | vested-at recompute, `released` update  |
-| claimable summation       |   1    | `Grant::claimable_at` + `saturating_add` (exposed via `claimable_total`) |
-| `claim_partial_internal`  |   1    | `min`, `checked_add`, `saturating_sub`  |
+| Entrypoint                        | Passes | Work per grant                                              |
+|-----------------------------------|:------:|-------------------------------------------------------------|
+| `claim` (`src/lib.rs:276`)        |   1    | `vested_at`, `saturating_sub`, `saturating_add`, `Vec::set`  |
+| `claim_partial` (`src/lib.rs:321`)|   2    | pass 1 totals claimable; pass 2 draws `amount` down          |
+| `claimable_total` (`src/lib.rs:558`) | 1   | `Grant::claimable_at` + `saturating_add` (read-only view)    |
 
 Total per-grant work is a small constant `c` (no nested loops, no allocation per
 grant), so:
@@ -74,12 +82,13 @@ via `#[cfg(test)] mod claim_cost_bench_test;` in `lib.rs`.
 
 Each benchmark helper carries NatSpec-style `///` doc comments.
 
-1. **Harness** — `fn measure_claim(n: usize) -> u64` (proposed benchmark helper; not an existing function): build a `Vesting`, fund the
-   contract, create `n` grants for one grantee with partially-elapsed schedules,
-   advance `now`, call `claim`, and return a deterministic cost proxy (iteration
-   count or, on-chain, the metered CPU instructions / budget).
+1. **Harness** — a test-local helper introduced by that file (no such helper
+   exists in the crate today): build a `VestingContract`, fund the contract,
+   create `n` grants for one grantee with partially-elapsed schedules, advance
+   `now`, call `claim`, and return a deterministic cost proxy (iteration count
+   or, on-chain, the metered CPU instructions / budget).
 2. **Linearity assertion** — measure at `n ∈ {1, 8, 32, 128, 256}` and assert
-   `measure_claim(2n) <= 2.2 * measure_claim(n)` between adjacent doublings.
+   `cost(2n) <= 2.2 * cost(n)` between adjacent doublings.
 3. **Edge cases:**
    - *Single grant* — establishes the baseline.
    - *Many grants* — at the soft cap (256); must stay within budget.


### PR DESCRIPTION
## Summary

Fixes #1683

`VESTING_CLAIM_COST.md` described a `claim` cost model built on symbols that do
not exist in `stellar-lend/contracts/vesting/src/lib.rs`. A perf harness written
against the documented interface would have had nothing to call, and the pass
count in the cost table was wrong. Every symbol below was re-checked line by line
against `lib.rs` on `main`.

### What was wrong, and the evidence

| Doc said | Reality in `vesting/src/lib.rs` |
|---|---|
| `claim` calls `sync_grants` | `sync_grants` — **0 occurrences in the whole crate** |
| ...then `claim_partial_internal` does another pass | `claim_partial_internal` — **0 occurrences** |
| `claim` is "roughly three passes" | `claim` (L276-L318) is a **single** `for i in 0..grants.len()` loop |
| `claim` sums `grant.claimable()` | `claim` never calls it; it inlines `g.vested_at(now).saturating_sub(g.claimed_amount)` (L291-L292) |
| `total_locked` scans the grantee's grants | L591-L593 is one `VestingKey::TotalLocked` storage read — **O(1)** |
| `balance_of` scans the grantee's grants | `balance_of` only exists at L774, inside `#[cfg(test)] pub mod sim` — not an on-chain entrypoint |
| `Vesting` stores the grants | the contract type is `VestingContract` (L136) |
| `fn measure_claim(n: usize) -> u64` | **0 occurrences** — never existed |

`Grant::claimable_at` (L128) *is* real: `vested_at(now) - claimed_amount`. Its
**only** call site in the crate is `claimable_total` (L558-L570, call at L567),
which is the public view. That is now what the doc says.

### Changes

Documentation only — one file, `VESTING_CLAIM_COST.md`. No source, test, CI or
manifest changes.

- Problem section rewritten as a per-entrypoint list with `src/lib.rs` line
  numbers: `claim` (1 pass), `claim_partial` (2 passes), `claimable_total`
  (1 pass, sole caller of `Grant::claimable_at`), `total_locked` (O(1) read).
- Cost table columns changed from invented phase names to the three real
  entrypoints, with their actual pass counts.
- "roughly three passes" corrected to one pass for `claim` (two for
  `claim_partial`). The `O(n)` conclusion and the `cost ≈ base + c*n` model are
  unchanged — only the pass accounting was wrong.
- `fn measure_claim(n: usize) -> u64` removed, per the acceptance criteria
  ("remove the nonexistent `measure_claim`"). The benchmark plan keeps the same
  content but describes the harness in prose and asserts on
  `cost(2n) <= 2.2 * cost(n)`.

### Which acceptance path this takes

#1683 offers two: (a) expose a public `get_claimable(grantee) -> i128` view, or
(b) correct the doc and remove `measure_claim`. This PR takes **(b)** — it is
documentation-only and adds no surface area. Note that (a) would be partly
redundant today: `claimable_total(env, grantee) -> i128` (L558) already exposes
the aggregate of `Grant::claimable_at` across a grantee's grants. If a maintainer
prefers a per-grant view as well, that is a separate code change and I am happy
to open it.

### Scope note

Beyond the two symbols named in the issue (`claimable`, `measure_claim`), the
same sentence and table also carried `sync_grants`, `claim_partial_internal`,
`balance_of` and `Vesting`, all equally unresolvable. Fixing only the two named
symbols would have left the paragraph asserting a three-pass `claim` that does
not exist, so they are corrected together. Happy to split if you would rather
keep the diff to the letter of the issue.

### Verification

- Every claim above cross-checked against `vesting/src/lib.rs` at `main`
  (`8637fd0e`); line numbers in the doc refer to that revision.
- `git diff --stat`: 1 file changed, markdown only.
- The current red checks on this PR are the repository-wide `main` failure
  (`wasm32` target missing `std`, cascading through Format & Lint / Soroban
  Validations / Security Audit); `Build & Test` and `Code Coverage` are
  `skipped`. They are unrelated to this patch — a markdown-only change cannot
  affect them.
