### PR TITLE
feat(bridge): emit admin events for register_bridge, set_bridge_fee, set_bridge_guardian (#1720)

### DIFF
--- a/stellar-lend/contracts/hello-world/src/bridge.rs
+++ b/stellar-lend/contracts/hello-world/src/bridge.rs
@@ -386,7 +386,7 @@ pub fn register_bridge(
     };
     env.storage().persistent().set(&key, &cfg);
     add_to_index(env, network_id);
-    emit_register_event(env, network_id, &bridge, fee_bps);
+    emit_register_event(env, network_id, &cfg.bridge, fee_bps);
     Ok(())
 }
 

--- a/stellar-lend/contracts/hello-world/src/bridge.rs
+++ b/stellar-lend/contracts/hello-world/src/bridge.rs
@@ -229,7 +229,6 @@ fn emit_freeze_event(env: &Env, guardian: &Address, is_frozen: bool) {
             timestamp: env.ledger().timestamp(),
         },
     );
-}    );
 }
 
 /// Emit a [`BridgeRegisteredEvent`] on bridge registration.

--- a/stellar-lend/contracts/hello-world/src/bridge.rs
+++ b/stellar-lend/contracts/hello-world/src/bridge.rs
@@ -118,6 +118,63 @@ pub struct BridgeFreezeEvent {
     pub timestamp: u64,
 }
 
+/// Structured payload for the `bridge_registered` event.
+///
+/// Emitted when `register_bridge` successfully creates a new cross-chain
+/// bridge registration. Indexers can use `("bridge", "v1", "register")`
+/// to capture all registration events.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BridgeRegisteredEvent {
+    /// Schema version at emit time.
+    pub schema_version: u32,
+    /// Remote network identifier assigned by the admin.
+    pub network_id: u32,
+    /// Address of the bridge adapter contract on the remote network.
+    pub bridge: Address,
+    /// Configured fee in basis points (0–10_000).
+    pub fee_bps: i128,
+    /// Ledger timestamp at the point of registration.
+    pub timestamp: u64,
+}
+
+/// Structured payload for the `bridge_fee_updated` event.
+///
+/// Emitted when `set_bridge_fee` changes the fee for an existing bridge.
+/// Indexers can use `("bridge", "v1", "fee_update")` to capture fee changes.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BridgeFeeUpdatedEvent {
+    /// Schema version at emit time.
+    pub schema_version: u32,
+    /// Network identifier of the bridge whose fee was changed.
+    pub network_id: u32,
+    /// Previous fee in basis points before this update.
+    pub old_fee_bps: i128,
+    /// New fee in basis points after this update.
+    pub new_fee_bps: i128,
+    /// Ledger timestamp at the point of fee update.
+    pub timestamp: u64,
+}
+
+/// Structured payload for the `bridge_guardian_changed` event.
+///
+/// Emitted when `set_bridge_guardian` changes the guardian address.
+/// Indexers can use `("bridge", "v1", "guardian_change")` to capture
+/// guardian rotations.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BridgeGuardianChangedEvent {
+    /// Schema version at emit time.
+    pub schema_version: u32,
+    /// Previous guardian address (if any) before this rotation.
+    pub old_guardian: Address,
+    /// New guardian address after this rotation.
+    pub new_guardian: Address,
+    /// Ledger timestamp at the point of guardian change.
+    pub timestamp: u64,
+}
+
 /// Errors returned by the bridge module.
 ///
 /// Variants are explicitly numbered; appending to the end of an enum is a
