### PR TITLE
ci: add --release flag to Build project step to exercise release profile (#1555)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Build project
         run: |
           cd stellar-lend
-          cargo build --verbose
+          cargo build --verbose --release
 
       - name: Run unit tests
         run: |


### PR DESCRIPTION
Closes #1555

## What

Adds `--release` to the `build-and-test` job's "Build project" step in
`.github/workflows/ci-cd.yml`:

```diff
       - name: Build project
         run: |
           cd stellar-lend
-          cargo build --verbose
+          cargo build --verbose --release
```

One line, one file. No other step is touched.

## Scope note — what #1555 asks for, and what is already covered

Issue #1555 lists two gaps in the "Build project" step (no `--target wasm32-*`,
no `--release`) and its acceptance criterion is:

> add a step that runs `cargo build --target wasm32-unknown-unknown --release`
> (or `stellar contract build`) for every workspace member and fails CI if it errors

The **wasm half is already satisfied on `main`**: the `soroban-checks` job runs
`stellar contract build --verbose` (ci-cd.yml, "Build contracts (wasm32)" step) against
the `wasm32v1-none` target, which builds in release mode internally and fails the job on
error. Soroban has moved from `wasm32-unknown-unknown` to `wasm32v1-none`, so that
step is the current-target equivalent of what the issue requests.

This PR therefore addresses only the remaining gap: the **native-target** build in
`build-and-test` never exercises the release profile, so profile-specific breakage
(`#[cfg(debug_assertions)]` gating, `debug-assertions = false`, `overflow-checks = true`,
`lto = true`, `panic = "abort"` from `[profile.release]` in `stellar-lend/Cargo.toml`)
is never compiled in CI.

## Reviewer decision needed — conflicts with documented guidance

`docs/CI_OVERVIEW.md` lines 393-395 currently states:

> Use `--release` builds only for `stellar contract build`; the regular
> `cargo build --verbose` in `build-and-test` uses the debug profile for faster linking.

This PR is in direct tension with that sentence, and with the trade-off behind it:
`build-and-test` runs on `macos-latest` and is called out at CI_OVERVIEW.md:391 as being
on the critical path. Because the later `cargo test` steps still use the dev profile, the
job would compile the dependency graph twice (release with `lto = true`, then debug),
which increases wall-clock time on the most expensive runner in the matrix.

Flagging this explicitly rather than leaving it to be discovered in review. If maintainers
want the release-profile coverage, `docs/CI_OVERVIEW.md:393-395` should be updated in the
same change; if the documented debug-only policy stands, this PR should be closed in
favour of extending `soroban-checks` instead. Happy to take either direction.

## CI status

The red checks on this branch are not caused by this change: `main` itself
(`8637fd0e`) is failing, and `Build & Test` / `Code Coverage` are `skipped` because
`check` and `soroban-checks` fail upstream of them. This PR touches no Rust source.