@@ -169,6 +226,77 @@ fn emit_freeze_event(env: &Env, guardian: &Address, is_frozen: bool) {
             schema_version: SCHEMA_VERSION,
             is_frozen,
             guardian: guardian.clone(),
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}    );
+}
+
+/// Emit a [`BridgeRegisteredEvent`] on bridge registration.
+///
+/// Topics: `("bridge", "v1", "register")`.
+fn emit_register_event(env: &Env, network_id: u32, bridge: &Address, fee_bps: i128) {
+    const SCHEMA_VERSION: u32 = 1;
+
+    env.events().publish(
+        (
+            symbol_short!("bridge"),
+            symbol_short!("v1"),
+            symbol_short!("register"),
+        ),
+        BridgeRegisteredEvent {
+            schema_version: SCHEMA_VERSION,
+            network_id,
+            bridge: bridge.clone(),
+            fee_bps,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+/// Emit a [`BridgeFeeUpdatedEvent`] on fee change.
+///
+/// Topics: `("bridge", "v1", "fee_update")`.
+fn emit_fee_update_event(
+    env: &Env,
+    network_id: u32,
+    old_fee_bps: i128,
+    new_fee_bps: i128,
+) {
+    const SCHEMA_VERSION: u32 = 1;
+
+    env.events().publish(
+        (
+            symbol_short!("bridge"),
+            symbol_short!("v1"),
+            symbol_short!("fee_update"),
+        ),
+        BridgeFeeUpdatedEvent {
+            schema_version: SCHEMA_VERSION,
+            network_id,
+            old_fee_bps,
+            new_fee_bps,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+/// Emit a [`BridgeGuardianChangedEvent`] on guardian rotation.
+///
+/// Topics: `("bridge", "v1", "guardian_change")`.
+fn emit_guardian_change_event(env: &Env, old_guardian: &Address, new_guardian: &Address) {
+    const SCHEMA_VERSION: u32 = 1;
+
+    env.events().publish(
+        (
+            symbol_short!("bridge"),
+            symbol_short!("v1"),
+            symbol_short!("guardian_change"),
+        ),
+        BridgeGuardianChangedEvent {
+            schema_version: SCHEMA_VERSION,
+            old_guardian: old_guardian.clone(),
+            new_guardian: new_guardian.clone(),
             timestamp: env.ledger().timestamp(),
         },
     );
@@ -264,6 +392,7 @@ pub fn register_bridge(
     };
     env.storage().persistent().set(&key, &cfg);
     add_to_index(env, network_id);
+    emit_register_event(env, network_id, &bridge, fee_bps);
     Ok(())
 }
 
@@ -292,8 +421,10 @@ pub fn set_bridge_fee(
         .persistent()
         .get(&key)
         .ok_or(BridgeError::NotFound)?;
+    let old_fee_bps = cfg.fee_bps;
     cfg.fee_bps = fee_bps;
     env.storage().persistent().set(&key, &cfg);
+    emit_fee_update_event(env, network_id, old_fee_bps, fee_bps);
     Ok(())
 }
 
@@ -311,9 +442,12 @@ pub fn set_bridge_guardian(
         crate::admin::AdminError::NotInitialized => BridgeError::AdminNotInitialized,
         _ => BridgeError::Unauthorized,
     })?;
+    let old_guardian: Option<Address> = env.storage().instance().get(&BridgeDataKey::Guardian);
     env.storage()
         .instance()
         .set(&BridgeDataKey::Guardian, &guardian);
+    let old_addr = old_guardian.unwrap_or_else(|| guardian.clone());
+    emit_guardian_change_event(env, &old_addr, &guardian);
     Ok(())
 }
 

--- a/stellar-lend/contracts/hello-world/src/bridge.rs
+++ b/stellar-lend/contracts/hello-world/src/bridge.rs
@@ -256,12 +256,7 @@ fn emit_register_event(env: &Env, network_id: u32, bridge: &Address, fee_bps: i1
 /// Emit a [`BridgeFeeUpdatedEvent`] on fee change.
 ///
 /// Topics: `("bridge", "v1", "fee_update")`.
-fn emit_fee_update_event(
-    env: &Env,
-    network_id: u32,
-    old_fee_bps: i128,
-    new_fee_bps: i128,
-) {
+fn emit_fee_update_event(env: &Env, network_id: u32, old_fee_bps: i128, new_fee_bps: i128) {
     const SCHEMA_VERSION: u32 = 1;
 
     env.events().publish(

--- a/stellar-lend/contracts/hello-world/src/bridge.rs
+++ b/stellar-lend/contracts/hello-world/src/bridge.rs
@@ -46,7 +46,7 @@
 //! and a `Vec<u32>` index of registered network IDs (used by [`list_bridges`]).
 //! Persistent storage holds per-network [`BridgeConfig`] records.
 
-use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Map, Vec};
+use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Map, Symbol, Vec};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -263,7 +263,7 @@ fn emit_fee_update_event(env: &Env, network_id: u32, old_fee_bps: i128, new_fee_
         (
             symbol_short!("bridge"),
             symbol_short!("v1"),
-            symbol_short!("fee_update"),
+            Symbol::new(env, "fee_update"),
         ),
         BridgeFeeUpdatedEvent {
             schema_version: SCHEMA_VERSION,
@@ -285,7 +285,7 @@ fn emit_guardian_change_event(env: &Env, old_guardian: &Address, new_guardian: &
         (
             symbol_short!("bridge"),
             symbol_short!("v1"),
-            symbol_short!("guardian_change"),
+            Symbol::new(env, "guardian_change"),
         ),
         BridgeGuardianChangedEvent {
             schema_version: SCHEMA_VERSION,


### PR DESCRIPTION
## Summary

Add three new event types (`BridgeRegisteredEvent`, `BridgeFeeUpdatedEvent`,
`BridgeGuardianChangedEvent`) mirroring `BridgeFreezeEvent`'s schema-versioned
pattern, and emit them in the corresponding admin mutators.

## Changes

- **New event structs**: `BridgeRegisteredEvent`, `BridgeFeeUpdatedEvent`,
  `BridgeGuardianChangedEvent` with `schema_version`, relevant fields, and
  `timestamp`.
- **New emit helpers**: `emit_register_event`, `emit_fee_update_event`,
  `emit_guardian_change_event`, each publishing on topics
  `("bridge", "v1", <action>)` consistent with the existing `emit_freeze_event`.
- **`register_bridge`**: calls `emit_register_event` after successful registration.
- **`set_bridge_fee`**: captures old fee before update, calls `emit_fee_update_event`
  with both old and new values.
- **`set_bridge_guardian`**: captures old guardian before rotation, calls
  `emit_guardian_change_event` with both addresses.

## Motivation

Registering a bridge, changing its fee, or rotating the guardian are at least
as security-relevant as freeze/unfreeze toggles, yet none of them produce an
on-chain signal. This PR adds indexed events so relayer operators and indexers
can monitor these admin actions.

Closes #1720